### PR TITLE
Install Intel MPI with the compiler through APT

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -44,7 +44,7 @@ runs:
             rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
             echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
             sudo apt-get update
-            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+            sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -106,8 +106,6 @@ runs:
           ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx  --with-device=ch4:ofi
           make -j2
           make install
-        elif [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi"* ]]; then
-           sudo apt install intel-oneapi-mpi-devel
         fi
 
   - name: setup-spack-env


### PR DESCRIPTION
intel-oneapi-mpi isn't cached and the workflow thinks it restores it from cache successfully at ~/mpi