### PR TITLE
Hera site config update

### DIFF
--- a/configs/sites/hera/README.md
+++ b/configs/sites/hera/README.md
@@ -14,7 +14,6 @@ This needs to be done every time before installing packages with spack or before
 
 Note. Temporary location, this needs to be moved elsewhere.
 ```
-module purge
 module use /scratch1/BMC/gsd-hpcs/Dom.Heinzeller/spack-stack/modulefiles
 module load miniconda/3.9.7
 ````

--- a/configs/sites/hera/README.md
+++ b/configs/sites/hera/README.md
@@ -2,10 +2,19 @@
 
 ## General instructions/prerequisites
 
+## General instructions/prerequisites
+
+module purge
+
+### One-off: prepare miniconda python3 environment
+See instructions in miniconda/README.md. Don't forget to log off and back on to forget about the conda environment.
+
 ### Set up the user environment for working with spack/building new software environments
+This needs to be done every time before installing packages with spack or before using spack-provided modules!
 
 Note. Temporary location, this needs to be moved elsewhere.
 ```
+module purge
 module use /scratch1/BMC/gsd-hpcs/Dom.Heinzeller/spack-stack/modulefiles
 module load miniconda/3.9.7
 ````

--- a/configs/sites/hera/compilers.yaml
+++ b/configs/sites/hera/compilers.yaml
@@ -1,19 +1,5 @@
 compilers:
 - compiler:
-    spec: intel@18.0.5.274
-    paths:
-      cc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icc
-      cxx: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icpc
-      f77: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-      fc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: any
-    modules:
-    - intel/18.0.5.274
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: intel@2021.5.0
     paths:
       cc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icc
@@ -25,7 +11,11 @@ compilers:
     target: any
     modules:
     - intel/2022.1.2
-    environment: {}
+    environment:
+      prepend_path:
+        PATH: '/apps/gnu/gcc-9.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-9.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-9.2.0/include'
     extra_rpaths: []
 - compiler:
     spec: gcc@9.2.0

--- a/configs/sites/hera/config.yaml
+++ b/configs/sites/hera/config.yaml
@@ -1,2 +1,2 @@
 config:
-  build_jobs: 20
+  build_jobs: 6

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -10,9 +10,12 @@ packages:
     - spec: intel-mpi@2018.0.4%intel@18.0.5.274
       modules:
       - impi/2018.0.4
+  intel-oneapi-mpi:
+    externals:
     - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
       modules:
       - impi/2022.1.2
+      prefix: /apps/oneapi
   openmpi:
     externals:
     - spec: openmpi@3.1.4%gcc@9.2.0~cuda+cxx+cxx_exceptions~java~memchecker+pmi+pmix~sqlite3+static~thread_multiple~wrapper-rpath fabrics=mxm schedulers=slurm

--- a/configs/sites/macos/README.md
+++ b/configs/sites/macos/README.md
@@ -32,6 +32,7 @@ brew install git-lfs@3.0.2
 brew install lmod@8.6.6
 brew install wget@1.21.2
 brew install bash@5.1.16
+```
 - Activate the `lua` module environment:
 ```
 source /usr/local/opt/lmod/init/profile
@@ -45,9 +46,13 @@ See https://github.com/spack/spack/issues/29308
 which pip3
 # make sure this points to homebrew's pip3
 pip3 install poetry
+# test - successful if no output
+python3 -c "import poetry"
 ```
 
 ### Known issues
 1. Error `invalid argument '-fgnu89-inline' not allowed with 'C++'`
 This error came up on macOS Monterey with mpich-3.4.3 installed via homebrew when trying to build the jedi bundles that use `ecbuild`. The reason was that the C compiler flag `-fgnu89-inline` from `/usr/local/Cellar/mpich/3.4.3/lib/pkgconfig/mpich.pc` was added to the C++ compiler flags by ecbuild. The solution was to set
 `CC=mpicc FC=mpif90 CXX=mpicxx` when calling `ecbuild` for those bundles.
+2. Installation of `poetry` using `pip3` or test with `python3` fails
+This can happen when multiple versions of Python were installed with `brew` and `pip3`/`python3` point to different versions. Run `brew doctor` and check if there are issues with Python not being properly linked. Follow the instructions given by `brew`, if applicable.

--- a/configs/sites/orion/README.md
+++ b/configs/sites/orion/README.md
@@ -9,6 +9,8 @@ See instructions in miniconda/README.md. Don't forget to log off and back on to 
 
 ### Set up the user environment for working with spack/building new software environments
 This needs to be done every time before installing packages with spack or before using spack-provided modules!
+
+Note. Temporary location, this needs to be moved elsewhere.
 ```
 module use /work/noaa/gsd-hpcs/dheinzel/jcsda/modulefiles
 module load miniconda/3.9.7

--- a/miniconda/README.md
+++ b/miniconda/README.md
@@ -20,18 +20,14 @@ module use /work/noaa/gsd-hpcs/dheinzel/jcsda/modulefiles
 module load miniconda/3.9.7
 which python3
 # make sure this points to the new miniconda install
-which pip3
-# make sure this points to the new miniconda install
-pip3 install poetry
-# ignore warnings/errors about pip's dependency resolver
-# test:
-python3 -c "import poetry"
-# successful if silent
 ```
-DOM: TEST IF THE PIP INSTALL CAN BE COMBINED WITH THIS
+Install two packages required for building Python modules with spack using conda
 ```
 eval "$(/scratch1/BMC/gsd-hpcs/Dom.Heinzeller/spack-stack/miniconda-3.9.7/bin/conda shell.bash hook)"
-conda install -c conda-forge libpython-static`
+conda install -c conda-forge libpython-static
+conda install poetry
+# Test, successful if silent
+python3 -c "import poetry"
 # log out to forget about the conda environment
 ```
 


### PR DESCRIPTION
This PR updates the hera site config. This config has been tested to install fv3-bundle-env, um-bundle-env, ufs-bundle-env (which includes everything for ufs-weather-model).

Also: update a number of `README.md` files with notes regarding Python installation.

Fixes #48