### PR TITLE
Fix .gitmodules for develop branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   #url = https://github.com/spack/spack
   #branch = develop
   url = https://github.com/NOAA-EMC/spack
-  branch = release/jcsda_emc_release_v1
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
When I merged #196 I changed the branch name to the release branch. This needs to be reverted for `.gitmodules`. Submodule pointer is the same for both develop and release/v1 right now (same hash).