### PR TITLE
esmf-8.3.0, ecbuild-3.6.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_esmf_830
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_esmf_830
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -62,8 +62,9 @@
       version: [3.1.0]
     py-pygrib:
       version: [2.1.4]
+    # Attention - when updating the version also check the common modules.yaml config and update the projections for lmod/tcl
     esmf:
-      version: [8.2.0]
+      version: [8.3.0]
       variants: ~xerces ~pnetcdf
     # Attention - when updating also check macos.default and macos--monterey-llvm-clang-openmpi-reference site configs
     fms:
@@ -129,7 +130,7 @@
     eigen:
       version: [3.4.0]
     ecbuild:
-      version: [3.6.1]
+      version: [3.6.5]
     ecflow:
       version: [5.8.3]
       variants: +ui


### PR DESCRIPTION
Bump versions for `esmf` to 8.3.0 and `ecbuild` to 3.6.5. Note that we have been building `ecbuild@3.6.5` already, even though the common `packages.yaml` listed 3.6.1.

- waiting on https://github.com/NOAA-EMC/spack/pull/95
- waiting on https://github.com/NOAA-EMC/spack-stack/pull/193 for the correct module names for `mapl` with `esmf@8.3.0`

- fixes https://github.com/NOAA-EMC/spack-stack/issues/190
- fixes https://github.com/NOAA-EMC/spack-stack/issues/188