### PR TITLE
Correct spack submodule pointer to point to head of noaa-emc/jcsda_emc_spack_stack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack.git
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack.git
-  branch = bugfix/hash_length_container
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack.git
+  branch = jcsda_emc_spack_stack


### PR DESCRIPTION
Correct spack submodule pointer to point to head of noaa-emc/jcsda_emc_spack_stack