### PR TITLE
Replace restricted access packages faux and trans with publicly available fiat and ectrans

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -133,11 +133,11 @@
       variants: +fckit
     shumlib:
       version: [macos_clang_port]
-    faux:
+    fiat:
       version: [develop]
-    # Attention - when updating also check macos site config
-    trans:
+    ectrans:
       version: [develop]
+      variants: ~enable_mkl
     git-lfs:
       version: [2.11.0]
     openblas:

--- a/configs/repos/jedi/packages/atlas/package.py
+++ b/configs/repos/jedi/packages/atlas/package.py
@@ -40,7 +40,7 @@ class Atlas(CMakePackage):
     variant('shared', default=True)
 
     variant('trans', default=False)
-    depends_on('trans', when='+trans')
+    depends_on('ectrans', when='+trans')
     #variant('cgal', default=False)
     #depends_on('cgal', when='+cgal')
     variant('eigen', default=True)

--- a/configs/repos/jedi/packages/ectrans/package.py
+++ b/configs/repos/jedi/packages/ectrans/package.py
@@ -6,29 +6,30 @@
 from spack import *
 
 
-class Trans(CMakePackage):
-    """Trans is the global spherical Harmonics transforms library, extracted from the IFS.
+class Ectrans(CMakePackage):
+    """Ectrans is the global spherical Harmonics transforms library, extracted from the IFS.
     It is using a hybrid of MPI and OpenMP parallelisation strategies. The package contains
     both single- and double precision Fortran libraries (trans_sp, trans_dp), as well as a
     C interface to the double-precision version (transi_dp)."""
 
-    # DH* TODO UPDATE
-    homepage = "https://github.com/JCSDA-internal/trans"
-    git = "https://github.com/JCSDA-internal/trans.git"
+    homepage = "https://github.com/ecmwf-ifs/ectrans"
+    git = "https://github.com/ecmwf-ifs/ectrans.git"
 
     maintainers = ['climbfuji']
 
     version('develop', branch='develop', no_cache=True, preferred=True)
+    version('main', branch='main', no_cache=True, preferred=False)
 
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')
 
+    #variant('double_precision', default=True, description='Support for double precision?')
+    #variant('single_precision', default=True, description='Support for single precision?')
+
     variant('mkl',  default=False, description='Use MKL?')
     variant('fftw', default=True, description='Use FFTW?')
 
-    #variant('double_precision', default=True, description='Enable double precision?')
-    #variant('single_precision', default=True, description='Enable single precision?')
-    #variant('transi', default=True, description='Use TransI?')
+    #variant('transi', default=True, description='Compile TransI C-interface to trans?')
 
     depends_on('ecbuild', type=('build'))
     depends_on('mpi',  when='+mpi')
@@ -37,15 +38,18 @@ class Trans(CMakePackage):
     depends_on('fftw-api', when='+fftw')
     depends_on('mkl', when='+mkl')
 
-    depends_on('faux~mpi',  when='~mpi')
-    depends_on('faux+mpi',  when='+mpi')
+    depends_on('fiat~mpi',  when='~mpi')
+    depends_on('fiat+mpi',  when='+mpi')
 
     def cmake_args(self):
         args = [
             self.define_from_variant('ENABLE_MPI', 'mpi'),
             self.define_from_variant('ENABLE_OMP', 'openmp'),
+            #self.define_from_variant('ENABLE_DOUBLE_PRECISION', 'double_precision'),
+            #self.define_from_variant('ENABLE_SINGLE_PRECISION', 'single_precision'),
             self.define_from_variant('ENABLE_FFTW', 'fftw'),
             self.define_from_variant('ENABLE_MKL', 'mkl')
+            #self.define_from_variant('ENABLE_TRANSI', 'transi')
         ]
 
         return args

--- a/configs/repos/jedi/packages/fiat/package.py
+++ b/configs/repos/jedi/packages/fiat/package.py
@@ -6,21 +6,24 @@
 from spack import *
 
 
-class Faux(CMakePackage):
-    """Faux is a collection of selected Fortran utility libraries, extracted from the IFS."""
+class Fiat(CMakePackage):
+    """FIAT (Fortran IFS and Arpege Toolkit) is a collection of selected
+    Fortran utility libraries, extracted from the IFS/Arpege model."""
 
-    # DH* TODO UPDATE
-    homepage = "https://github.com/JCSDA-internal/faux"
-    git = "https://github.com/JCSDA-internal/faux.git"
+    homepage = "https://github.com/ecmwf-ifs/fiat"
+    git = "https://github.com/ecmwf-ifs/fiat.git"
 
     maintainers = ['climbfuji']
 
     version('develop', branch='develop', no_cache=True, preferred=True)
+    version('main', branch='main', no_cache=True, preferred=False)
 
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')
     variant('fckit', default=True, description='Use fckit?')
-    #variant('enable_dr_hook_multi_precision_handles', default=False, description='Use deprecated single precision handles for DR_HOOK?')
+    #variant('dr_hook_multi_precision_handles', default=False,
+    #    description='Use deprecated single precision handles for DR_HOOK?')
+    #variant('warnings', default=True, description='Enable compiler warnings')
 
     depends_on('ecbuild', type=('build'))
     depends_on('mpi', when='+mpi')
@@ -32,7 +35,9 @@ class Faux(CMakePackage):
             self.define_from_variant('ENABLE_OMP', 'openmp'),
             self.define_from_variant('ENABLE_MPI', 'mpi'),
             self.define_from_variant('ENABLE_FCKIT', 'fckit')
-            #self.define_from_variant('ENABLE_DR_HOOK_MULTI_PRECISION_HANDLES')
+            #self.define_from_variant('ENABLE_DR_HOOK_MULTI_PRECISION_HANDLES',
+            #   'dr_hook_multi_precision_handles')
+            #self.define_from_variant('ENABLE_WARNINGS, 'warnings')
         ]
 
         return args

--- a/configs/repos/jedi/packages/jedi-um-bundle-env/package.py
+++ b/configs/repos/jedi/packages/jedi-um-bundle-env/package.py
@@ -23,5 +23,5 @@ class JediUmBundleEnv(BundlePackage):
     depends_on('jedi-base-env', type='run')
 
     depends_on('shumlib', type='run')
-    depends_on('faux', type='run')
-    depends_on('trans', type='run')
+    depends_on('fiat', type='run')
+    depends_on('ectrans', type='run')

--- a/configs/sites/macos/packages.yaml
+++ b/configs/sites/macos/packages.yaml
@@ -24,8 +24,6 @@ packages:
     variants:: +64bit +enable_quad_precision +gfs_phys ~openmp +pic
   fms-jcsda:
     variants:: +64bit +enable_quad_precision +gfs_phys ~openmp +pic
-  trans:
-    variants:: ~enable_mkl
 
 ### All other external packages listed alphabetically
   apple-libunwind:


### PR DESCRIPTION
ECMWF has released their packages fiat (replaces faux) and ectrans (replaces trans) to the public.

This PR replaces the two restricted packages with the public versions. atlas and the rest of the stack build fine with fiat and ectrans under the hood (on macOS and on hera).

Fixes #70.