### PR TITLE
Add noavx512 variant to OpenBLAS

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -86,13 +86,6 @@ runs:
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
 
-      if [[ "${{ inputs.compiler }}" == "intel" ]]; then
-        # Problem with ifort "internal error: 04010003_1159"
-        # Disable AVX-512 for openblas by setting haswell arch
-        spack config add "packages:openblas:target:[haswell]"
-        spack config add "packages:all:target:[haswell]"
-      fi
-
       cd ${{ inputs.path }}/envs/${{ inputs.app }}
 
       if [ "$RUNNER_OS" == "Linux" ]; then

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -149,6 +149,7 @@
       version: [2.11.0]
     openblas:
       version: [0.3.19]
+      variants: +noavx512
     fftw:
       version: [3.3.10]
     py-numpy:


### PR DESCRIPTION
Update submodule pointer, remove hack in Github Action, and add noavx512 to OpenBLAS variants.