### PR TITLE
Update atlas version to 0.29.0 and enable variant trans in ecmwf-atlas

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack.git
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack.git
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack.git
+  branch = feature/atlas_0_29_0_ectrans_options

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack.git
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack.git
-  branch = feature/atlas_0_29_0_ectrans_options
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack.git
+  branch = jcsda_emc_spack_stack

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -140,8 +140,8 @@
       version: [0.9.5]
       variants: +eckit
     ecmwf-atlas:
-      version: [0.27.0]
-      variants: +fckit
+      version: [0.29.0]
+      variants: +fckit +trans
     shumlib:
       version: [macos_clang_port]
     fiat:
@@ -152,9 +152,8 @@
     #git-lfs:
       # Assume git-lfs is provided, hard to install
       # because of dependencies on go/go-bootstrap.
-      # No need to uncomment here as long as the
-      # site config provides an external package.
-      #buildable: False
+      # Note: Uncommenting this entry will break
+      # the container builds.
       #version: [2.11.0]
     openblas:
       version: [0.3.19]


### PR DESCRIPTION
This PR:
- updates atlas to version 0.29.0
- enables variant `+trans` in ecmwf-atlas
- update the submodule pointer for spack for the associated changes in https://github.com/NOAA-EMC/spack/pull/62

Fixes https://github.com/NOAA-EMC/spack-stack/issues/141

Waiting on https://github.com/NOAA-EMC/spack/pull/62

After merging https://github.com/NOAA-EMC/spack/pull/62, the spack submodule pointer needs to be updated and the `.gitmodules` change reverted.

**Testing**

Tested successfully on my local Mac. CI tests all pass, too: https://github.com/climbfuji/spack-stack/actions (look for "3 days ago" as of May 16).