### PR TITLE
By default, turn off variant unix_stdio_64 for gdal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,5 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/gdal_unix_stdio_64_default_off
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,7 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack.git
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/gdal_unix_stdio_64_default_off


### PR DESCRIPTION
This PR: (WORK IN PROGRESS)By default, turn off variant unix_stdio_64 for gdal

- Update `.gitmodules` and submodule pointer for `spack` for CI testing
- fixes https://github.com/NOAA-EMC/spack-stack/issues/152 (to be confirmed)