### PR TITLE
Feature/spack stack extension

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -163,7 +163,7 @@ runs:
       fi
 
       source setup.sh
-      ./create.py environment --site default --app ${{ inputs.app }} --name ${{ inputs.app }}
+      spack stack create env --site default --app ${{ inputs.app }} --name ${{ inputs.app }}
       spack env activate envs/${{ inputs.app }}
 
       # LLVM Clang not in PATH, search for it specifically

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,21 @@
+name: create-spack-mirror
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: run-unit-tests
+        run: |
+          source ./setup.sh
+          spack unit-test --extension=stack

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: create-spack-mirror
+name: unit-tests
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 envs
 __pycache__
 cache
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack.git
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/kgerheiser/spack.git
+  branch = spack-stack-extension
+  # url = https://github.com/NOAA-EMC/spack.git
+  # branch = jcsda_emc_spack_stack

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/kgerheiser/spack.git
-  branch = spack-stack-extension
-  # url = https://github.com/NOAA-EMC/spack.git
-  # branch = jcsda_emc_spack_stack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack.git
+  branch = jcsda_emc_spack_stack

--- a/.spackstack
+++ b/.spackstack
@@ -1,1 +1,1 @@
-Hidden file for spack stack command to find spack-stack configs
+Let's spack stack command ffind top-level spack-stack directory for config location

--- a/.spackstack
+++ b/.spackstack
@@ -1,0 +1,1 @@
+Hidden file for spack stack command to find spack-stack configs

--- a/.spackstack
+++ b/.spackstack
@@ -1,1 +1,1 @@
-Let's spack stack command ffind top-level spack-stack directory for config location
+Lets spack stack command find top-level spack-stack directory for config location

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ spack-stack is a collaborative effort between the NOAA Environmental Modeling Ce
 
 [spack](https://github.com/spack/spack) is a community-supported, multi-platform, Python-based package manager originally developed by the Lawrence Livermore National Laboratory (LLNL; https://computing.llnl.gov/projects/spack-hpc-package-manager). It is provided as a submodule so that a stable version can be referenced. [See the Spack Documentation for more information](https://spack.readthedocs.io/en/latest/)
 
-spack-stack is mainly a collection of Spack configuration files, but provides a few Python scripts to simplify the installation process:
-- `create.py` is provided to copy common, site-specific, and application-specific configuration files into a coherent Spack environment and to create container recipes
+spack-stack is mainly a collection of Spack configuration files, but provides a Spack extension to simplify the installation process:
+- `spack stack create` is provided to copy common, site-specific, and application-specific configuration files into a coherent Spack environment and to create container recipes
 - `meta_modules/setup_meta_modules.py` creates compiler, MPI and Python meta-modules for a convenient setup of a user environment using modules (lua and tcl)
 
 spack-stack is maintained by:
@@ -42,17 +42,17 @@ cd spack-stack
 source setup.sh
 
 # Basic usage of create.py
-./create.py -h
+spack stack create -h
 ```
 
 ### Create local environment
 ```
 # See a list of sites and apps
-./create.py environment -h
+spack stack create env -h
 
 # Create a pre-configured Spack environment in envs/<app>.<site>
 # (copies site-specific, application-specific, and common config files into the environment directory)
-./create.py environment --site hera --app jedi-fv3 --name jedi-fv3.hera
+spack stack create env --site hera --app jedi-fv3 --name jedi-fv3.hera
 
 # Activate the newly created environment
 # Optional: decorate the command line prompt using -p
@@ -81,13 +81,13 @@ spack module lmod refresh
 ### Create container
 ```
 # See a list of preconfigured containers
-./create.py container -h
+spack stack create container -h
 
 # Create container spack definition (spack.yaml) in directory envs/<spec>.<config>
-./create.py container --config docker-ubuntu-gcc-openmpi --spec esmf
+spack stack create container docker-ubuntu-gcc-openmpi --app ufs-weather-model
 
 # Descend into container environment directory
-cd envs/esmf.docker-ubuntu-gcc-openmpi
+cd envs/docker-ubuntu-gcc-openmpi.ufs-weather-model
 
 # Optionally edit config file
 emacs spack.yaml
@@ -102,7 +102,7 @@ docker run -it myimage
 ## Generating new site config
 Recommended: Start with an empty (default) site config. Then run `spack external find` to locate common external packages such as git, Perl, CMake, etc., and run `spack compiler find` to locate compilers in your path. Compilers or external packages with modules need to be added manually.
 ```
-./create.py environment --site default --app jedi-ufs --name jedi-ufs.mysite
+spack stack create env --site default --app jedi-ufs --name jedi-ufs.mysite
 
 # Descend into site config directory
 cd envs/jedi-ufs.mysite/site

--- a/configs/apps/empty/spack.yaml
+++ b/configs/apps/empty/spack.yaml
@@ -2,6 +2,6 @@ spack:
   concretization: separately
   view: false
   
-  
+  include: []
 
   specs: []

--- a/configs/apps/empty/spack.yaml
+++ b/configs/apps/empty/spack.yaml
@@ -2,6 +2,6 @@ spack:
   concretization: separately
   view: false
   
-  @CONFIG_INCLUDES@
+  
 
   specs: []

--- a/configs/apps/jedi-ewok/spack.yaml
+++ b/configs/apps/jedi-ewok/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
 
   specs:
     - jedi-ewok-env

--- a/configs/apps/jedi-ewok/spack.yaml
+++ b/configs/apps/jedi-ewok/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
 
   specs:
     - jedi-ewok-env

--- a/configs/apps/jedi-fv3/spack.yaml
+++ b/configs/apps/jedi-fv3/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
 
   specs:
   - jedi-fv3-bundle-env

--- a/configs/apps/jedi-fv3/spack.yaml
+++ b/configs/apps/jedi-fv3/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
 
   specs:
   - jedi-fv3-bundle-env

--- a/configs/apps/jedi-tools/spack.yaml
+++ b/configs/apps/jedi-tools/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
 
   specs:
   - jedi-tools-env

--- a/configs/apps/jedi-tools/spack.yaml
+++ b/configs/apps/jedi-tools/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
 
   specs:
   - jedi-tools-env

--- a/configs/apps/jedi-ufs/spack.yaml
+++ b/configs/apps/jedi-ufs/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
 
   specs:
   - jedi-ufs-bundle-env

--- a/configs/apps/jedi-ufs/spack.yaml
+++ b/configs/apps/jedi-ufs/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
 
   specs:
   - jedi-ufs-bundle-env

--- a/configs/apps/jedi-um/spack.yaml
+++ b/configs/apps/jedi-um/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
   
   specs:
   - jedi-um-bundle-env

--- a/configs/apps/jedi-um/spack.yaml
+++ b/configs/apps/jedi-um/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
   
   specs:
   - jedi-um-bundle-env

--- a/configs/apps/nceplibs/spack.yaml
+++ b/configs/apps/nceplibs/spack.yaml
@@ -3,7 +3,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
 
   specs:
     - nceplibs-bundle-env

--- a/configs/apps/nceplibs/spack.yaml
+++ b/configs/apps/nceplibs/spack.yaml
@@ -3,7 +3,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
 
   specs:
     - nceplibs-bundle-env

--- a/configs/apps/soca/spack.yaml
+++ b/configs/apps/soca/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  
 
   specs:
   - soca-bundle-env

--- a/configs/apps/soca/spack.yaml
+++ b/configs/apps/soca/spack.yaml
@@ -2,7 +2,7 @@ spack:
   concretization: separately
   view: false
 
-  
+  include: []
 
   specs:
   - soca-bundle-env

--- a/configs/apps/spack.template.yaml
+++ b/configs/apps/spack.template.yaml
@@ -3,7 +3,7 @@ spack:
   concretization: separately
   view: false
   
-  @CONFIG_INCLUDES@
+  
 
 # File in specs
   specs:  

--- a/configs/apps/spack.template.yaml
+++ b/configs/apps/spack.template.yaml
@@ -3,7 +3,9 @@ spack:
   concretization: separately
   view: false
   
-  
+  # Custom includes which can be a directory containg
+  # Spack config files or a file itself.
+  include: [] 
 
 # File in specs
   specs:  

--- a/configs/apps/ufs-weather-model/spack.yaml
+++ b/configs/apps/ufs-weather-model/spack.yaml
@@ -1,9 +1,8 @@
-# Template spack.yaml for apps
 spack:
   concretization: separately
   view: false
 
-  @CONFIG_INCLUDES@
+  include: []
 
   specs:
     - ufs-weather-model-env

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -22,7 +22,6 @@ spack:
       extra_rpaths: []
 
   # Basic package config from configs/common/packages.yaml
-  @PACKAGE_CONFIG@
   # Additional package config for container
     gcc:
       buildable: False
@@ -40,22 +39,7 @@ spack:
       - spec: git-lfs@2
         prefix: /usr
 
-  specs:
-    ### Not yet tested
-    #- jedi-ewok-env
-    #- jedi-um-bundle-env
-    #- jedi-tools-env
-    #- ufs-weather-model-env
-    #- nceplibs-bundle-env
-    ### Tested to work - increasing level of complexity
-    #- wget
-    #- esmf
-    #- base-env
-    #- jedi-base-env
-    #- jedi-fv3-bundle-env
-    #- jedi-ufs-bundle-env
-    #- jedi-um-bundle-env
-    - @SPEC@
+  specs: []
 
   container:
 
@@ -114,5 +98,5 @@ spack:
 
     # Labels for the image
     labels:
-      app: "@SPEC@"
+      app: ""
       mpi: "openmpi"

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -23,6 +23,7 @@ spack:
 
   # Basic package config from configs/common/packages.yaml
   # Additional package config for container
+  packages:
     gcc:
       buildable: False
       externals:
@@ -75,7 +76,6 @@ spack:
       - g++-10
       - gfortran-10
       - cpp-10
-      #- libgomp
       - git
       - git-lfs
       final:
@@ -83,7 +83,6 @@ spack:
       - g++-10
       - gfortran-10
       - cpp-10
-      #- libgomp
       - git
       - git-lfs
 


### PR DESCRIPTION
Depends on https://github.com/NOAA-EMC/spack/pull/63

`./create environment/container` becomes `spack stack create env/container`. And instead of `--config` it's a positional argument as the first arg to `create container`.

The CI is running now and I was able to generate a valid container. The runs havemade it through the environment setup, so all seems well.
