### PR TITLE
Dynamically include common/ and site/ configs

### DIFF
--- a/configs/apps/all/spack.yaml
+++ b/configs/apps/all/spack.yaml
@@ -1,7 +1,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+  
+  @CONFIG_INCLUDES@
 
   specs:
     - jedi-fv3-bundle-env

--- a/configs/apps/all/spack.yaml
+++ b/configs/apps/all/spack.yaml
@@ -2,11 +2,6 @@ spack:
   concretization: separately
   view: false
   include:
-    - site.yaml
-    - config.yaml
-    - packages.yaml
-    - modules.yaml
-    - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
     - jedi-fv3-bundle-env

--- a/configs/apps/jedi-all/spack.yaml
+++ b/configs/apps/jedi-all/spack.yaml
@@ -1,7 +1,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
 
   specs:
     - jedi-fv3-bundle-env

--- a/configs/apps/jedi-all/spack.yaml
+++ b/configs/apps/jedi-all/spack.yaml
@@ -2,11 +2,6 @@ spack:
   concretization: separately
   view: false
   include:
-    - site.yaml
-    - config.yaml
-    - packages.yaml
-    - modules.yaml
-    - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
     - jedi-fv3-bundle-env

--- a/configs/apps/jedi-fv3/spack.yaml
+++ b/configs/apps/jedi-fv3/spack.yaml
@@ -2,11 +2,6 @@ spack:
   concretization: separately
   view: false
   include:
-  - site.yaml
-  - config.yaml
-  - packages.yaml
-  - modules.yaml
-  - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
   - jedi-fv3-bundle-env

--- a/configs/apps/jedi-fv3/spack.yaml
+++ b/configs/apps/jedi-fv3/spack.yaml
@@ -1,7 +1,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
 
   specs:
   - jedi-fv3-bundle-env

--- a/configs/apps/jedi-tools/spack.yaml
+++ b/configs/apps/jedi-tools/spack.yaml
@@ -1,7 +1,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
 
   specs:
   - jedi-tools-env

--- a/configs/apps/jedi-tools/spack.yaml
+++ b/configs/apps/jedi-tools/spack.yaml
@@ -2,11 +2,6 @@ spack:
   concretization: separately
   view: false
   include:
-  - site.yaml
-  - config.yaml
-  - packages.yaml
-  - modules.yaml
-  - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
   - jedi-tools-env

--- a/configs/apps/jedi-ufs/spack.yaml
+++ b/configs/apps/jedi-ufs/spack.yaml
@@ -2,11 +2,6 @@ spack:
   concretization: separately
   view: false
   include:
-  - site.yaml
-  - config.yaml
-  - packages.yaml
-  - modules.yaml
-  - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
   - jedi-ufs-bundle-env

--- a/configs/apps/jedi-ufs/spack.yaml
+++ b/configs/apps/jedi-ufs/spack.yaml
@@ -1,7 +1,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
 
   specs:
   - jedi-ufs-bundle-env

--- a/configs/apps/jedi-um/spack.yaml
+++ b/configs/apps/jedi-um/spack.yaml
@@ -1,7 +1,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
   
   specs:
   - jedi-um-bundle-env

--- a/configs/apps/jedi-um/spack.yaml
+++ b/configs/apps/jedi-um/spack.yaml
@@ -2,11 +2,6 @@ spack:
   concretization: separately
   view: false
   include:
-  - site.yaml
-  - config.yaml
-  - packages.yaml
-  - modules.yaml
-  - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
-
+  
   specs:
   - jedi-um-bundle-env

--- a/configs/apps/nceplibs/spack.yaml
+++ b/configs/apps/nceplibs/spack.yaml
@@ -3,11 +3,6 @@ spack:
   concretization: separately
   view: false
   include:
-    - site.yaml
-    - config.yaml
-    - packages.yaml
-    - modules.yaml
-    - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
     - nceplibs-bundle

--- a/configs/apps/nceplibs/spack.yaml
+++ b/configs/apps/nceplibs/spack.yaml
@@ -2,7 +2,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
 
   specs:
     - nceplibs-bundle

--- a/configs/apps/spack.template.yaml
+++ b/configs/apps/spack.template.yaml
@@ -2,7 +2,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+  
+  @CONFIG_INCLUDES@
 
 # File in specs
   specs:  

--- a/configs/apps/spack.template.yaml
+++ b/configs/apps/spack.template.yaml
@@ -3,11 +3,6 @@ spack:
   concretization: separately
   view: false
   include:
-  - site.yaml
-  - config.yaml
-  - packages.yaml
-  - modules.yaml
-  - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
 # File in specs
   specs:  

--- a/configs/apps/ufs-weather-model/spack.yaml
+++ b/configs/apps/ufs-weather-model/spack.yaml
@@ -2,7 +2,8 @@
 spack:
   concretization: separately
   view: false
-  include:
+
+  @CONFIG_INCLUDES@
 
   specs:
     - ufs-weather-model-env

--- a/configs/apps/ufs-weather-model/spack.yaml
+++ b/configs/apps/ufs-weather-model/spack.yaml
@@ -3,11 +3,6 @@ spack:
   concretization: separately
   view: false
   include:
-    - site.yaml
-    - config.yaml
-    - packages.yaml
-    - modules.yaml
-    - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
 
   specs:
     - ufs-weather-model-env

--- a/create-env.py
+++ b/create-env.py
@@ -61,7 +61,8 @@ def copy_app_config(app, env_dir):
             configs = list(filter(lambda f: f in valid_configs, listdir(config_dir)))
             configs = map(lambda conf: '  - {}/{}'.format(config_type, conf), configs)
             includes += configs
-        
+    # Always include the repos (could be an option to point somewhere else) or not at all
+    includes += ['  - ${SPACK_STACK_DIR}/configs/repos/repos.yaml']
     includes.insert(0, 'include:') if includes else includes.insert(0, '')
     new_contents = contents.replace('@CONFIG_INCLUDES@', linesep.join(includes))
 
@@ -118,7 +119,7 @@ parser = argparse.ArgumentParser(description=description_text,
                                  epilog=epilog_text,
                                  formatter_class=RawTextHelpFormatter)
 
-parser.add_argument('--site', type=str, required=False, nargs='?', const='default', help=site_help())
+parser.add_argument('--site', type=str, required=False, nargs='?', default='default', help=site_help())
 parser.add_argument('--app', type=str, required=True, help=app_help())
 parser.add_argument('--name', type=str, required=False,
                     help='Optional name for env dir. Defaults to app.site name.')

--- a/create-env.py
+++ b/create-env.py
@@ -3,33 +3,34 @@
 import argparse
 from operator import index
 import os
+from os import listdir, path, makedirs, linesep
 import sys
 import shutil
 from argparse import RawTextHelpFormatter
 
 # Get directory of this script
-stack_dir = os.path.dirname(os.path.realpath(__file__))
+stack_dir = path.dirname(path.realpath(__file__))
 
-
+# Possible spack configuration files
 valid_configs = ['compilers.yaml', 'config.yaml', 'mirrors.yaml',
                  'modules.yaml', 'packages.yaml', 'repos.yaml', 'concretizer.yaml']
 
-# Get a path
-
+# Pass this value to --site for an empty config
+empty_site = 'default'
 
 def stack_path(*paths):
-    return os.path.join(stack_dir, *paths)
+    return path.join(stack_dir, *paths)
 
 
 def create_env_dir(name):
     # Create spack-stack/envs to hold envrionments, if it doesn't exist
-    if not os.path.exists(stack_path('envs')):
-        os.makedirs(stack_path('envs'))
+    if not path.exists(stack_path('envs')):
+        makedirs(stack_path('envs'))
 
     # Create env_dir
     env_dir = stack_path('envs', env_name)
-    if not os.path.exists(env_dir):
-        os.makedirs(env_dir)
+    if not path.exists(env_dir):
+        makedirs(env_dir)
         print("Created environment {} in {}".format(env_name, env_dir))
     else:
         sys.exit('Error: env {} already exists'.format(env_dir))
@@ -39,72 +40,65 @@ def create_env_dir(name):
 
 def copy_common_configs(env_dir):
     common_dir = stack_path('configs', 'common')
-    common_configs = os.listdir(common_dir)
-    shutil.copytree(common_dir, os.path.join(env_dir, 'common'))
+    common_configs = listdir(common_dir)
+    shutil.copytree(common_dir, path.join(env_dir, 'common'))
 
 
 def copy_site_configs(site, env_dir):
     site_dir = stack_path('configs', 'sites', site)
-    shutil.copytree(site_dir, os.path.join(env_dir, 'site'))
+    shutil.copytree(site_dir, path.join(env_dir, 'site'))
 
 
 def copy_app_config(app, env_dir):
     app_config = stack_path('configs', 'apps', app, 'spack.yaml')
     with open(app_config, "r") as f:
-        contents = f.readlines()
+        contents = f.read()
 
-    include_index = [idx for idx, s in enumerate(
-        contents) if 'include:' in s][0]
-    common_includes = os.listdir(os.path.join(env_dir, 'common'))
-    site_includes = os.listdir(os.path.join(env_dir, 'site'))
+    includes = []
+    for config_type in ['common', 'site']:
+        config_dir = stack_path(env_dir, config_type)
+        if path.isdir(config_dir):
+            configs = list(filter(lambda f: f in valid_configs, listdir(config_dir)))
+            configs = map(lambda conf: '  - {}/{}'.format(config_type, conf), configs)
+            includes += configs
+        
+    includes.insert(0, 'include:') if includes else includes.insert(0, '')
+    new_contents = contents.replace('@CONFIG_INCLUDES@', linesep.join(includes))
 
-    common_includes = filter(lambda f: f in valid_configs, common_includes)
-    site_includes = filter(lambda f: f in valid_configs, site_includes)
-
-    index_offset = 1
-    for config in common_includes:
-        contents.insert(include_index + index_offset,
-                        '   - common/{}'.format(config) + os.linesep)
-        index_offset += 1
-
-    for config in site_includes:
-        contents.insert(include_index + index_offset,
-                        '   - site/{}'.format(config) + os.linesep)
-        index_offset += 1
-
-    contents.insert(include_index + index_offset,
-                    '   - ${SPACK_STACK_DIR}/configs/repos/repos.yaml' + os.linesep)
-    with open(os.path.join(env_dir, 'spack.yaml'), "w") as f:
-        contents = "".join(contents)
-        f.write(contents)
+    with open(path.join(env_dir, 'spack.yaml'), "w") as f:
+        f.write(new_contents)
 
 
 def check_inputs(app, site):
     app_path = stack_path('configs', 'apps', app, 'spack.yaml')
-    if not os.path.exists(app_path):
+    if not path.exists(app_path):
         sys.exit('Error: invalid app {}, "{}" does not exist'.format(app, app_path))
 
+    if site == empty_site:
+        return
+
     site_path = stack_path('configs', 'sites', site)
-    if not os.path.exists(site_path):
+    if not path.exists(site_path):
         sys.exit('Error: invalid site {}, "{}" does not exist'.format(
             site, site_path))
 
 
 def site_help():
     _, site_dirs, _ = next(os.walk(stack_path('configs', 'sites')))
-    help_string = 'Pre-configured platform, or "default" for an empty site.yaml.' + os.linesep
-    help_string += 'Available options are: ' + os.linesep
+    help_string = 'Pre-configured platform, or "default" for an empty site.yaml.' + linesep
+    help_string += 'Defaults to "default" if no arg is given' + linesep
+    help_string += 'Available options are: ' + linesep
     for site in site_dirs:
-        help_string += '\t' + site + os.linesep
+        help_string += '\t' + site + linesep
     return help_string
 
 
 def app_help():
     _, app_dirs, _ = next(os.walk(stack_path('configs', 'apps')))
-    help_string = 'Application environment to build.' + os.linesep
-    help_string += 'Available options are: ' + os.linesep
+    help_string = 'Application environment to build.' + linesep
+    help_string += 'Available options are: ' + linesep
     for app in app_dirs:
-        help_string += '\t' + app + os.linesep
+        help_string += '\t' + app + linesep
     return help_string
 
 
@@ -124,7 +118,7 @@ parser = argparse.ArgumentParser(description=description_text,
                                  epilog=epilog_text,
                                  formatter_class=RawTextHelpFormatter)
 
-parser.add_argument('--site', type=str, required=True, help=site_help())
+parser.add_argument('--site', type=str, required=False, nargs='?', const='default', help=site_help())
 parser.add_argument('--app', type=str, required=True, help=app_help())
 parser.add_argument('--name', type=str, required=False,
                     help='Optional name for env dir. Defaults to app.site name.')
@@ -142,5 +136,6 @@ check_inputs(app, site)
 env_dir = create_env_dir(env_name)
 if not exclude_common_configs:
     copy_common_configs(env_dir)
-copy_site_configs(site, env_dir)
+if site != empty_site:
+    copy_site_configs(site, env_dir)
 copy_app_config(app, env_dir)


### PR DESCRIPTION
create-env.py will copy the copy the common/ and site/ configs and dynamically include them in the spack.yaml. 

Fix #71 

Now a spack.yaml looks like:

```
  include:
   - common/concretizer.yaml
   - common/config.yaml
   - common/packages.yaml
   - common/modules.yaml
   - site/config.yaml
   - site/packages.yaml
   - site/compilers.yaml
   - site/modules.yaml
   - ${SPACK_STACK_DIR}/configs/repos/repos.yaml
```