### PR TITLE
Set DYLD_LIBRARY_PATH in modules

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -153,9 +153,11 @@ modules:
       lib:
       - LIBRARY_PATH
       - LD_LIBRARY_PATH
+      - DYLD_LIBRARY_PATH
       lib64:
       - LIBRARY_PATH
       - LD_LIBRARY_PATH
+      - DYLD_LIBRARY_PATH
       include:
       - CPATH
       lib/pkgconfig:


### PR DESCRIPTION
macOS does not use LD_LIBRARY_PATH. We should also set DYLD_LIBRARY_PATH.

I think this will help with #78 