### PR TITLE
Add ability to create mirror using Github Actions

### DIFF
--- a/.github/workflows/create-spack-mirror.yaml
+++ b/.github/workflows/create-spack-mirror.yaml
@@ -1,0 +1,45 @@
+name: create-spack-mirror
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        type: string
+        description: "App to generate mirror for"
+        required: true
+        default: "all"
+      site:
+        type: string
+        description: "Site to create environment for"
+        required: true
+        default: "default"
+jobs:
+  create-spack-mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: create-env
+        run: |
+          source ./setup.sh
+          ./create-env.py --app ${{ github.event.inputs.app }}  --site ${{ github.event.inputs.site }}  --name all
+          spack env activate -d envs/all
+          spack compiler find
+          spack add re2c
+          spack add clingo
+          spack concretize
+          spack mirror create -a
+          # upload-artifact does not allow filenames that begin with '?'
+          rm cache/source_cache/autoconf/\?id=05972f49ee632cd98057a3caf82ebfb9574846da-eaa3f69
+          rm cache/source_cache/boost/attachment.cgi?id=356970-b6f6ce6
+          rm cache/source_cache/py-scipy/extern_decls.patch?id=711fe05025795e44b84233e065d240859ccae5bd-5433f60
+
+      - name: upload-mirror
+        uses: actions/upload-artifact@v2
+        with:
+          name: spack_mirror
+          path: cache/source_cache

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-intel-build
-on: push
+on: workflow_dispatch
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
@@ -13,7 +13,6 @@ jobs:
         app: [nceplibs]
     runs-on: ubuntu-latest
     steps:
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 envs
 __pycache__
+cache

--- a/configs/apps/all/spack.yaml
+++ b/configs/apps/all/spack.yaml
@@ -8,14 +8,7 @@ spack:
     - modules.yaml
     - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
-  packages:
-    all:
-      compiler:: [gcc@9.4.0]
-    mpi:
-      buildable: False
-
   specs:
-    - re2c
     - jedi-fv3-bundle-env
     - jedi-ufs-bundle-env
     - ufs-weather-model-bundle-env

--- a/configs/apps/all/spack.yaml
+++ b/configs/apps/all/spack.yaml
@@ -1,0 +1,22 @@
+spack:
+  concretization: separately
+  view: false
+  include:
+    - site.yaml
+    - config.yaml
+    - packages.yaml
+    - modules.yaml
+    - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
+
+  packages:
+    all:
+      compiler:: [gcc@9.4.0]
+    mpi:
+      buildable: False
+
+  specs:
+    - re2c
+    - jedi-fv3-bundle-env
+    - jedi-ufs-bundle-env
+    - ufs-weather-model-bundle-env
+    - nceplibs-bundle

--- a/configs/common/config.yaml
+++ b/configs/common/config.yaml
@@ -1,9 +1,27 @@
-  # Set package and module installation directories
-  config:
-    install_hash_length: 7
-    install_tree:
-      root: install
-      projections:
-        all:  "${COMPILERNAME}/${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
-    module_roots:
-      lmod: install/modulefiles
+# Set package and module installation directories
+config:
+  install_hash_length: 7
+  install_tree:
+    root: install
+    projections:
+      all: "${COMPILERNAME}/${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+  module_roots:
+    lmod: install/modulefiles
+
+  # The build stage can be purged with `spack clean --stage` and
+  # `spack clean -a`, so it is important that the specified directory uniquely
+  # identifies Spack staging to avoid accidentally wiping out non-Spack work.
+  build_stage: ${SPACK_STACK_DIR}/cache/build_stage
+
+  # Directory in which to run tests and store test results.
+  # Tests will be stored in directories named by date/time and package
+  # name/hash.
+  test_stage: ${SPACK_STACK_DIR}/cache/test_stage
+
+  # Cache directory for already downloaded source tarballs and archived
+  # repositories. This can be purged with `spack clean --downloads`.
+  source_cache: ${SPACK_STACK_DIR}/cache/source_cache
+
+  # Cache directory for miscellaneous files, like the package index.
+  # This can be purged with `spack clean --misc-cache`
+  misc_cache: ${SPACK_STACK_DIR}/cache/misc_cache

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -1,5 +1,10 @@
 # Pin versions and specs when building packages
   packages:
+    all:
+      providers:
+        blas: [openblas]
+        lapack: [openblas]
+        fftw-api: [fftw]
     cmake:
       version: [3.22.1]
     zlib:


### PR DESCRIPTION
Create a workflow that creates a Spack mirror using a newly created "all" app that combines all current bundles into one environment. I figure this will also be useful to have in case you want to build everything. The workflow is run manually and then the artifact can be downloaded which contains all the individual package sources.

The mirror is placed in `cache/source_cache` (#26)

This can be used in Spack like `spack mirror add my_mirror file://$HOME/spack-mirror`

An example artifact can be seen here: https://github.com/kgerheiser/spack-stack/actions/runs/1885201334

Along the way I added the providers for #40 so to be sure the correct packages are downloaded.

Some of the patches downloaded for the mirror have question marks from links in their name which upload-artifact does not allow, so I delete them before uploading. None of them are relevant to the versions that we use.

Fix #40
Fix #27 
Fix #26

And working towards #16

Also disables the automatic (and failing) Intel build to be consistent with the rest of the workflow that are set to run manually.