### PR TITLE
Fix wgrib2 build and re-enable

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -82,6 +82,8 @@ runs:
         spack compiler add $(brew --prefix llvm)
         sed -i".bak" "s|f77: null|f77: /usr/local/bin/gfortran-10|" ${SPACK_ENV}/spack.yaml
         sed -i".bak" "s|fc: null|fc: /usr/local/bin/gfortran-10|" ${SPACK_ENV}/spack.yaml
+        # Linker can't find -lomp in non-default path. Add to /usr/local/lib
+        sudo ln -s $(brew --prefix llvm)/lib/libomp.dylib /usr/local/lib/libomp.dylib
       elif [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
         # Workaround for error "libimf.so cannot be found":

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -154,6 +154,11 @@ runs:
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
       spack install --fail-fast
+
+  - name: test
+    if: always()
+    shell: bash
+    run: |
       cat /Users/runner/work/spack-stack/spack-stack/cache/build_stage/spack-stage-wgrib2-2.0.8-7ipi6wagv6kzmg2sehhmfmeertwvo75y/spack-src/libaec-1.0.2/config.log
 
   - name: create-meta-modules

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -158,12 +158,6 @@ runs:
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
       spack install --fail-fast
 
-  - name: test
-    if: always()
-    shell: bash
-    run: |
-      cat /Users/runner/work/spack-stack/spack-stack/cache/build_stage/spack-stage-wgrib2-2.0.8-7ipi6wagv6kzmg2sehhmfmeertwvo75y/spack-src/libaec-1.0.2/config.log
-
   - name: create-meta-modules
     shell: bash
     run: |

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -57,7 +57,61 @@ runs:
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
 
- 
+  - name: cache-mpi
+    id: cache-mpi
+    uses: actions/cache@v2
+    with:
+      path: ~/mpi
+      key: mpi-${{ inputs.mpi }}-${{ inputs.compiler }}.${{ runner.os }}2
+
+  # MPI takes a long time to build. Built it externally and cache it.
+  - name: install-mpi
+    shell: bash
+    if: steps.cache-mpi.outputs.cache-hit != 'true'
+    run: |
+        echo "" >> ~/.bash_profile
+
+        if [[ "${{ inputs.compiler }}" == "gcc@9"* ]]; then
+          export CC=gcc-9
+          export FC=gfortran-9
+          export CXX=g++-9
+        elif [[ "${{ inputs.compiler }}" == "gcc@10"* ]]; then
+          export CC=gcc-10
+          export FC=gfortran-10
+          export CXX=g++-10
+          export FFLAGS="-fallow-argument-mismatch"
+        elif [[ "${{ inputs.compiler }}" == "apple-clang"* ]]; then
+          export CC=clang
+          export CXX=clang++
+          export FC=gfortran-10
+          export FFLAGS="-fallow-argument-mismatch"
+        elif [[ "${{ inputs.compiler }}" == "clang"* ]]; then
+          export CC=$(brew --prefix llvm)/bin/clang
+          export CXX=$(brew --prefix llvm)/bin/clang++
+          export FC=gfortran-10
+          export FFLAGS="-fallow-argument-mismatch"
+        fi
+
+        export MPICH_VERSION="3.4.3"
+        export OPENMPI_VERSION="4.1.3"
+
+        if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz
+          tar -xzf openmpi-${OPENMPI_VERSION}.tar.gz
+          cd openmpi-${OPENMPI_VERSION}
+          # --with-hwloc=internal --with-libevent=internal : https://www.open-mpi.org/faq/?category=building#libevent-or-hwloc-errors-when-linking-fortran
+          ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx --with-hwloc=internal --with-libevent=internal
+          make -j2
+          make install
+        elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
+          wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+          tar -xzf mpich-${MPICH_VERSION}.tar.gz
+          cd mpich-${MPICH_VERSION}
+          ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx  --with-device=ch4:ofi
+          make -j2
+          make install
+        fi
+
   - name: setup-spack-env
     shell: bash
     run: |
@@ -88,6 +142,38 @@ runs:
         sed -i 's#environment: {}#environment: {prepend_path: {LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin}}#g' envs/${{ inputs.app }}/spack.yaml
       else
         spack compiler find
+      fi
+
+      # No external find for intel-oneapi-mpi, and problems finding other MPI libraries as well
+      # And no way to add object entry to list using "spack config add"
+      # Add this first so "spack config add packages:" will append to this entry
+      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
+        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        echo "" >> ${SPACK_ENV}/spack.yaml
+        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
+        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
+      elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
+        mpich_ver=${MPICH_VERSION}
+        echo "" >> ${SPACK_ENV}/spack.yaml
+        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+        echo "    mpich:" >> ${SPACK_ENV}/spack.yaml
+        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: mpich@${mpich_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: $HOME/mpi" >> ${SPACK_ENV}/spack.yaml
+      elif [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
+        openmpi_ver=${OPENMPI_VERSION}
+        echo "" >> ${SPACK_ENV}/spack.yaml
+        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+        echo "    openmpi:" >> ${SPACK_ENV}/spack.yaml
+        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+        echo "      - spec: openmpi@${openmpi_ver}" >> ${SPACK_ENV}/spack.yaml
+        echo "        prefix: $HOME/mpi" >> ${SPACK_ENV}/spack.yaml
       fi
 
       # Spack external find is by default only looking for build-tools. Either

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -57,61 +57,7 @@ runs:
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
 
-  - name: cache-mpi
-    id: cache-mpi
-    uses: actions/cache@v2
-    with:
-      path: ~/mpi
-      key: mpi-${{ inputs.mpi }}-${{ inputs.compiler }}.${{ runner.os }}2
-
-  # MPI takes a long time to build. Built it externally and cache it.
-  - name: install-mpi
-    shell: bash
-    if: steps.cache-mpi.outputs.cache-hit != 'true'
-    run: |
-        echo "" >> ~/.bash_profile
-
-        if [[ "${{ inputs.compiler }}" == "gcc@9"* ]]; then
-          export CC=gcc-9
-          export FC=gfortran-9
-          export CXX=g++-9
-        elif [[ "${{ inputs.compiler }}" == "gcc@10"* ]]; then
-          export CC=gcc-10
-          export FC=gfortran-10
-          export CXX=g++-10
-          export FFLAGS="-fallow-argument-mismatch"
-        elif [[ "${{ inputs.compiler }}" == "apple-clang"* ]]; then
-          export CC=clang
-          export CXX=clang++
-          export FC=gfortran-10
-          export FFLAGS="-fallow-argument-mismatch"
-        elif [[ "${{ inputs.compiler }}" == "clang"* ]]; then
-          export CC=$(brew --prefix llvm)/bin/clang
-          export CXX=$(brew --prefix llvm)/bin/clang++
-          export FC=gfortran-10
-          export FFLAGS="-fallow-argument-mismatch"
-        fi
-
-        export MPICH_VERSION="3.4.3"
-        export OPENMPI_VERSION="4.1.3"
-
-        if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz
-          tar -xzf openmpi-${OPENMPI_VERSION}.tar.gz
-          cd openmpi-${OPENMPI_VERSION}
-          # --with-hwloc=internal --with-libevent=internal : https://www.open-mpi.org/faq/?category=building#libevent-or-hwloc-errors-when-linking-fortran
-          ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx --with-hwloc=internal --with-libevent=internal
-          make -j2
-          make install
-        elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
-          wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
-          tar -xzf mpich-${MPICH_VERSION}.tar.gz
-          cd mpich-${MPICH_VERSION}
-          ./configure --prefix=$HOME/mpi --enable-fortran --enable-cxx  --with-device=ch4:ofi
-          make -j2
-          make install
-        fi
-
+ 
   - name: setup-spack-env
     shell: bash
     run: |
@@ -142,38 +88,6 @@ runs:
         sed -i 's#environment: {}#environment: {prepend_path: {LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin}}#g' envs/${{ inputs.app }}/spack.yaml
       else
         spack compiler find
-      fi
-
-      # No external find for intel-oneapi-mpi, and problems finding other MPI libraries as well
-      # And no way to add object entry to list using "spack config add"
-      # Add this first so "spack config add packages:" will append to this entry
-      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
-      elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
-        mpich_ver=${MPICH_VERSION}
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    mpich:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: mpich@${mpich_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: $HOME/mpi" >> ${SPACK_ENV}/spack.yaml
-      elif [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-        openmpi_ver=${OPENMPI_VERSION}
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    openmpi:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: openmpi@${openmpi_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: $HOME/mpi" >> ${SPACK_ENV}/spack.yaml
       fi
 
       # Spack external find is by default only looking for build-tools. Either
@@ -240,6 +154,7 @@ runs:
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.app }}
       spack install --fail-fast
+      cat /Users/runner/work/spack-stack/spack-stack/cache/build_stage/spack-stage-wgrib2-2.0.8-7ipi6wagv6kzmg2sehhmfmeertwvo75y/spack-src/libaec-1.0.2/config.log
 
   - name: create-meta-modules
     shell: bash

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -82,8 +82,6 @@ runs:
         spack compiler add $(brew --prefix llvm)
         sed -i".bak" "s|f77: null|f77: /usr/local/bin/gfortran-10|" ${SPACK_ENV}/spack.yaml
         sed -i".bak" "s|fc: null|fc: /usr/local/bin/gfortran-10|" ${SPACK_ENV}/spack.yaml
-        # Linker can't find -lomp in non-default path. Add to /usr/local/lib
-        sudo ln -s $(brew --prefix llvm)/lib/libomp.dylib /usr/local/lib/libomp.dylib
       elif [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
         # Workaround for error "libimf.so cannot be found":
@@ -135,6 +133,9 @@ runs:
       if [[ "$RUNNER_OS" == "Linux" ]]; then
         echo ""
       elif [[ "$RUNNER_OS" == "macOS" ]]; then
+        # Clang has trouble finding -lomp for OpenMP because of non-standard location
+        # Could be fixed by setting compiler environment LDFLAGS to -L$(brew --prefix llvm)/lib or wherever libomp is
+        spack config add "packages:wgrib2:variants: ~openmp"
         spack config add "packages:boost:version:[1.78.0]"
         spack config add "packages:fms:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"
         spack config add "packages:fms-jcsda:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"

--- a/configs/apps/jedi-ufs-all/spack.yaml
+++ b/configs/apps/jedi-ufs-all/spack.yaml
@@ -5,5 +5,6 @@ spack:
   @CONFIG_INCLUDES@
 
   specs:
-  - wgrib2@2.0.8
-  - wgrib2@3.1.1
+    - jedi-ufs-all-env
+    # Needs to be added separately
+    - ufs-weather-model-debug-env

--- a/configs/apps/jedi-ufs-all/spack.yaml
+++ b/configs/apps/jedi-ufs-all/spack.yaml
@@ -5,6 +5,5 @@ spack:
   @CONFIG_INCLUDES@
 
   specs:
-    - jedi-ufs-all-env
-    # Needs to be added separately
-    - ufs-weather-model-debug-env
+  - wgrib2@2.0.8
+  - wgrib2@3.1.1

--- a/configs/repos/ufs/packages/nceplibs-bundle/package.py
+++ b/configs/repos/ufs/packages/nceplibs-bundle/package.py
@@ -53,6 +53,6 @@ class NceplibsBundle(BundlePackage):
     depends_on('w3emc')
     depends_on('w3nco')
     depends_on('wrf-io')
-    #depends_on('wgrib2')
+    depends_on('wgrib2')
 
     # There is no need for install() since there is no code.

--- a/configs/repos/ufs/packages/wgrib2/package.py
+++ b/configs/repos/ufs/packages/wgrib2/package.py
@@ -128,6 +128,7 @@ class Wgrib2(MakefilePackage):
         # ifort no longer accepts -openmp
         makefile.filter(r'-openmp', '-qopenmp')
         makefile.filter(r'-Wall', ' ')
+        makefile.filter(r'-Werror=format-security', ' ')
 
         # clang doesn't understand --fast-math
         if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):


### PR DESCRIPTION
Fixes wgrib2 build error `cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]`.

I see this error around the internet such as here: https://bugzilla.mozilla.org/show_bug.cgi?id=1388681

Build tested with Clang, Apple Clang, GCC, and Intel.

https://github.com/kgerheiser/spack-stack/actions/runs/2204985895

https://github.com/kgerheiser/spack-stack/actions/runs/2204985761