### PR TITLE
Add nco and soca-bundle-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack.git
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack.git
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack.git
+  branch = bugfix/parallelio_mpich_401

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack.git
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack.git
-  branch = bugfix/parallelio_mpich_401
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack.git
+  branch = jcsda_emc_spack_stack

--- a/configs/apps/all/spack.yaml
+++ b/configs/apps/all/spack.yaml
@@ -7,6 +7,10 @@ spack:
   specs:
     - jedi-fv3-bundle-env
     - jedi-ufs-bundle-env
+    - jedi-um-bundle-env
+    # Do not add, this leads to duplicate packages being installed
+    #- jedi-tools-env
+    - nceplibs-bundle
+    - soca-bundle-env
     - ufs-weather-model-env
     - ufs-weather-model-debug-env
-    - nceplibs-bundle

--- a/configs/apps/jedi-all/spack.yaml
+++ b/configs/apps/jedi-all/spack.yaml
@@ -10,3 +10,4 @@ spack:
     - jedi-um-bundle-env
     # Do not add, this leads to duplicate packages being installed
     #- jedi-tools-env
+    - soca-bundle-env

--- a/configs/apps/soca/spack.yaml
+++ b/configs/apps/soca/spack.yaml
@@ -1,0 +1,8 @@
+spack:
+  concretization: separately
+  view: false
+
+  @CONFIG_INCLUDES@
+
+  specs:
+  - soca-bundle-env

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -145,6 +145,9 @@
       variants: +noavx512
     fftw:
       version: [3.3.10]
+    nco:
+      version: [5.0.1]
+      variants: ~doc
     nlohmann-json:
       version: [3.10.5]
     nlohmann-json-schema-validator:

--- a/configs/repos/jedi/packages/soca-bundle-env/package.py
+++ b/configs/repos/jedi/packages/soca-bundle-env/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class SocaBundleEnv(BundlePackage):
+    """Development environment for soca-bundle"""
+
+    # DH* TODO UPDATE
+    homepage = "https://github.com/JCSDA-internal/soca"
+    git      = "https://github.com/JCSDA-internal/soca.git"
+
+    maintainers = ['climbfuji', 'travissluka' ]
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+    depends_on('jedi-base-env', type='run')
+
+    depends_on('nco', type='run')


### PR DESCRIPTION
This PR adds a `soca-bundle-env` and a corresponding `soca` app, as well as a new dependency for soca, `nco`. Soca uses `ncks` in its testing framework.

I tested the installation of `nco` on macOS with clang and mpich. 

Fixes https://github.com/NOAA-EMC/spack-stack/issues/78.