### PR TITLE
Update compilers on Orion with GCC path

### DIFF
--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -19,14 +19,15 @@ compilers:
       cxx: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/icpc
       f77: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/ifort
       fc: /apps/intel-2021.2/intel-2021.2/compiler/2021.2.0/linux/bin/intel64/ifort
-    flags:
-      cxxflags: '-gxx-name=/apps/gcc-10.2.0/gcc-10.2.0/bin/g++ -Wl,-rpath,/apps/gcc-10.2.0/gcc-10.2.0/lib64'
-      ldflags: '-gxx-name=/apps/gcc-10.2.0/gcc-10.2.0/bin/g++ -Wl,-rpath,/apps/gcc-10.2.0/gcc-10.2.0/lib64'
+    flags: {}
     operating_system: centos7
     target: x86_64
     modules:
     - intel/2021.2
-    environment: {}
+    environment:
+      prepend_path:
+        PATH: '/apps/gcc-10.2.0/gcc-10.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gcc-10.2.0/gcc-10.2.0/lib64:/apps/gcc-10.2.0/gcc-10.2.0/contrib/lib'
     extra_rpaths: []
 #- compiler:
 #    spec: oneapi@2021.2.0

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -28,6 +28,7 @@ compilers:
       prepend_path:
         PATH: '/apps/gcc-10.2.0/gcc-10.2.0/bin'
         LD_LIBRARY_PATH: '/apps/gcc-10.2.0/gcc-10.2.0/lib64:/apps/gcc-10.2.0/gcc-10.2.0/contrib/lib'
+        CPATH: '/apps/gcc-10.2.0/gcc-10.2.0/include'
     extra_rpaths: []
 #- compiler:
 #    spec: oneapi@2021.2.0

--- a/configs/sites/orion/config.yaml
+++ b/configs/sites/orion/config.yaml
@@ -1,2 +1,2 @@
 config:
-  build_jobs: 20
+  build_jobs: 6

--- a/meta_modules/setup_meta_modules.py
+++ b/meta_modules/setup_meta_modules.py
@@ -220,10 +220,6 @@ for compiler in compiler_config:
             substitutes['ENVVARS'] = substitutes['ENVVARS'].rstrip('\n')
             logging.debug("  ... ... ENVVARS  : {}".format(substitutes['ENVVARS']))
 
-        # Extra rpaths - not supported
-        if compiler['compiler']['extra_rpaths']:
-            raise Exception("Support for extra_rpaths not yet implemented")
-
         # Spack compiler module hierarchy
         substitutes['MODULEPATH'] = os.path.join(module_dir, compiler_name, compiler_version)
         logging.debug("  ... ... MODULEPATH  : {}".format(substitutes['MODULEPATH']))


### PR DESCRIPTION
* Set PATH for GCC
* Lower the number of build jobs
* Remove rpath check, it should be possible to use rpath without raising exception in meta modules

Fix #56 