### PR TITLE
Re-usable MPI builds and other CI improvements

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: 'Which application env to build'
     required: true
   compiler:
-    description: 'Compiler (available options gcc@9, gcc@10, intel)'
+    description: 'Compiler (available options gcc@9, gcc@10, clang, apple-clang, intel)'
     required: true
     default: 'gcc@9'
   mpi:
@@ -44,7 +44,7 @@ runs:
             rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
             echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
             sudo apt-get update
-            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
+            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -59,7 +59,7 @@ runs:
     uses: actions/cache@v2
     with:
       path: ~/mpi
-      key: mpi-${{ inputs.mpi }}-${{ inputs.compiler }}.${{ runner.os }}1
+      key: mpi-${{ inputs.mpi }}-${{ inputs.compiler }}.${{ runner.os }}2
 
   # MPI takes a long time to build. Built it externally and cache it.
   - name: install-mpi
@@ -106,6 +106,8 @@ runs:
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx  --with-device=ch4:ofi
           make -j2
           make install
+        elif [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi"* ]]; then
+           sudo apt install intel-oneapi-mpi-devel
         fi
 
   - name: setup-spack-env

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -130,6 +130,20 @@ runs:
         spack compiler find
       fi
 
+      # No external find for intel-oneapi-mpi
+      # And no way to add object entry to list using "spack config add"
+      # Add this first so "spack config add packages:" will append to this entry
+      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
+        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        echo "" >> ${SPACK_ENV}/spack.yaml
+        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
+        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
+      fi
+
       spack external find
 
   - name: update-bash-profile
@@ -148,20 +162,6 @@ runs:
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
-
-      # No external find for intel-oneapi-mpi
-      # And no way to add object entry to list using "spack config add"
-      # Add this first so "spack config add packages:" will append to this entry
-      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
-      fi
 
       # Use external MPI to save compilation time
       spack config add "packages:mpi:buildable:False"

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -169,7 +169,7 @@ runs:
 
       # Remove external OpenSSL entry
       # Error when wget attempts to build using external on macOS
-      spack config rm packages:openssl
+      spack config rm "packages:openssl"
 
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -70,7 +70,7 @@ runs:
     if: steps.cache-mpi.outputs.cache-hit != 'true'
     run: |
         echo "" >> ~/.bash_profile
-        if [[ "${ {inputs.compiler }}" == "gcc@9" ]]; then
+        if [[ "${{ inputs.compiler }}" == "gcc@9" ]]; then
           export CC=gcc-9
           export FC=gfortran-9
           export CXX=g++-9

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -48,9 +48,6 @@ runs:
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [ "$RUNNER_OS" == "macOS" ]; then
-        if [[ "${{ inputs.compiler }}" == "clang"* ]]; then
-            brew install llvm
-        fi
         echo ""
       fi
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -89,14 +89,14 @@ runs:
         echo "" >> ~/.bash_profile
 
         if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz &> /dev/null
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz
           tar -xzf openmpi-${OPENMP_VERSION}.tar.gz
           cd openmpi-${OPENMP_VERSION}
           ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
           make -j2
           make install
         elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
-          wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz &> /dev/null
+          wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
           tar -xzf mpich-${MPICH_VERSION}.tar.gz
           cd mpich-${MPICH_VERSION}
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -106,8 +106,8 @@ runs:
       source setup.sh
       ./create-env.py --site default --app ${{ inputs.app }} --name ${{ inputs.app }}
       spack env activate envs/${{ inputs.app }}
-      
-      echo "$HOME/mpi/bin" >> $GITHUB_PATH
+
+      export "PATH=$HOME/mpi/bin:${PATH}"
 
       spack external find
       spack compiler find

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -126,6 +126,8 @@ runs:
         spack compiler add $(brew --prefix llvm)
       fi
 
+      if 
+
       spack external find
       spack compiler find
 
@@ -170,6 +172,7 @@ runs:
 
       if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
         impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        echo "" >> ${SPACK_ENV}/spack.yaml
         echo "  packages:" >> ${SPACK_ENV}/spack.yaml
         echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
         echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -167,7 +167,7 @@ runs:
         echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
         echo "      externals:" >> ${SPACK_ENV}/spack.yaml
         echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: /opt/intel" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
       fi
 
       if [ "$RUNNER_OS" == "Linux" ]; then

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
 
   steps:
-  
+
   - name: checkout-spack-stack
     if: ${{ inputs.use-local-checkout == 'false' }}
     uses: actions/checkout@v2
@@ -81,16 +81,16 @@ runs:
         fi
 
         if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.gz &> /dev/null
-          tar -xzf openmpi-4.1.1.tar.gz
-          cd openmpi-4.1.1
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.3.tar.gz &> /dev/null
+          tar -xzf openmpi-4.1.3.tar.gz
+          cd openmpi-4.1.3
           ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
           make -j2
           make install
         elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
-          wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz &> /dev/null
-          tar -xzf mpich-3.3.2.tar.gz
-          cd mpich-3.3.2
+          wget http://www.mpich.org/static/downloads/3.4.3/mpich-3.4.3.tar.gz &> /dev/null
+          tar -xzf mpich-3.4.3.tar.gz
+          cd mpich-3.4.3
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx
           make -j2
           make install

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -124,6 +124,8 @@ runs:
 
       # So Spack can find external MPI
       export "PATH=$HOME/mpi/bin:${PATH}"
+      mpichversion
+      usr/local/opt/llvm/bin/clang --version
 
       # LLVM Clang not in PATH, search for it specifically
       # Then, Fortran compilers are null, so set to gfortran

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -71,8 +71,8 @@ runs:
         export CXX=g++-10
       fi
 
-      export MPICH_VERSION = "3.4.3"
-      export OPENMPI_VERSION = "4.1.3"
+      export MPICH_VERSION="3.4.3"
+      export OPENMPI_VERSION="4.1.3"
 
   - name: cache-mpi
     id: cache-mpi

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -57,23 +57,6 @@ runs:
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
 
-  - name: set-env
-    shell: bash
-    id: set-env
-    run: |
-      if [[ "${{ inputs.compiler }}" == "gcc@9" ]]; then
-        export CC=gcc-9
-        export FC=gfortran-9
-        export CXX=g++-9
-      elif [[ "${{ inputs.compiler }}" == "gcc@10" ]]; then
-        export CC=gcc-10
-        export FC=gfortran-10
-        export CXX=g++-10
-      fi
-
-      export MPICH_VERSION="3.4.3"
-      export OPENMPI_VERSION="4.1.3"
-
   - name: cache-mpi
     id: cache-mpi
     uses: actions/cache@v2
@@ -87,8 +70,19 @@ runs:
     if: steps.cache-mpi.outputs.cache-hit != 'true'
     run: |
         echo "" >> ~/.bash_profile
-        echo ${OPENMPI_VERSION}
-        echo ${MPICH_VERSION}
+
+        if [[ "${{ inputs.compiler }}" == "gcc@9" ]]; then
+          export CC=gcc-9
+          export FC=gfortran-9
+          export CXX=g++-9
+        elif [[ "${{ inputs.compiler }}" == "gcc@10" ]]; then
+          export CC=gcc-10
+          export FC=gfortran-10
+          export CXX=g++-10
+        fi
+
+        export MPICH_VERSION="3.4.3"
+        export OPENMPI_VERSION="4.1.3"
 
         if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
           wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -160,7 +160,7 @@ runs:
         echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
         echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
         echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: intel-oneapi-mpi@${impi_ver}%intel@{intel_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: intel-oneapi-mpi@${impi_ver}%intel@${intel_ver}" >> ${SPACK_ENV}/spack.yaml
         echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
       fi
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -83,7 +83,8 @@ runs:
         elif [[ "${{ inputs.compiler }}" == *"clang"* ]]; then
           export CC=clang
           export CXX=clang++
-          export FC=gfortran-9
+          export FC=gfortran-10
+          export FFLAGS="-fallow-argument-mismatch"
         fi
 
         export MPICH_VERSION="3.4.3"

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -120,11 +120,14 @@ runs:
 
       export "PATH=$HOME/mpi/bin:${PATH}"
 
-      if [ "$RUNNER_OS" == "macOS" ]; then
+      # LLVM Clang not in PATH, search for it specifically
+      # Then, Fortran compilers are null, so set to gfortran
+      # Add minimal compilers just to prevent other compilers from being used by accident
+      if [[ "$RUNNER_OS" == "macOS" && ${{ inputs.compiler }} == "clang"* ]]; then
         spack compiler add $(brew --prefix llvm)
-      fi
-
-      if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+        sed -i".bak" "s|f77: null|f77: /usr/local/bin/gfortran-10|" ${SPACK_ENV}/spack.yaml
+        sed -i".bak" "s|fc: null|fc: /usr/local/bin/gfortran-10|" ${SPACK_ENV}/spack.yaml
+      elif [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
       else
         spack compiler find
@@ -185,9 +188,9 @@ runs:
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
 
-      if [ "$RUNNER_OS" == "Linux" ]; then
+      if [[ "$RUNNER_OS" == "Linux" ]]; then
         echo ""
-      elif [ "$RUNNER_OS" == "macOS" ]; then
+      elif [[ "$RUNNER_OS" == "macOS" ]]; then
         spack config add "packages:boost:version:[1.78.0]"
         spack config add "packages:fms:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"
         spack config add "packages:fms-jcsda:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -154,13 +154,12 @@ runs:
       # Add this first so "spack config add packages:" will append to this entry
       if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
         impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
-        intel_ver=$(find /opt/intel/oneapi/compiler -maxdepth 1 -mindepth 1 -type d | xargs basename)
         echo "" >> ${SPACK_ENV}/spack.yaml
         echo "  packages:" >> ${SPACK_ENV}/spack.yaml
         echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
         echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
         echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: intel-oneapi-mpi@${impi_ver}%intel@${intel_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
         echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
       fi
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -130,6 +130,7 @@ runs:
 
       # Use external MPI to save compilation time
       spack config add "packages:mpi:buildable:False"
+      spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
 
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -125,7 +125,8 @@ runs:
       # So Spack can find external MPI
       export "PATH=$HOME/mpi/bin:${PATH}"
       mpichversion
-      usr/local/opt/bin/clang --version
+      /usr/local/opt/llvm/bin/clang --version
+
 
       # LLVM Clang not in PATH, search for it specifically
       # Then, Fortran compilers are null, so set to gfortran

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -44,7 +44,7 @@ runs:
             rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
             echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
             sudo apt-get update
-            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -57,12 +57,29 @@ runs:
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
 
+  - name: set-env
+    shell: bash
+    id: set-env
+    run: |
+      if [[ "${{ inputs.compiler }}" == "gcc@9" ]]; then
+        export CC=gcc-9
+        export FC=gfortran-9
+        export CXX=g++-9
+      elif [[ "${{ inputs.compiler }}" == "gcc@10" ]]; then
+        export CC=gcc-10
+        export FC=gfortran-10
+        export CXX=g++-10
+      fi
+
+      export MPICH_VERSION = "3.4.3"
+      export OPENMPI_VERSION = "4.1.3"
+
   - name: cache-mpi
     id: cache-mpi
     uses: actions/cache@v2
     with:
       path: ~/mpi
-      key: mpi-${{ inputs.mpi }}-${{ runner.os }}
+      key: mpi-${{ inputs.mpi }}-${{ runner.os }}1
 
   # MPI takes a long time to build. Built it externally and cache it.
   - name: install-mpi
@@ -70,30 +87,23 @@ runs:
     if: steps.cache-mpi.outputs.cache-hit != 'true'
     run: |
         echo "" >> ~/.bash_profile
-        if [[ "${{ inputs.compiler }}" == "gcc@9" ]]; then
-          export CC=gcc-9
-          export FC=gfortran-9
-          export CXX=g++-9
-        elif [[ "${{ inputs.compiler }}" == "gcc@10" ]]; then
-          export CC=gcc-10
-          export FC=gfortran-10
-          export CXX=g++-10
-        fi
 
         if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.3.tar.gz &> /dev/null
-          tar -xzf openmpi-4.1.3.tar.gz
-          cd openmpi-4.1.3
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz &> /dev/null
+          tar -xzf openmpi-${OPENMP_VERSION}.tar.gz
+          cd openmpi-${OPENMP_VERSION}
           ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
           make -j2
           make install
         elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
-          wget http://www.mpich.org/static/downloads/3.4.3/mpich-3.4.3.tar.gz &> /dev/null
-          tar -xzf mpich-3.4.3.tar.gz
-          cd mpich-3.4.3
+          wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz &> /dev/null
+          tar -xzf mpich-${MPICH_VERSION}.tar.gz
+          cd mpich-${MPICH_VERSION}
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx
           make -j2
           make install
+        elif [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
+          sudo apt-get install intel-oneapi-mpi-devel
         fi
 
   - name: setup-spack-env
@@ -103,6 +113,7 @@ runs:
       if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         source /opt/intel/oneapi/setvars.sh
       fi
+
       source setup.sh
       ./create-env.py --site default --app ${{ inputs.app }} --name ${{ inputs.app }}
       spack env activate envs/${{ inputs.app }}
@@ -146,6 +157,16 @@ runs:
       # Whitelist the mpi providers so that spack creates the modules for them
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
+
+      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
+        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
+        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: /opt/intel" >> ${SPACK_ENV}/spack.yaml
+      fi
 
       if [ "$RUNNER_OS" == "Linux" ]; then
         echo ""

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -95,7 +95,7 @@ runs:
           wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
           tar -xzf mpich-${MPICH_VERSION}.tar.gz
           cd mpich-${MPICH_VERSION}
-          ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx
+          ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx  --with-device=ch4:ofi
           make -j2
           make install
         elif [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -80,7 +80,7 @@ runs:
           export FC=gfortran-10
           export CXX=g++-10
           export FFLAGS="-fallow-argument-mismatch"
-        elfif [[ "${{ inputs.compiler }}" == "clang"* ]]; then
+        elfif [[ "${{ inputs.compiler }}" == *"clang"* ]]; then
           export CC=clang
           export CXX=clang++
           export FC=gfortran

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -79,7 +79,7 @@ runs:
     uses: actions/cache@v2
     with:
       path: ~/mpi
-      key: mpi-${{ inputs.mpi }}-${{ runner.os }}1
+      key: mpi-${{ inputs.mpi }}-${{ inputs.compiler }}.${{ runner.os }}1
 
   # MPI takes a long time to build. Built it externally and cache it.
   - name: install-mpi

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -77,9 +77,14 @@ runs:
           export FC=gfortran-10
           export CXX=g++-10
           export FFLAGS="-fallow-argument-mismatch"
-        elif [[ "${{ inputs.compiler }}" == *"clang"* ]]; then
+        elif [[ "${{ inputs.compiler }}" == "apple-clang"* ]]; then
           export CC=clang
           export CXX=clang++
+          export FC=gfortran-10
+          export FFLAGS="-fallow-argument-mismatch"
+        elif [[ "${{ inputs.compiler }}" == "clang"* ]]; then
+          export CC=$(brew --prefix llvm)/bin/clang
+          export CXX=$(brew --prefix llvm)/bin/clang++
           export FC=gfortran-10
           export FFLAGS="-fallow-argument-mismatch"
         fi
@@ -211,7 +216,7 @@ runs:
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
       if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         source /opt/intel/oneapi/setvars.sh
-        # Pass --dirty to fix Intel compiler environment to fix missing LD_LIBRARY_PATH
+        # Pass --dirty for Intel compiler environment to fix missing LD_LIBRARY_PATH
         spack install --dirty --fail-fast
       else
         spack install --fail-fast

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -44,7 +44,7 @@ runs:
             rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
             echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
             sudo apt-get update
-            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -104,8 +104,6 @@ runs:
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx  --with-device=ch4:ofi
           make -j2
           make install
-        elif [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-          sudo apt-get install intel-oneapi-mpi-devel
         fi
 
   - name: setup-spack-env
@@ -126,10 +124,13 @@ runs:
         spack compiler add $(brew --prefix llvm)
       fi
 
-      if 
+      if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+        spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
+      else
+        spack compiler find
+      fi
 
       spack external find
-      spack compiler find
 
   - name: update-bash-profile
     shell: bash

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -70,11 +70,11 @@ runs:
     if: steps.cache-mpi.outputs.cache-hit != 'true'
     run: |
         echo "" >> ~/.bash_profile
-        if [[ "${inputs.compiler}" == "gcc@9" ]]; then
+        if [[ "${ {inputs.compiler }}" == "gcc@9" ]]; then
           export CC=gcc-9
           export FC=gfortran-9
           export CXX=g++-9
-        elif [[ "${inputs.compiler}" == "gcc@10" ]]; then
+        elif [[ "${{ inputs.compiler }}" == "gcc@10" ]]; then
           export CC=gcc-10
           export FC=gfortran-10
           export CXX=g++-10

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -83,7 +83,8 @@ runs:
         elif [[ "${{ inputs.compiler }}" == *"clang"* ]]; then
           export CC=clang
           export CXX=clang++
-          export FC=gfortran
+          export FC=gfortran-9
+          which gfortran
         fi
 
         export MPICH_VERSION="3.4.3"

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -122,6 +122,10 @@ runs:
 
       export "PATH=$HOME/mpi/bin:${PATH}"
 
+      if [ "$RUNNER_OS" == "macOS" ]; then
+        spack compiler add $(brew --prefix llvm)
+      fi
+
       spack external find
       spack compiler find
 
@@ -145,6 +149,10 @@ runs:
       # Use external MPI to save compilation time
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
+
+      # Remove external OpenSSL entry
+      # Error when wget attempts to build using external on macOS
+      spack config rm packages:openssl
 
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
 
@@ -184,6 +192,7 @@ runs:
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
+      cat ${SPACK_ENV}/spack.yaml
       spack concretize
 
   - name: build-env
@@ -195,9 +204,9 @@ runs:
       if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         source /opt/intel/oneapi/setvars.sh
         # Pass --dirty to fix Intel compiler environment to fix missing LD_LIBRARY_PATH
-        spack install --dirty
+        spack install --dirty --fail-fast
       else
-        spack install
+        spack install --fail-fast
       fi
 
   - name: create-meta-modules

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -149,6 +149,21 @@ runs:
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
 
+      # No external find for intel-oneapi-mpi
+      # And no way to add object entry to list using "spack config add"
+      # Add this first so "spack config add packages:" will append to this entry
+      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
+        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        intel_ver=$(find /opt/intel/oneapi/compiler -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        echo "" >> ${SPACK_ENV}/spack.yaml
+        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
+        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: intel-oneapi-mpi@${impi_ver}%intel@{intel_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
+      fi
+
       # Use external MPI to save compilation time
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
@@ -170,17 +185,6 @@ runs:
       # Whitelist the mpi providers so that spack creates the modules for them
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
-
-      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
-      fi
 
       if [ "$RUNNER_OS" == "Linux" ]; then
         echo ""

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -80,7 +80,7 @@ runs:
           export FC=gfortran-10
           export CXX=g++-10
           export FFLAGS="-fallow-argument-mismatch"
-        elfif [[ "${{ inputs.compiler }}" == *"clang"* ]]; then
+        elif [[ "${{ inputs.compiler }}" == *"clang"* ]]; then
           export CC=clang
           export CXX=clang++
           export FC=gfortran

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -84,7 +84,6 @@ runs:
           export CC=clang
           export CXX=clang++
           export FC=gfortran-9
-          which gfortran
         fi
 
         export MPICH_VERSION="3.4.3"

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -87,7 +87,6 @@ runs:
           ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
           make -j2
           make install
-          echo "export PATH=$HOME/mpi/bin:${PATH}" >> ~/.bash_profile
         elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
           wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz &> /dev/null
           tar -xzf mpich-3.3.2.tar.gz
@@ -95,7 +94,6 @@ runs:
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx
           make -j2
           make install
-          echo "export PATH=$HOME/mpi/bin:${PATH}" >> ~/.bash_profile
         fi
 
   - name: setup-spack-env
@@ -108,6 +106,8 @@ runs:
       source setup.sh
       ./create-env.py --site default --app ${{ inputs.app }} --name ${{ inputs.app }}
       spack env activate envs/${{ inputs.app }}
+      
+      echo "$HOME/mpi/bin" >> $GITHUB_PATH
 
       spack external find
       spack compiler find
@@ -120,6 +120,7 @@ runs:
       echo "" >> ~/.bash_profile
       echo "source ${{ inputs.path }}/setup.sh" >> ~/.bash_profile
       echo "spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}" >> ~/.bash_profile
+      echo "export PATH=$HOME/mpi/bin:${PATH}" >> ~/.bash_profile
 
   - name: configure-options
     shell: bash

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -71,14 +71,19 @@ runs:
     run: |
         echo "" >> ~/.bash_profile
 
-        if [[ "${{ inputs.compiler }}" == "gcc@9" ]]; then
+        if [[ "${{ inputs.compiler }}" == "gcc@9"* ]]; then
           export CC=gcc-9
           export FC=gfortran-9
           export CXX=g++-9
-        elif [[ "${{ inputs.compiler }}" == "gcc@10" ]]; then
+        elif [[ "${{ inputs.compiler }}" == "gcc@10"* ]]; then
           export CC=gcc-10
           export FC=gfortran-10
           export CXX=g++-10
+          export FFLAGS="-fallow-argument-mismatch"
+        elfif [[ "${{ inputs.compiler }}" == "clang"* ]]; then
+          export CC=clang
+          export CXX=clang++
+          export FC=gfortran
         fi
 
         export MPICH_VERSION="3.4.3"

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -118,6 +118,7 @@ runs:
       ./create-env.py --site default --app ${{ inputs.app }} --name ${{ inputs.app }}
       spack env activate envs/${{ inputs.app }}
 
+      # So Spack can find external MPI
       export "PATH=$HOME/mpi/bin:${PATH}"
 
       # LLVM Clang not in PATH, search for it specifically

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -87,15 +87,15 @@ runs:
           ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
           make -j2
           make install
-          echo 'export PATH=$HOME/mpi/bin:${PATH}' >> ~/.bash_profile
-        elif [[ "${{ inputs.mpi }}" == "mpich"* ]]
+          echo "export PATH=$HOME/mpi/bin:${PATH}" >> ~/.bash_profile
+        elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
           wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz &> /dev/null
           tar -xzf mpich-3.3.2.tar.gz
           cd mpich-3.3.2
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx
           make -j2
           make install
-          echo 'export PATH=$HOME/mpi/bin:${PATH}' >> ~/.bash_profile
+          echo "export PATH=$HOME/mpi/bin:${PATH}" >> ~/.bash_profile
         fi
 
   - name: setup-spack-env

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -125,7 +125,7 @@ runs:
       # So Spack can find external MPI
       export "PATH=$HOME/mpi/bin:${PATH}"
       mpichversion
-      usr/local/opt/llvm/bin/clang --version
+      usr/local/opt/bin/clang --version
 
       # LLVM Clang not in PATH, search for it specifically
       # Then, Fortran compilers are null, so set to gfortran

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -57,6 +57,47 @@ runs:
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
 
+  - name: cache-mpi
+    id: cache-mpi
+    uses: actions/cache@v2
+    with:
+      path: ~/mpi
+      key: mpi-${{ inputs.mpi }}-${{ runner.os }}
+
+  # MPI takes a long time to build. Built it externally and cache it.
+  - name: install-mpi
+    shell: bash
+    if: steps.cache-mpi.outputs.cache-hit != 'true'
+    run: |
+        echo "" >> ~/.bash_profile
+        if [[ "${inputs.compiler}" == "gcc@9" ]]; then
+          export CC=gcc-9
+          export FC=gfortran-9
+          export CXX=g++-9
+        elif [[ "${inputs.compiler}" == "gcc@10" ]]; then
+          export CC=gcc-10
+          export FC=gfortran-10
+          export CXX=g++-10
+        fi
+
+        if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.gz &> /dev/null
+          tar -xzf openmpi-4.1.1.tar.gz
+          cd openmpi-4.1.1
+          ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
+          make -j2
+          make install
+          echo 'export PATH=$HOME/mpi/bin:${PATH}' >> ~/.bash_profile
+        elif [[ "${{ inputs.mpi }}" == "mpich"* ]]
+          wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz &> /dev/null
+          tar -xzf mpich-3.3.2.tar.gz
+          cd mpich-3.3.2
+          ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx
+          make -j2
+          make install
+          echo 'export PATH=$HOME/mpi/bin:${PATH}' >> ~/.bash_profile
+        fi
+
   - name: setup-spack-env
     shell: bash
     run: |
@@ -87,8 +128,10 @@ runs:
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
 
+      # Use external MPI to save compilation time
+      spack config add "packages:mpi:buildable:False"
+
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
-      spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
 
       # Currently, this is the case for all workflows - wrap in if statement
       # when this changes in the future

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -87,6 +87,8 @@ runs:
     if: steps.cache-mpi.outputs.cache-hit != 'true'
     run: |
         echo "" >> ~/.bash_profile
+        echo ${OPENMPI_VERSION}
+        echo ${MPICH_VERSION}
 
         if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
           wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz


### PR DESCRIPTION
* Build MPI manually and use `spack external find` to use it. This saves on compilation time. Options are MPICH 3.4.3 and OpenMPI 4.1.3. I just took the latest stable versions of each.
* Add external entry for `intel-oneapi-mpi`. This is done manually with `cat` because you can't add an object array entry with `spack config add` 
* Fix macOS builds by using `spack config rm openssl` because while OpenSSL is installed, the development libraries aren't. Let Spack build them.
* Fix LLVM Clang not being used even though it was set. It's not in the default `PATH` have to point Spack to it in `(brew --prefix llvm)`. `apple-clang` was always being used instead. Also, LLVM Clang is installed by default, no need to install with Homebrew.
* Add `--fail-fast` to `spack install` so build failures are immediately noticed.

I will check back later, but the Ubuntu GCC build was successful and the other ones are chugging along.

