### PR TITLE
Bug fix for shumlib to recognize apple-clang as clang

### DIFF
--- a/configs/repos/jedi/packages/shumlib/package.py
+++ b/configs/repos/jedi/packages/shumlib/package.py
@@ -30,7 +30,7 @@ class Shumlib(MakefilePackage):
 
     def build(self, spec, prefix):
         # DH* TODO: SWITCH FOR DIFFERENT ARCHITECTURES
-        if spec.satisfies('%clang'):
+        if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):
             os.system('make -f make/vm-x86-gfortran-clang.mk')
         #elif spec.satisfies('%gcc'):
         else:


### PR DESCRIPTION
As the title says. While LLVM's clang is called "clang" in spack, the native Apple clang is called "apple-clang".
