### PR TITLE
Remove jedi-um-bundle-env from all

### DIFF
--- a/configs/apps/all/spack.yaml
+++ b/configs/apps/all/spack.yaml
@@ -9,6 +9,7 @@ spack:
     - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
-    - jedi-env
+    - jedi-fv3-bundle-env
+    - jedi-ufs-bundle-env
     - ufs-weather-model-env
     - nceplibs-bundle


### PR DESCRIPTION
jedi-um-bundle-env contains internal JCSDA repos

Fix #57

@climbfuji how is this for a workaround?