### PR TITLE
Global workflow env

### DIFF
--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env]
+        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Can't build jedi-ewok on macOS (12) with gcc (11)
-        spec: [jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env]
+        spec: [jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env]
+        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env]
+        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # jedi-tools-env does not build with intel
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env]
+        spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
     runs-on: ubuntu-latest
     steps:
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/kgerheiser/spack.git
+  branch = feature/global-workflow-env
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/kgerheiser/spack.git
-  branch = feature/global-workflow-env
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -230,7 +230,7 @@
     mpich:
       variants: ~hwloc +two_level_namespace
     met:
-      version: [10.1.0]
+      version: [10.1.1]
       variants: +python +grib2
     metplus:
-      version: [4.1.0]
+      version: [4.1.1]


### PR DESCRIPTION
Add global-workflow-env to test specs.

This most specifically adds MET/METplus.

I have tested this pretty extensively on a fresh Ubuntu 20.04 VM with GCC/Intel, and my Mac 12.4 with GCC/Clang. The Ubuntu GCC runner finished, and the other ones are still going.

https://github.com/kgerheiser/spack-stack/actions