### PR TITLE
Update zlib

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -18,7 +18,7 @@
     flex:
       version: [2.6.3]
     zlib:
-      version: [1.2.11]
+      version: [1.2.12]
     hdf:
       version: [4.2.15]
       variants: ~fortran +netcdf


### PR DESCRIPTION
1.2.11 and earlier have been deprecated.

Fix #178 