### PR TITLE
Pin py-pythran to version 0.11.0 so that py-scipy builds on macOS, add jedi-um-bundle-env and package dependencies

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -140,8 +140,10 @@
       version: [2.8.2]
     py-pandas:
       version: [1.3.5]
+    py-pythran:
+      # Earlier versions don't compile on macOS with llvm-clang/13.0.0 and Python/3.9
+      version: [0.11.0]
     py-scipy:
-      # Does this version work with all the other packages listed here? 1.5.3 worked ...
       version: [1.7.3]
     bufr:
       version: [11.5.0]


### PR DESCRIPTION
Pin py-pythran to latest version 0.11.0 so that py-scipy builds on macOS with llvm-clang 13.0.0 and Python 3.9. The corresponding PR to spack was merged (https://github.com/NOAA-EMC/spack/pull/11).

Fixes https://github.com/NOAA-EMC/spack-stack/issues/30
