### PR TITLE
Remove external python@2.7.5 from Orion

### DIFF
--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -168,8 +168,6 @@ packages:
       prefix: /apps/python-3.7.5
       modules:
       - python/3.7.5
-    - spec: python@2.7.5+bz2+ctypes+dbm+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-      prefix: /usr
   rsync:
     externals:
     - spec: rsync@3.1.2


### PR DESCRIPTION
./setup_meta_modules can only have one Python spec