### PR TITLE
release/v1 bug fixes: revert ESMF to 8.3.0b09, disable netCDF in HDF, TEST: run full CI tests for every PR

### DIFF
--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -1,5 +1,9 @@
 name: macos-apple-clang-build
-on: workflow_dispatch
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:

--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -2,7 +2,7 @@ name: macos-apple-clang-build
 
 on:
   pull_request:
-  push:
+  #push:
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -1,5 +1,9 @@
 name: macos-gcc-build
-on: workflow_dispatch
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -2,7 +2,7 @@ name: macos-gcc-build
 
 on:
   pull_request:
-  push:
+  #push:
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -1,5 +1,9 @@
 name: macos-llvm-clang-build
-on: workflow_dispatch
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -2,7 +2,7 @@ name: macos-llvm-clang-build
 
 on:
   pull_request:
-  push:
+  #push:
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -1,5 +1,9 @@
 name: ubuntu-gcc-build
-on: workflow_dispatch
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -2,7 +2,7 @@ name: ubuntu-gcc-build
 
 on:
   pull_request:
-  push:
+  #push:
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -1,5 +1,9 @@
 name: ubuntu-intel-build
-on: workflow_dispatch
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -2,7 +2,7 @@ name: ubuntu-intel-build
 
 on:
   pull_request:
-  push:
+  #push:
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,7 +2,7 @@ name: unit-tests
 
 on:
   pull_request:
-  push:
+  #push:
   workflow_dispatch:
 
 jobs:

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -115,6 +115,8 @@ modules:
         suffixes:
           ^esmf@8.2.0~debug: 'esmf-8.2.0'
           ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
+          ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
+          ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
           ^esmf@8.3.0~debug: 'esmf-8.3.0'
           ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
       openmpi:
@@ -334,6 +336,8 @@ modules:
         suffixes:
           ^esmf@8.2.0~debug: 'esmf-8.2.0'
           ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
+          ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
+          ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
           ^esmf@8.3.0~debug: 'esmf-8.3.0'
           ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
       openmpi:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -21,7 +21,7 @@
       version: [1.2.12]
     hdf:
       version: [4.2.15]
-      variants: ~fortran +netcdf
+      variants: ~fortran ~netcdf
     hdf5:
       version: [1.12.1]
       variants: +hl +fortran +mpi +threadsafe
@@ -64,7 +64,7 @@
       version: [2.1.4]
     # Attention - when updating the version also check the common modules.yaml config and update the projections for lmod/tcl
     esmf:
-      version: [8.3.0]
+      version: [8.3.0b09]
       variants: ~xerces ~pnetcdf
     # Attention - when updating also check macos.default and macos--monterey-llvm-clang-openmpi-reference site configs
     fms:

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -576,7 +576,8 @@ The following instructions were used to prepare a basic Ubuntu 20.04 system as i
    # Misc
    apt install -y build-essential
    apt install -y libcurl4-openssl-dev
-   ### TRY WITHOUT apt install krb5-user libkrb5-dev
+   ### TRY WITHOUT apt install krb5-user
+   apt install -y libkrb5-dev
    apt install -y m4
    # Skip cmake, default version 3.16 is too old
    apt install -y git


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack-stack/issues/205

Avoids issue https://github.com/NOAA-EMC/spack/issues/98 and https://github.com/NOAA-EMC/spack/issues/100 (to be confirmed) by reverting ESMF back to 8.3.0b09.

Note. The UFS is currently not moving to 8.3.0 due to a potential issue with the release, they are staying with 8.3.0b09 for now. See https://github.com/NOAA-EMC/fv3atm/issues/129

Also: This tests turns on the full CI build tests for the release/v1 branch. Currently a bit slow, but better to wait a little longer than to have to go back and fix broken builds.