### PR TITLE
Update Orion compilers/mpi

### DIFF
--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -27,6 +27,20 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: oneapi@2021.2.0
+    paths:
+       cc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icx
+       cxx: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icpx
+       f77: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
+       fc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
+    flags: {}
+    operating_system: centos7
+    target: x86_64
+    modules:
+    - intel/2021.2
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: intel@2018.4
     paths:
       cc: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/icc

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -13,40 +13,12 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: intel@2020.2
-    paths:
-      cc: /apps/intel-2020.2/intel-2020.2/compilers_and_libraries_2020.2.254/linux/bin/intel64/icc
-      cxx: /apps/intel-2020.2/intel-2020.2/compilers_and_libraries_2020.2.254/linux/bin/intel64/icpc
-      f77: /apps/intel-2020.2/intel-2020.2/compilers_and_libraries_2020.2.254/linux/bin/intel64/ifort
-      fc: /apps/intel-2020.2/intel-2020.2/compilers_and_libraries_2020.2.254/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - intel/2020.2
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: intel@2021.2.0
     paths:
       cc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/icc
       cxx: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/icpc
       f77: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/ifort
       fc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - intel/2021.2
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: oneapi@2021.2.0
-    paths:
-      cc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icx
-      cxx: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icpx
-      f77: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
-      fc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
     flags: {}
     operating_system: centos7
     target: x86_64

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -29,10 +29,10 @@ compilers:
 - compiler:
     spec: oneapi@2021.2.0
     paths:
-       cc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icx
-       cxx: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icpx
-       f77: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
-       fc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
+      cc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icx
+      cxx: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/icpx
+      f77: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
+      fc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/ifx
     flags: {}
     operating_system: centos7
     target: x86_64

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -7,7 +7,7 @@ packages:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.2.0%intel@2021.2.0
+    - spec: intel-oneapi-mpi@2021.2.0
       prefix: /apps/intel-2021.2/intel-2021.2
       modules:
       - impi/2021.2    

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -12,6 +12,7 @@ packages:
       modules:
       - impi/2021.2    
   intel-mpi:
+    externals:
     - spec: intel-mpi@2018.5.274%intel@2018.4
       prefix: /apps/intel-2018/intel-2018.u4
       modules:

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -6,19 +6,14 @@ packages:
   mpi:
     buildable: False
   intel-oneapi-mpi:
-    buildable: False
     externals:
-    - spec: intel-oneapi-mpi@2021.2.0
+    - spec: intel-oneapi-mpi@2021.2.0%intel@2021.2.0
       prefix: /apps/intel-2021.2/intel-2021.2
       modules:
       - impi/2021.2    
   intel-mpi:
-    buildable: False
-    externals:
-    - spec: intel-mpi@2020.2
-      modules:
-      - impi/2020.2
-    - spec: intel-mpi@2018.4
+    - spec: intel-mpi@2018.5.274%intel@2018.4
+      prefix: /apps/intel-2018/intel-2018.u4
       modules:
       - intel-mpi@2018.4
   autoconf:


### PR DESCRIPTION
Cleanup the packages/compilers on Orion.

Leave just 2018.4 and 2021.2. Had to add a prefix for intel-mpi.

intel@2018.4 is what we currently use, and intel@2021.2 is what we're moving to.

Note: it's good to add `%compiler@version` to the MPI spec so the concretizer knows the matching compiler. Otherwise, Clingo wasn't honoring my choice of MPI unless I removed all other entries.

Was able to build ufs-weather-model-env on Orion with these combinations. 