### PR TITLE
Re-apply fix for 2.4.0_emc

### DIFF
--- a/configs/repos/common/packages/crtm-fix/package.py
+++ b/configs/repos/common/packages/crtm-fix/package.py
@@ -45,6 +45,21 @@ class CrtmFix(Package):
         for d in endian_dirs:
             fix_files = fix_files + find('.', '*/{}/*'.format(d))
 
+        # Big_Endian amsua_metop-c.SpcCoeff.bin is incorrect
+        # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be
+        # Remove the incorrect file, and install it as noACC, and install the correct file.
+         if '+big_endian' in spec and spec.version == Version('2.4.0_emc'):
+            fix_files.remove(
+                join_path(cwd, 'SpcCoeff', 'Big_Endian', 'amsua_metop-c.SpcCoeff.bin'))
+
+            # This file is incorrect, install it as a different name.
+            install(join_path('SpcCoeff', 'Big_Endian', 'amsua_metop-c.SpcCoeff.bin'),
+                        join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.noACC.bin'))
+                        
+            # This "Little_Endian" file is actually the correct one.
+            install(join_path('SpcCoeff', 'Little_Endian', 'amsua_metop-c_v2.SpcCoeff.bin'),
+                        join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.bin'))
+
         mkdir(self.prefix.fix)
         cwd = pwd()
 


### PR DESCRIPTION
I mistakenly thought this was changed on the ftp site, but turns out something else was changed.

Some files need to be manually updated because of an inconsistency in the fix files.

The file that is 'Little_Endian/amsua_metop-c_v2.SpcCoeff.bin' is the same file found in 2.3.0 as 'Big_Endian/amsua_metop-c.SpcCoeff.bin'.

And after this PR, this package should be moved into Spack like the others. This is the only here.