### PR TITLE
Sanitize jedi-env, update submodule pointer for spack

### DIFF
--- a/configs/repos/jedi/packages/jedi-env/package.py
+++ b/configs/repos/jedi/packages/jedi-env/package.py
@@ -22,4 +22,5 @@ class JediEnv(BundlePackage):
     depends_on('jedi-fv3-bundle-env', type='run')
     depends_on('jedi-um-bundle-env',  type='run')
     depends_on('jedi-ufs-bundle-env', type='run')
-    depends_on('jedi-tools-env',      type='run')
+    # This is not needed on the HPCs
+    #depends_on('jedi-tools-env',      type='run')

--- a/configs/repos/jedi/packages/jedi-ufs-bundle-env/package.py
+++ b/configs/repos/jedi/packages/jedi-ufs-bundle-env/package.py
@@ -22,20 +22,21 @@ class JediUfsBundleEnv(BundlePackage):
     depends_on('base-env', type='run')
     depends_on('jedi-base-env', type='run')
 
-    depends_on('jasper', type='run')
-    depends_on('libpng', type='run')
-
-    depends_on('fms', type='run')
-    depends_on('esmf', type='run')
-
-    depends_on('bacio',  type='run')
-    depends_on('crtm',   type='run')
-    depends_on('g2',     type='run')
-    depends_on('g2tmpl', type='run')
-    depends_on('ip',     type='run')
-    depends_on('sp',     type='run')
-    depends_on('w3nco',  type='run')
-
-    depends_on('gftl-shared', type='run')
-    depends_on('yafyaml',     type='run')
-    depends_on('mapl',        type='run')
+    depends_on('ufs-weather-model-env', type='run')
+    #depends_on('jasper', type='run')
+    #depends_on('libpng', type='run')
+    #
+    #depends_on('fms', type='run')
+    #depends_on('esmf', type='run')
+    #
+    #depends_on('bacio',  type='run')
+    #depends_on('crtm',   type='run')
+    #depends_on('g2',     type='run')
+    #depends_on('g2tmpl', type='run')
+    #depends_on('ip',     type='run')
+    #depends_on('sp',     type='run')
+    #depends_on('w3nco',  type='run')
+    #
+    #depends_on('gftl-shared', type='run')
+    #depends_on('yafyaml',     type='run')
+    #depends_on('mapl',        type='run')


### PR DESCRIPTION
This is a tiny change that cleans up the jedi environments and updates the submodule pointer for spack following the latest cray changes.

@kgerheiser this has been tested, please merge if approved (I'll be out for the rest of the day).