### PR TITLE
Add template for skylab-1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch =   feature/solo_r2d2_ewok
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch =   feature/solo_r2d2_ewok
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -1,0 +1,13 @@
+spack:
+  concretizer:
+    unify: when_possible
+
+  view: false
+  include: []
+
+  specs:
+    - jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
+    - jedi-fv3-env@1.0.0
+    - jedi-mpas-env@1.0.0
+    - jedi-ufs-env@1.0.0
+    - jedi-um-env@1.0.0


### PR DESCRIPTION
## Description

Add new template `configs/templates/skylab-1.0.0/spack.yaml` which will be used for the internal JEDI release at the end of June 2022.

Note that building `skylab-1.0.0` requires access to JCSDA-internal for `solo`, `r2d2`, `ewok`, therefore cannot test in CI. This is temporary only, access to these repositories will be opened up in the next quarter (Q3 2022).

Apart from these three repos, `skylab-1.0.0` pulls together all jedi-MODEL-env dependencies. Everything builds out of the box on my macOS Monterey with `apple-clang-13.1.6` and `openmpi-4.1.3`.

## Issues

- fixes https://github.com/NOAA-EMC/spack-stack/issues/164

## Dependencies

- waiting on https://github.com/NOAA-EMC/spack/pull/92
