### PR TITLE
Cleanup CI scripts and speed up CI tests

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -59,6 +59,14 @@ runs:
         # Install krb5 to avoid compilation errors of "hdf" on Ubuntu
         sudo apt-get install krb5-user libkrb5-dev
 
+        # DH*
+        # For now, install qt5 using apt on Linux. Later, should consider
+        # using https://github.com/jurplel/install-qt-action for all runners
+        # and also get rid of the macOS homebrew installation/package config
+        sudo apt-get install qt5-default qttools5-dev-tools
+        #sudo apt-get install qt5-default
+        # *DH
+
         if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
             cd /tmp
             wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
@@ -68,15 +76,6 @@ runs:
             sudo apt-get update
             sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
-            #
-            # DH*
-            # For now, install qt5 only for Intel to shorten the build time
-            # without having to rerun all other CI tests. Later, should consider
-            # using https://github.com/jurplel/install-qt-action for all runners
-            # and get rid of the macOS homebrew installation/package config
-            #sudo apt-get install qt5-default qttools5-dev-tools
-            sudo apt-get install qt5-default
-            # *DH
         fi
       elif [[ "$RUNNER_OS" == "macOS" ]]; then
         # These are already installed
@@ -233,9 +232,9 @@ runs:
       # Spack external find is by default only looking for build-tools. Either
       # search for additional packages explicitly, or fall back to the old
       # behavior to find all external packages.
-      #spack external find 
-      #spack external find git-lfs openmpi mpich
-      spack external find --all
+      spack external find 
+      spack external find git-lfs openmpi mpich qt5 wget
+      #spack external find --all
 
   - name: configure-options
     shell: bash
@@ -252,21 +251,21 @@ runs:
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
 
-      # Remove external OpenSSL entry
-      # Error when wget attempts to build using external on macOS
-      spack config rm "packages:openssl"
-
-      # Remove external SQLite entry
-      # Error when proj attempts to build using external on macOS
-      spack config rm "packages:sqlite"
-
-      # Remove external ncurses entry
-      # Error when proj attempts to build using external on macOS
-      spack config rm "packages:ncurses"
-
-      # Remove external m4 entry
-      # Error when cairo attempts to build using external on macOS
-      spack config rm "packages:m4"
+      ### # Remove external OpenSSL entry
+      ### # Error when wget attempts to build using external on macOS
+      ### spack config rm "packages:openssl"
+      ### 
+      ### # Remove external SQLite entry
+      ### # Error when proj attempts to build using external on macOS
+      ### spack config rm "packages:sqlite"
+      ### 
+      ### # Remove external ncurses entry
+      ### # Error when proj attempts to build using external on macOS
+      ### spack config rm "packages:ncurses"
+      ### 
+      ### # Remove external m4 entry
+      ### # Error when cairo attempts to build using external on macOS
+      ### spack config rm "packages:m4"
 
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
 
@@ -306,8 +305,8 @@ runs:
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-      # DH* For now only with Intel to avoid having to rerun all CI tests
-      if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+      # DH* Speed up installation by building in parallel
+      #if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
         for i in {1..8}; do
           nohup spack install --fail-fast >> spack_install.log 2>&1 &
         done
@@ -317,9 +316,9 @@ runs:
           tail -n 10 spack_install.log
           sleep 60
         done
-      else
-        spack install --fail-fast
-      fi
+      #else
+      #  spack install --fail-fast
+      #fi
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -63,7 +63,7 @@ runs:
         # For now, install qt5 using apt on Linux. Later, should consider
         # using https://github.com/jurplel/install-qt-action for all runners
         # and also get rid of the macOS homebrew installation/package config
-        sudo apt-get install qt5-default qttools5-dev-tools
+        sudo apt-get install qt5-default qttools5-dev-tools libqt5svg5-dev
         #sudo apt-get install qt5-default
         # *DH
 
@@ -330,7 +330,9 @@ runs:
       ###     sleep 60
       ###   done
       ### #else
-        spack install --fail-fast
+        #spack install --fail-fast
+        # DH*
+        spack install --fail-fast ecflow
       #fi
 
   - name: create-meta-modules

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -175,7 +175,7 @@ runs:
       fi
 
       source setup.sh
-      spack stack create env --template ${{ inputs.template }} --specs ${{ inputs.specs }} --name ${{ inputs.name }}
+      spack stack create env --template ${{ inputs.template }} --specs ${{ inputs.specs }} --name ${{ inputs.name }} --site ${{ inputs.site }}
       spack env activate envs/${{ inputs.name }}
 
       # LLVM Clang not in PATH, search for it specifically
@@ -233,7 +233,7 @@ runs:
       # search for additional packages explicitly, or fall back to the old
       # behavior to find all external packages.
       spack external find 
-      spack external find git-lfs openmpi mpich qt5 wget
+      spack external find git-lfs openmpi mpich wget qt@5
       #spack external find --all
 
   - name: configure-options
@@ -275,15 +275,15 @@ runs:
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
 
-      if [[ "$RUNNER_OS" == "Linux" ]]; then
-        echo ""
-      elif [[ "$RUNNER_OS" == "macOS" ]]; then
-        # Clang has trouble finding -lomp for OpenMP because of non-standard location
-        # Could be fixed by setting compiler environment LDFLAGS to -L$(brew --prefix llvm)/lib or wherever libomp is
-        spack config add "packages:wgrib2:variants: ~openmp"
-        spack config add "packages:fms:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"
-        spack config add "packages:fms-jcsda:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"
-      fi
+      ### if [[ "$RUNNER_OS" == "Linux" ]]; then
+      ###   echo ""
+      ### elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      ###   # Clang has trouble finding -lomp for OpenMP because of non-standard location
+      ###   # Could be fixed by setting compiler environment LDFLAGS to -L$(brew --prefix llvm)/lib or wherever libomp is
+      ###   spack config add "packages:wgrib2:variants: ~openmp"
+      ###   spack config add "packages:fms:variants: ~openmp"
+      ###   spack config add "packages:fms-jcsda:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"
+      ### fi
 
       mkdir ${GITHUB_WORKSPACE}/logs
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -214,7 +214,7 @@ runs:
 
       # Make homebrew qt@5 detectable on macOS
       if [[ "$RUNNER_OS" == "macOS" ]]; then
-        export "PATH"=/usr/local/opt/qt@5/bin:${PATH}"
+        export "PATH=/usr/local/opt/qt@5/bin:${PATH}"
       fi
 
       ## Same for qt@5 on macOS or on Linux w/ Intel
@@ -239,7 +239,12 @@ runs:
       # Spack external find is by default only looking for build-tools, Either
       # need to search for additional packages explicitly.
       spack external find
-      spack external find mpich openmpi perl qt@5 wget
+      spack external find mpich
+      spack external find openmpi
+      spack external find perl
+      spack external find python@3
+      spack external find qt@5
+      spack external find wget
 
   - name: configure-options
     shell: bash
@@ -255,6 +260,9 @@ runs:
       # Use external MPI to save compilation time
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
+
+      # Use external Python to save compilation time
+      spack config add "packages:python:buildable:False"
 
       ### # Remove external OpenSSL entry
       ### # Error when wget attempts to build using external on macOS
@@ -305,24 +313,24 @@ runs:
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     env:
-      OMP_NUM_THREADS: 16
+      OMP_NUM_THREADS: 4
     run: |
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-      # DH* Speed up installation by building in parallel
-      #if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
-        for i in {1..8}; do
-          nohup spack install --fail-fast >> spack_install.log 2>&1 &
-        done
-        #
-        while ps -ef | grep -ve 'grep' | grep 'spack install'; do
-          echo "Still running"
-          tail -n 10 spack_install.log
-          sleep 60
-        done
-      #else
-      #  spack install --fail-fast
+      ### # DH* Speed up installation by building in parallel
+      ### #if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+      ###   for i in {1..2}; do
+      ###     nohup spack install --fail-fast >> spack_install.log 2>&1 &
+      ###   done
+      ###   #
+      ###   while ps -ef | grep -ve 'grep' | grep 'spack install'; do
+      ###     echo "Still running"
+      ###     tail -n 10 spack_install.log
+      ###     sleep 60
+      ###   done
+      ### #else
+        spack install --fail-fast
       #fi
 
   - name: create-meta-modules

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: "Concretize environment without building."
     required: false
     default: 'false'
+  site:
+    description: "The suite for which to build."
+    required: false
+    default: 'linux.default'
 
 runs:
   using: "composite"
@@ -341,7 +345,7 @@ runs:
         cd ${{ inputs.path }}
         source setup.sh
         spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-        spack module lmod refresh
+        spack module lmod refresh --yes-to-all
         spack stack setup-meta-modules
       fi
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -320,20 +320,18 @@ runs:
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
       ### # DH* Speed up installation by building in parallel
       ### #if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
-      ###   for i in {1..2}; do
-      ###     nohup spack install --fail-fast >> spack_install.log 2>&1 &
-      ###   done
-      ###   #
-      ###   while ps -ef | grep -ve 'grep' | grep 'spack install'; do
-      ###     echo "Still running"
-      ###     tail -n 10 spack_install.log
-      ###     sleep 60
-      ###   done
+         for i in {1..2}; do
+           nohup spack install --fail-fast >> spack_install.log 2>&1 &
+         done
+         #
+         while ps -ef | grep -ve 'grep' | grep 'spack install'; do
+           echo "Still running"
+           tail -n 10 spack_install.log
+           sleep 60
+         done
       ### #else
-        #spack install --fail-fast
-        # DH*
-        spack install --fail-fast ecflow
-      #fi
+      ###  spack install --fail-fast
+      ### #fi
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}
@@ -343,6 +341,7 @@ runs:
         cd ${{ inputs.path }}
         source setup.sh
         spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
+        spack module lmod refresh
         spack stack setup-meta-modules
       fi
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -63,13 +63,10 @@ runs:
         # Install krb5 to avoid compilation errors of "hdf" on Ubuntu
         sudo apt-get install krb5-user libkrb5-dev
 
-        # DH*
         # For now, install qt5 using apt on Linux. Later, should consider
         # using https://github.com/jurplel/install-qt-action for all runners
         # and also get rid of the macOS homebrew installation/package config
         sudo apt-get install qt5-default qttools5-dev-tools libqt5svg5-dev
-        #sudo apt-get install qt5-default
-        # *DH
 
         if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
             cd /tmp
@@ -221,25 +218,6 @@ runs:
         export "PATH=/usr/local/opt/qt@5/bin:${PATH}"
       fi
 
-      ## Same for qt@5 on macOS or on Linux w/ Intel
-      #if [[ "$RUNNER_OS" == "macOS" ]]; then
-      #  echo "" >> ${SPACK_ENV}/spack.yaml
-      #  echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-      #  echo "    qt:" >> ${SPACK_ENV}/spack.yaml
-      #  echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-      #  echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-      #  echo "      - spec: qt@5" >> ${SPACK_ENV}/spack.yaml
-      #  echo "        prefix: /usr/local/opt/qt@5" >> ${SPACK_ENV}/spack.yaml
-      ##elif [[ "${{ inputs.compiler }}" == "intel"* ]]; then
-      ##  echo "" >> ${SPACK_ENV}/spack.yaml
-      ##  echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-      ##  echo "    qt:" >> ${SPACK_ENV}/spack.yaml
-      ##  echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-      ##  echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-      ##  echo "      - spec: qt@5" >> ${SPACK_ENV}/spack.yaml
-      ##  echo "        prefix: /usr" >> ${SPACK_ENV}/spack.yaml
-      #fi
-
       # Spack external find is by default only looking for build-tools, Either
       # need to search for additional packages explicitly.
       spack external find
@@ -268,22 +246,6 @@ runs:
       # Use external Python to save compilation time
       spack config add "packages:python:buildable:False"
 
-      ### # Remove external OpenSSL entry
-      ### # Error when wget attempts to build using external on macOS
-      ### spack config rm "packages:openssl"
-      ### 
-      ### # Remove external SQLite entry
-      ### # Error when proj attempts to build using external on macOS
-      ### spack config rm "packages:sqlite"
-      ### 
-      ### # Remove external ncurses entry
-      ### # Error when proj attempts to build using external on macOS
-      ### spack config rm "packages:ncurses"
-      ### 
-      ### # Remove external m4 entry
-      ### # Error when cairo attempts to build using external on macOS
-      ### spack config rm "packages:m4"
-
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
 
       # Currently, this is the case for all workflows - wrap in if statement
@@ -291,16 +253,6 @@ runs:
       # Whitelist the mpi providers so that spack creates the modules for them
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
-
-      ### if [[ "$RUNNER_OS" == "Linux" ]]; then
-      ###   echo ""
-      ### elif [[ "$RUNNER_OS" == "macOS" ]]; then
-      ###   # Clang has trouble finding -lomp for OpenMP because of non-standard location
-      ###   # Could be fixed by setting compiler environment LDFLAGS to -L$(brew --prefix llvm)/lib or wherever libomp is
-      ###   spack config add "packages:wgrib2:variants: ~openmp"
-      ###   spack config add "packages:fms:variants: ~openmp"
-      ###   spack config add "packages:fms-jcsda:variants: +64bit +enable_quad_precision +gfs_phys ~openmp +pic"
-      ### fi
 
       mkdir ${GITHUB_WORKSPACE}/logs
 
@@ -322,20 +274,16 @@ runs:
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-      ### # DH* Speed up installation by building in parallel
-      ### #if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
-         for i in {1..2}; do
-           nohup spack install --fail-fast >> spack_install.log 2>&1 &
-         done
-         #
-         while ps -ef | grep -ve 'grep' | grep 'spack install'; do
-           echo "Still running"
-           tail -n 10 spack_install.log
-           sleep 60
-         done
-      ### #else
-      ###  spack install --fail-fast
-      ### #fi
+      # Speed up installation by building in parallel
+      for i in {1..2}; do
+        nohup spack install --fail-fast >> spack_install.log 2>&1 &
+      done
+      #
+      while ps -ef | grep -ve 'grep' | grep 'spack install'; do
+        echo "Still running"
+        tail -n 10 spack_install.log
+        sleep 60
+      done
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -101,6 +101,8 @@ runs:
   # MPI takes a long time to build. Built it externally and cache it.
   - name: install-mpi
     shell: bash
+    env:
+      OMP_NUM_THREADS: 4
     if: steps.cache-mpi.outputs.cache-hit != 'true'
     run: |
         echo "" >> ~/.bash_profile
@@ -145,7 +147,7 @@ runs:
                 --enable-mpi-fortran --enable-mpi-cxx \
                 --with-hwloc=internal --with-libevent=internal
           fi
-          make -j2
+          make -j4
           make install
         elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
           wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
@@ -162,7 +164,7 @@ runs:
                 --enable-fortran --enable-cxx \
                 --with-device=ch4:ofi
           fi
-          make -j2
+          make -j4
           make install
         fi
 
@@ -193,9 +195,6 @@ runs:
         spack compiler find
       fi
 
-      # So Spack can find external MPI
-      export "PATH=$HOME/mpi/bin:${PATH}"
-
       # No external find for intel-oneapi-mpi, 
       # And no way to add object entry to list using "spack config add"
       # Add this first so "spack config add packages:" will append to this entry
@@ -208,33 +207,39 @@ runs:
         echo "      externals:" >> ${SPACK_ENV}/spack.yaml
         echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
         echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
+      else
+        # So Spack can find external MPI
+        export "PATH=$HOME/mpi/bin:${PATH}"
       fi
 
-      # Same for qt@5 on macOS or on Linux w/ Intel
+      # Make homebrew qt@5 detectable on macOS
       if [[ "$RUNNER_OS" == "macOS" ]]; then
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    qt:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: qt@5" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: /usr/local/opt/qt@5" >> ${SPACK_ENV}/spack.yaml
-      #elif [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+        export "PATH"=/usr/local/opt/qt@5/bin:${PATH}"
+      fi
+
+      ## Same for qt@5 on macOS or on Linux w/ Intel
+      #if [[ "$RUNNER_OS" == "macOS" ]]; then
       #  echo "" >> ${SPACK_ENV}/spack.yaml
       #  echo "  packages:" >> ${SPACK_ENV}/spack.yaml
       #  echo "    qt:" >> ${SPACK_ENV}/spack.yaml
       #  echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
       #  echo "      externals:" >> ${SPACK_ENV}/spack.yaml
       #  echo "      - spec: qt@5" >> ${SPACK_ENV}/spack.yaml
-      #  echo "        prefix: /usr" >> ${SPACK_ENV}/spack.yaml
-      fi
+      #  echo "        prefix: /usr/local/opt/qt@5" >> ${SPACK_ENV}/spack.yaml
+      ##elif [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+      ##  echo "" >> ${SPACK_ENV}/spack.yaml
+      ##  echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+      ##  echo "    qt:" >> ${SPACK_ENV}/spack.yaml
+      ##  echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+      ##  echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+      ##  echo "      - spec: qt@5" >> ${SPACK_ENV}/spack.yaml
+      ##  echo "        prefix: /usr" >> ${SPACK_ENV}/spack.yaml
+      #fi
 
-      # Spack external find is by default only looking for build-tools. Either
-      # search for additional packages explicitly, or fall back to the old
-      # behavior to find all external packages.
-      spack external find 
-      spack external find git-lfs openmpi mpich wget qt@5
-      #spack external find --all
+      # Spack external find is by default only looking for build-tools, Either
+      # need to search for additional packages explicitly.
+      spack external find
+      spack external find mpich openmpi perl qt@5 wget
 
   - name: configure-options
     shell: bash

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -40,6 +40,7 @@ jobs:
           mpi: openmpi
           path: ${{ github.workspace }}
           concretize_only: 'true'
+          site: macos.default
 
   linux_concretize:
     strategy:
@@ -60,6 +61,7 @@ jobs:
           mpi: openmpi
           path: ${{ github.workspace }}
           concretize_only: 'true'
+          site: linux.default
 
   intel_concretize:
     runs-on: ubuntu-latest
@@ -77,5 +79,4 @@ jobs:
           mpi: intel-oneapi-mpi
           path: ${{ github.workspace }}
           concretize_only: 'true'
-
-  
+          site: linux.default

--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -26,3 +26,4 @@ jobs:
           compiler: apple-clang
           mpi: openmpi
           path: ${{ github.workspace }}
+          site: macos.default

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -27,3 +27,4 @@ jobs:
           compiler: gcc@9
           mpi: mpich
           path: ${{ github.workspace }}
+          site: macos.default

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -26,3 +26,4 @@ jobs:
           compiler: clang
           mpi: openmpi
           path: ${{ github.workspace }}
+          site: macos.default

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -26,3 +26,4 @@ jobs:
           compiler: gcc@9
           mpi: mpich
           path: ${{ github.workspace }}
+          site: linux.default

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         # jedi-tools-env does not build with intel
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        #spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        spec: [jedi-ewok-env]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -11,8 +11,7 @@ jobs:
     strategy:
       matrix:
         # jedi-tools-env does not build with intel
-        #spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
-        spec: [jedi-ewok-env]
+        spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -27,3 +27,4 @@ jobs:
           compiler: intel
           mpi: intel-oneapi-mpi
           path: ${{ github.workspace }}
+          site: linux.default

--- a/configs/templates/ufs-weather-model/spack.yaml
+++ b/configs/templates/ufs-weather-model/spack.yaml
@@ -3,7 +3,6 @@ spack:
     unify: when_possible
 
   view: false
-
   include: []
 
   specs:

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -368,20 +368,26 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
    vi envs/jedi-ufs.mymacos/packages.yaml
    vi envs/jedi-ufs.mymacos/site/*.yaml
 
-8. Process the specs and install
+8. Activate the environment (optional: decorate bash prompt with environment name; warning: this can scramble the prompt for long lines)
+
+.. code-block:: console
+
+   spack env activate [-p] envs/jedi-ufs.mymacos
+
+9. Process the specs and install
 
 .. code-block:: console
 
    spack concretize
    spack install [--verbose] [--fail-fast]
 
-9. Create lua module files
+10. Create lua module files
 
 .. code-block:: console
 
    spack module lmod refresh
 
-10. Create meta-modules for compiler, mpi, python
+11. Create meta-modules for compiler, mpi, python
 
 .. code-block:: console
 
@@ -447,20 +453,26 @@ Creating a new environment
    vi envs/jedi-ufs.mylinux/packages.yaml
    vi envs/jedi-ufs.mylinux/site/*.yaml
 
-7. Process the specs and install
+7. Activate the environment (optional: decorate bash prompt with environment name; warning: this can scramble the prompt for long lines)
+
+.. code-block:: console
+
+   spack env activate [-p] envs/jedi-ufs.mymacos
+
+8. Process the specs and install
 
 .. code-block:: console
 
    spack concretize
    spack install [--verbose] [--fail-fast]
 
-8. Create lua module files
+9. Create lua module files
 
 .. code-block:: console
 
    spack module lmod refresh
 
-9. Create meta-modules for compiler, mpi, python
+10. Create meta-modules for compiler, mpi, python
 
 .. code-block:: console
 


### PR DESCRIPTION
Cleanup CI scripts and speed up CI builds by:
- building in parallel
- using external qt@5
- using the correct site config (`linux.default` or `macos.default`)

CI tests all pass, see https://github.com/climbfuji/spack-stack/actions entry `ubuntu-intel-build #46` and above.

Fixes https://github.com/NOAA-EMC/spack-stack/issues/137
Fixes https://github.com/NOAA-EMC/spack-stack/issues/134
Fixes https://github.com/NOAA-EMC/spack-stack/issues/100