### PR TITLE
Feature/updates for rc2

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -87,10 +87,7 @@ runs:
         brew install qt@5
         brew install readline
         brew install wget
-        brew list
       fi
-
-      exit 1
 
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
@@ -217,11 +214,6 @@ runs:
         export "PATH=$HOME/mpi/bin:${PATH}"
       fi
 
-      # Make homebrew qt@5 detectable on macOS
-      if [[ "$RUNNER_OS" == "macOS" ]]; then
-        export "PATH=/usr/local/opt/qt@5/bin:${PATH}"
-      fi
-
       # Spack external find is by default only looking for build-tools, Either
       # need to search for additional packages explicitly.
       spack external find
@@ -229,8 +221,19 @@ runs:
       spack external find openmpi
       spack external find perl
       spack external find python@3
-      spack external find qt@5
       spack external find wget
+
+      # Find qt@5 on macOS
+      if [[ "$RUNNER_OS" == "macOS" ]]; then
+        PATH="/usr/local/opt/qt5/bin:$PATH" \
+             spack external find qt@5
+      fi
+
+      # Find curl on macOS
+      if [[ "$RUNNER_OS" == "macOS" ]]; then
+        PATH="/usr/local/opt/curl/bin:$PATH" \
+             spack external find curl
+      fi
 
   - name: configure-options
     shell: bash

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -303,7 +303,7 @@ runs:
       #  tail -n 10 spack_install.log
       #  sleep 60
       #done
-      spack install --fail-fast
+      spack install --verbose --fail-fast
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -257,6 +257,8 @@ runs:
         spack config add "packages:ecflow:variants:~ssl"
       fi
 
+      cat ${SPACK_ENV}/spack.yaml
+
       # Remove specs that don't build under certain configurations.
       # Only need that for the concretize_only steps, because the full
       # builds only build one spec at a time (and the cases that are

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -79,10 +79,10 @@ runs:
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [[ "$RUNNER_OS" == "macOS" ]]; then
-        brew install curl
-        brew install git
-        brew install git-lfs
-        brew install openssl
+        # These are already installed
+        #brew install curl
+        #brew install git
+        #brew install git-lfs
         brew install lmod
         brew install qt@5
         brew install readline
@@ -214,6 +214,11 @@ runs:
         export "PATH=$HOME/mpi/bin:${PATH}"
       fi
 
+      # Make homebrew qt@5 detectable on macOS
+      if [[ "$RUNNER_OS" == "macOS" ]]; then
+        export "PATH=/usr/local/opt/qt@5/bin:${PATH}"
+      fi
+
       # Spack external find is by default only looking for build-tools, Either
       # need to search for additional packages explicitly.
       spack external find
@@ -221,19 +226,8 @@ runs:
       spack external find openmpi
       spack external find perl
       spack external find python@3
+      spack external find qt@5
       spack external find wget
-
-      # Find qt@5 on macOS
-      if [[ "$RUNNER_OS" == "macOS" ]]; then
-        PATH="/usr/local/opt/qt5/bin:$PATH" \
-             spack external find qt@5
-      fi
-
-      # Find curl on macOS
-      if [[ "$RUNNER_OS" == "macOS" ]]; then
-        PATH="/usr/local/opt/curl/bin:$PATH" \
-             spack external find curl
-      fi
 
   - name: configure-options
     shell: bash
@@ -263,9 +257,6 @@ runs:
         spack config add "packages:ecflow:variants:~ssl"
       fi
 
-      echo "Contents of ${SPACK_ENV}/spack.yaml:"
-      cat ${SPACK_ENV}/spack.yaml
-
       # Remove specs that don't build under certain configurations.
       # Only need that for the concretize_only steps, because the full
       # builds only build one spec at a time (and the cases that are
@@ -292,22 +283,21 @@ runs:
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     env:
-      OMP_NUM_THREADS: 2
+      OMP_NUM_THREADS: 4
     run: |
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-      ## Speed up installation by building in parallel
-      #for i in {1..2}; do
-      #  nohup spack install --fail-fast >> spack_install.log 2>&1 &
-      #done
-      ##
-      #while ps -ef | grep -ve 'grep' | grep 'spack install'; do
-      #  echo "Still running"
-      #  tail -n 10 spack_install.log
-      #  sleep 60
-      #done
-      spack install --verbose --fail-fast
+      # Speed up installation by building in parallel
+      for i in {1..2}; do
+        nohup spack install --fail-fast >> spack_install.log 2>&1 &
+      done
+      #
+      while ps -ef | grep -ve 'grep' | grep 'spack install'; do
+        echo "Still running"
+        tail -n 10 spack_install.log
+        sleep 60
+      done
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -252,6 +252,10 @@ runs:
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
 
+
+      echo "Contents of ${SPACK_ENV}/spack.yaml:"
+      cat ${SPACK_ENV}/spack.yaml
+
       # Remove specs that don't build under certain configurations.
       # Only need that for the concretize_only steps, because the full
       # builds only build one spec at a time (and the cases that are

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -79,16 +79,18 @@ runs:
             echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         fi
       elif [[ "$RUNNER_OS" == "macOS" ]]; then
-        # These are already installed
-        #brew install curl
-        #brew install git
-        #brew install git-lfs
+        brew install curl
+        brew install git
+        brew install git-lfs
         brew install openssl
         brew install lmod
         brew install qt@5
         brew install readline
         brew install wget
+        brew list
       fi
+
+      exit 1
 
       # Install Python poetry to avoid install errors in spack
       python3 -m pip install poetry
@@ -261,14 +263,12 @@ runs:
       # Only need that for the concretize_only steps, because the full
       # builds only build one spec at a time (and the cases that are
       # removed below don't exist).
-      ### if [[ "${{ inputs.concretize_only }}" == "true" ]]; then
-        if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
-          spack rm jedi-tools-env || true
-        fi
-        if [[ "$RUNNER_OS" == "macOS" && "${{ inputs.compiler }}" == "gcc"* ]]; then
-          spack rm jedi-ewok-env || true
-        fi
-      ### fi
+      if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
+        spack rm jedi-tools-env || true
+      fi
+      if [[ "$RUNNER_OS" == "macOS" && "${{ inputs.compiler }}" == "gcc"* ]]; then
+        spack rm jedi-ewok-env || true
+      fi
 
       mkdir ${GITHUB_WORKSPACE}/logs
 
@@ -306,19 +306,19 @@ runs:
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     run: |
-      ### if [[ ! "${{ inputs.specs }}" == "" || ! "${{ inputs.templates }}" == "empty" ]]; then
+      if [[ ! "${{ inputs.specs }}" == "" || ! "${{ inputs.templates }}" == "empty" ]]; then
         cd ${{ inputs.path }}
         source setup.sh
         spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
         spack module lmod refresh --yes-to-all
         spack stack setup-meta-modules
-      ### fi
+      fi
 
   - name: test-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     run: |
-      ### if [[ ! "${{ inputs.specs }}" == "empty" ]]; then
+      if [[ ! "${{ inputs.specs }}" == "" || ! "${{ inputs.templates }}" == "empty" ]]; then
         cd ${{ inputs.path }}
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           # Not yet: need lmod installed, loaded and module use command
@@ -335,7 +335,7 @@ runs:
           #   module load stack-${{ inputs.mpi }}
           # fi
         fi
-      ### fi
+      fi
 
   - name: Upload logs
     if: ${{ always() }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -256,14 +256,14 @@ runs:
       # Only need that for the concretize_only steps, because the full
       # builds only build one spec at a time (and the cases that are
       # removed below don't exist).
-      if [[ "${{ inputs.concretize_only }}" == "true" ]]; then
+      #if [[ "${{ inputs.concretize_only }}" == "true" ]]; then
         if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
           spack rm jedi-tools-env || true
         fi
         if [[ "$RUNNER_OS" == "macOS" && "${{ inputs.compiler }}" == "gcc"* ]]; then
           spack rm jedi-ewok-env || true
         fi
-      fi
+      #fi
 
       mkdir ${GITHUB_WORKSPACE}/logs
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -5,8 +5,8 @@ inputs:
     description: 'Give the environment a name'
     required: false
     default: 'default'
-  template:
-    description: 'Base spack.yaml template. Default is an empty environment.'
+  templates:
+    description: 'Base spack.yaml templates. Default is an empty environment.'
     required: false
     default: 'empty'
   specs:
@@ -178,7 +178,7 @@ runs:
       fi
 
       source setup.sh
-      spack stack create env --template ${{ inputs.template }} --name ${{ inputs.name }} --site ${{ inputs.site }}
+      spack stack create env --template ${{ inputs.templates }} --name ${{ inputs.name }} --site ${{ inputs.site }}
       spack env activate envs/${{ inputs.name }}
       spack add ${{ inputs.specs }}
 
@@ -256,14 +256,14 @@ runs:
       # Only need that for the concretize_only steps, because the full
       # builds only build one spec at a time (and the cases that are
       # removed below don't exist).
-      #if [[ "${{ inputs.concretize_only }}" == "true" ]]; then
+      ### if [[ "${{ inputs.concretize_only }}" == "true" ]]; then
         if [[ "${{ inputs.compiler }}" == "intel"* ]]; then
           spack rm jedi-tools-env || true
         fi
         if [[ "$RUNNER_OS" == "macOS" && "${{ inputs.compiler }}" == "gcc"* ]]; then
           spack rm jedi-ewok-env || true
         fi
-      #fi
+      ### fi
 
       mkdir ${GITHUB_WORKSPACE}/logs
 
@@ -300,19 +300,19 @@ runs:
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     run: |
-      if [[ ! "${{ inputs.specs }}" == "empty" ]]; then
+      ### if [[ ! "${{ inputs.specs }}" == "" || ! "${{ inputs.templates }}" == "empty" ]]; then
         cd ${{ inputs.path }}
         source setup.sh
         spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
         spack module lmod refresh --yes-to-all
         spack stack setup-meta-modules
-      fi
+      ### fi
 
   - name: test-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     run: |
-      if [[ ! "${{ inputs.specs }}" == "empty" ]]; then
+      ### if [[ ! "${{ inputs.specs }}" == "empty" ]]; then
         cd ${{ inputs.path }}
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           # Not yet: need lmod installed, loaded and module use command
@@ -329,7 +329,7 @@ runs:
           #   module load stack-${{ inputs.mpi }}
           # fi
         fi
-      fi
+      ### fi
 
   - name: Upload logs
     if: ${{ always() }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -284,21 +284,22 @@ runs:
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     env:
-      OMP_NUM_THREADS: 4
+      OMP_NUM_THREADS: 2
     run: |
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-      # Speed up installation by building in parallel
-      for i in {1..2}; do
-        nohup spack install --fail-fast >> spack_install.log 2>&1 &
-      done
-      #
-      while ps -ef | grep -ve 'grep' | grep 'spack install'; do
-        echo "Still running"
-        tail -n 10 spack_install.log
-        sleep 60
-      done
+      ## Speed up installation by building in parallel
+      #for i in {1..2}; do
+      #  nohup spack install --fail-fast >> spack_install.log 2>&1 &
+      #done
+      ##
+      #while ps -ef | grep -ve 'grep' | grep 'spack install'; do
+      #  echo "Still running"
+      #  tail -n 10 spack_install.log
+      #  sleep 60
+      #done
+      spack install --fail-fast
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -83,6 +83,7 @@ runs:
         #brew install curl
         #brew install git
         #brew install git-lfs
+        brew install openssl
         brew install lmod
         brew install qt@5
         brew install readline

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -258,6 +258,10 @@ runs:
       spack config add "modules:default:tcl:whitelist:[${{ inputs.mpi }}]"
       spack config add "modules:default:lmod:whitelist:[${{ inputs.mpi }}]"
 
+      # Turn of SSL for ecflow CI builds for now
+      if [[ "$RUNNER_OS" == "macOS" && "${{ inputs.compiler }}" == *"clang"* ]]; then
+        spack config add "packages:ecflow:variants:~ssl"
+      fi
 
       echo "Contents of ${SPACK_ENV}/spack.yaml:"
       cat ${SPACK_ENV}/spack.yaml

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -285,21 +285,23 @@ runs:
     if: ${{ inputs.concretize_only == 'false' }}
     shell: bash
     env:
-      OMP_NUM_THREADS: 4
+      OMP_NUM_THREADS: 2
     run: |
       cd ${{ inputs.path }}
       source setup.sh
       spack env activate ${{ inputs.path }}/envs/${{ inputs.name }}
-      # Speed up installation by building in parallel
-      for i in {1..2}; do
-        nohup spack install --fail-fast >> spack_install.log 2>&1 &
-      done
-      #
-      while ps -ef | grep -ve 'grep' | grep 'spack install'; do
-        echo "Still running"
-        tail -n 10 spack_install.log
-        sleep 60
-      done
+      ## Note: This is unreliable ...
+      ## Speed up installation by building in parallel
+      #for i in {1..2}; do
+      #  nohup spack install --fail-fast >> spack_install.log 2>&1 &
+      #done
+      ##
+      #while ps -ef | grep -ve 'grep' | grep 'spack install'; do
+      #  echo "Still running"
+      #  tail -n 10 spack_install.log
+      #  sleep 60
+      #done
+      spack install --fail-fast
 
   - name: create-meta-modules
     if: ${{ inputs.concretize_only == 'false' }}

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         compiler: [clang, apple-clang]
+        template: [jedi-ufs-all]
+
     runs-on: macos-latest
     steps:
       - name: checkout
@@ -26,7 +28,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
-          template: jedi-ufs-all
+          templates: ${{ matrix.template }}
           compiler: ${{ matrix.compiler }}
           mpi: openmpi
           path: ${{ github.workspace }}
@@ -37,6 +39,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc@9.4.0, gcc@10.3.0]
+        template: [jedi-ufs-all]
     runs-on: macos-latest
     steps:
       - name: checkout
@@ -47,7 +50,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
-          template: jedi-ufs-all
+          templates: ${{ matrix.template }}
           compiler: ${{ matrix.compiler }}
           mpi: openmpi
           path: ${{ github.workspace }}
@@ -57,6 +60,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc@9.4.0, gcc@10.3.0]
+        template: [jedi-ufs-all]
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -67,7 +71,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
-          template: jedi-ufs-all
+          templates: ${{ matrix.template }}
           compiler: ${{ matrix.compiler }}
           mpi: openmpi
           path: ${{ github.workspace }}
@@ -75,6 +79,9 @@ jobs:
           site: linux.default
 
   linux_intel_concretize:
+    strategy:
+      matrix:
+        template: [jedi-ufs-all]
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -85,7 +92,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
-          template: jedi-ufs-all
+          templates: ${{ matrix.template }}
           compiler: intel
           mpi: intel-oneapi-mpi
           path: ${{ github.workspace }}

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         compiler: [clang, apple-clang]
         template: [jedi-ufs-all]
-
     runs-on: macos-latest
     steps:
       - name: checkout

--- a/.github/workflows/create-spack-mirror.yaml
+++ b/.github/workflows/create-spack-mirror.yaml
@@ -6,11 +6,11 @@ on:
       template:
         description: 'Base spack.yaml template. Default is an empty environment.'
         required: false
-        default: 'empty'
-      specs:
-        description: 'Which specs to add to the template'
-        required: false
-        default: 'jedi-ufs-env'
+        default: 'jedi-ufs-all'
+      #specs:
+      #  description: 'Which specs to add to the template'
+      #  required: false
+      #  default: 'jedi-ufs-env'
 
 jobs:
   create-spack-mirror:
@@ -27,11 +27,14 @@ jobs:
           source ./setup.sh
           spack stack create env --template ${{ github.event.inputs.template }} --name mirror
           spack env activate -d envs/mirror
-          spack add ${{ github.event.inputs.specs }}
+          #spack add ${{ github.event.inputs.specs }}
           spack compiler find
           spack add re2c
           spack add clingo
           spack concretize
+          # spack mirror doesn't like environment variables:
+          # ==> Error: Invalid url format from url: ${SPACK_STACK_DIR}/cache/source_cache
+          sed -i "s#\${SPACK_STACK_DIR}#$SPACK_STACK_DIR#g" envs/mirror/common/config.yaml
           spack mirror create -a
           # upload-artifact does not allow filenames that contain '?'
           rm -vf `find cache/source_cache -name '*\?*'`

--- a/.github/workflows/create-spack-mirror.yaml
+++ b/.github/workflows/create-spack-mirror.yaml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       template:
-        description: 'Base spack.yaml template. Default is an empty environment.'
-        required: false
+        description: 'Base spack.yaml template. Default is a complete environment (jedi-ufs-all)'
+        required: true
         default: 'jedi-ufs-all'
-      #specs:
-      #  description: 'Which specs to add to the template'
-      #  required: false
-      #  default: 'jedi-ufs-env'
+      specs:
+        description: 'Which specs to add to the template'
+        required: false
+        default: ''
 
 jobs:
   create-spack-mirror:
@@ -27,12 +27,13 @@ jobs:
           source ./setup.sh
           spack stack create env --template ${{ github.event.inputs.template }} --name mirror
           spack env activate -d envs/mirror
-          #spack add ${{ github.event.inputs.specs }}
+          # This doesn't throw and error when specs are an empty string ('')
+          spack add ${{ github.event.inputs.specs }}
           spack compiler find
           spack add re2c
           spack add clingo
           spack concretize
-          # spack mirror doesn't like environment variables:
+          # But "spack mirror" doesn't like environment variables:
           # ==> Error: Invalid url format from url: ${SPACK_STACK_DIR}/cache/source_cache
           sed -i "s#\${SPACK_STACK_DIR}#$SPACK_STACK_DIR#g" envs/mirror/common/config.yaml
           spack mirror create -a

--- a/.github/workflows/create-spack-mirror.yaml
+++ b/.github/workflows/create-spack-mirror.yaml
@@ -1,6 +1,17 @@
 name: create-spack-mirror
 
 on:
+  pull_request:
+    inputs:
+      template:
+        description: 'Base spack.yaml template. Default is a complete environment (jedi-ufs-all)'
+        required: true
+        default: 'jedi-ufs-all'
+      specs:
+        description: 'Which specs to add to the template'
+        required: false
+        default: ''
+  #push:
   workflow_dispatch:
     inputs:
       template:

--- a/.github/workflows/create-spack-mirror.yaml
+++ b/.github/workflows/create-spack-mirror.yaml
@@ -1,22 +1,11 @@
 name: create-spack-mirror
 
 on:
-  pull_request:
-    inputs:
-      template:
-        description: 'Base spack.yaml template. Default is a complete environment (jedi-ufs-all)'
-        required: true
-        default: 'jedi-ufs-all'
-      specs:
-        description: 'Which specs to add to the template'
-        required: false
-        default: ''
-  #push:
   workflow_dispatch:
     inputs:
       template:
         description: 'Base spack.yaml template. Default is a complete environment (jedi-ufs-all)'
-        required: true
+        required: false
         default: 'jedi-ufs-all'
       specs:
         description: 'Which specs to add to the template'

--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -14,7 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ufs-all]
+        template: [jedi-ufs-all]
+        spec: []
     runs-on: macos-latest
     steps:
 
@@ -26,6 +27,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
+          templates: ${{ matrix.template }}
           specs: ${{ matrix.spec }}
           compiler: apple-clang
           mpi: openmpi

--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        spec: [jedi-ufs-all]
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         template: [jedi-ufs-all]
-        spec: []
+        spec: ['']
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -1,7 +1,7 @@
 name: macos-gcc-build
 
 on:
-  pull_request:
+  #pull_request:
   #push:
   workflow_dispatch:
 

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
+          templates: ${{ matrix.template }}
           specs: ${{ matrix.spec }}
           compiler: gcc@9
           mpi: mpich

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -14,8 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # Can't build jedi-ewok on macOS (12) with gcc (11)
-        spec: [jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        spec: [jedi-ufs-all]
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -1,7 +1,7 @@
 name: macos-gcc-build
 
 on:
-  #pull_request:
+  pull_request:
   #push:
   workflow_dispatch:
 
@@ -14,7 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ufs-all]
+        template: [jedi-ufs-all]
+        spec: ['']
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        spec: [jedi-ufs-all]
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -1,7 +1,7 @@
 name: macos-llvm-clang-build
 
 on:
-  #pull_request:
+  pull_request:
   #push:
   workflow_dispatch:
 
@@ -14,7 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ufs-all]
+        template: [jedi-ufs-all]
+        spec: ['']
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
+          templates: ${{ matrix.template }}
           specs: ${{ matrix.spec }}
           compiler: clang
           mpi: openmpi

--- a/.github/workflows/macos-llvm-clang.yaml
+++ b/.github/workflows/macos-llvm-clang.yaml
@@ -1,7 +1,7 @@
 name: macos-llvm-clang-build
 
 on:
-  pull_request:
+  #pull_request:
   #push:
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
+          templates: ${{ matrix.template }}
           specs: ${{ matrix.spec }}
           compiler: gcc@9
           mpi: mpich

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-tools-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        spec: [jedi-ufs-all]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -1,7 +1,7 @@
 name: ubuntu-gcc-build
 
 on:
-  pull_request:
+  #pull_request:
   #push:
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -1,7 +1,7 @@
 name: ubuntu-gcc-build
 
 on:
-  #pull_request:
+  pull_request:
   #push:
   workflow_dispatch:
 
@@ -14,7 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ufs-all]
+        template: [jedi-ufs-all]
+        spec: ['']
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -1,7 +1,7 @@
 name: ubuntu-intel-build
 
 on:
-  #pull_request:
+  pull_request:
   #push:
   workflow_dispatch:
 
@@ -14,7 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        spec: [jedi-ufs-all]
+        template: [jedi-ufs-all]
+        spec: ['']
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -14,8 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # jedi-tools-env does not build with intel
-        spec: [jedi-ewok-env, jedi-fv3-env, jedi-ufs-env, jedi-um-env, nceplibs-env, soca-env, global-workflow-env]
+        spec: [jedi-ufs-all]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -1,7 +1,7 @@
 name: ubuntu-intel-build
 
 on:
-  pull_request:
+  #pull_request:
   #push:
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: install-env
         uses: ./.github/actions/setup-spack-stack
         with:
+          templates: ${{ matrix.template }}
           specs: ${{ matrix.spec }}
           compiler: intel
           mpi: intel-oneapi-mpi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = release/jcsda_emc_release_v1
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = release/jcsda_emc_release_v1
+  url = https://github.com/climbfuji/spack
+  branch = feature/updates_for_rc2
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = release/jcsda_emc_release_v1
-  url = https://github.com/climbfuji/spack
-  branch = feature/updates_for_rc2
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = release/jcsda_emc_release_v1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -83,6 +83,7 @@ modules:
       - xrandr
       - xtrans
       - xz
+      - yaksa
       # Do not create MPI modules - we create our own meta modules
       - cray-mpich
       - mpich
@@ -304,6 +305,7 @@ modules:
       - xrandr
       - xtrans
       - xz
+      - yaksa
       # Do not create MPI modules - we create our own meta modules
       - cray-mpich
       - mpich

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -168,10 +168,8 @@
       version: [3.10.5]
     nlohmann-json-schema-validator:
       version: [2.1.0]
-    # Do not build pkgconf/pkg-config - https://github.com/NOAA-EMC/spack-stack/issues/123
+    # Do not build pkgconf - https://github.com/NOAA-EMC/spack-stack/issues/123
     pkgconf:
-      buildable: False
-    pkg-config:
       buildable: False
     python:
       version: [3.9.12]

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -133,7 +133,7 @@
       version: [3.6.5]
     ecflow:
       version: [5.8.3]
-      variants: +ui +static_boost
+      variants: +ui
     eckit:
       version: [1.19.0]
       variants: linalg=eigen,lapack compression=lz4,bzip2

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -146,7 +146,7 @@
     shumlib:
       version: [macos_clang_linux_intel_port]
     fiat:
-      version: [develop]
+      version: [main]
     ectrans:
       version: [develop]
       variants: ~enable_mkl

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -133,7 +133,7 @@
       version: [3.6.5]
     ecflow:
       version: [5.8.3]
-      variants: +ui
+      variants: +ui +static_boost
     eckit:
       version: [1.19.0]
       variants: linalg=eigen,lapack compression=lz4,bzip2
@@ -168,6 +168,9 @@
       version: [3.10.5]
     nlohmann-json-schema-validator:
       version: [2.1.0]
+    # Do not build pkg-config - https://github.com/NOAA-EMC/spack-stack/issues/123
+    pkg-config:
+      buildable: False
     python:
       version: [3.9.12]
     py-cartopy:
@@ -208,8 +211,9 @@
       version: [1.55]
     py-openpyxl:
       version: [3.0.3]
-    py-setuptools:
-      version: [57.4.0]
+    # Try without
+    #py-setuptools:
+    #  version: [59.4.0]
     qt:
       version: [5.15.3]
     #texlive:
@@ -235,6 +239,7 @@
       variants: +python +grib2
     metplus:
       version: [4.1.1]
+    # Attention - when updating also check discover site config
     mapl:
       version: [2.12.3]
     yafyaml:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -168,7 +168,9 @@
       version: [3.10.5]
     nlohmann-json-schema-validator:
       version: [2.1.0]
-    # Do not build pkg-config - https://github.com/NOAA-EMC/spack-stack/issues/123
+    # Do not build pkgconf/pkg-config - https://github.com/NOAA-EMC/spack-stack/issues/123
+    pkgconf:
+      buildable: False
     pkg-config:
       buildable: False
     python:

--- a/configs/sites/discover/compilers.yaml
+++ b/configs/sites/discover/compilers.yaml
@@ -19,27 +19,20 @@ compilers:
       set:
         I_MPI_ROOT: '/usr/local/intel/oneapi/2021/mpi/2021.5.0'
     extra_rpaths: []
-# Used for testing only
-#- compiler:
-#    spec: intel@2022.0.2
-#    paths:
-#      cc: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1/compiler/2022.0.2/linux/bin/intel64/icc
-#      cxx: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1/compiler/2022.0.2/linux/bin/intel64/icpc
-#      f77: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1/compiler/2022.0.2/linux/bin/intel64/ifort
-#      fc: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1/compiler/2022.0.2/linux/bin/intel64/ifort
-#    flags: {}
-#    operating_system: sles12
-#    target: x86_64
-#    modules: []
-#    environment:
-#      prepend_path:
-#        PATH: '/usr/local/other/gcc/10.1.0/bin'
-#        CPATH: '/usr/local/other/gcc/10.1.0/include'
-#        LD_LIBRARY_PATH: '/discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/usr/local/other/gcc/10.1.0/lib64'
-#      set:
-#        I_MPI_ROOT: '/discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1/mpi/2021.5.1'
-#    extra_rpaths: []
-# Not yet tested:
+- compiler:
+    spec: gcc@10.1.0
+    paths:
+      cc: /usr/local/other/gcc/10.1.0/bin/gcc
+      cxx: /usr/local/other/gcc/10.1.0/bin/g++
+      f77: /usr/local/other/gcc/10.1.0/bin/gfortran
+      fc: /usr/local/other/gcc/10.1.0/bin/gfortran
+    flags: {}
+    operating_system: sles12
+    target: x86_64
+    modules:
+    - comp/gcc/10.1.0
+    environment: {}
+    extra_rpaths: []
 - compiler:
     spec: gcc@11.2.0
     paths:

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -90,7 +90,7 @@ packages:
   ecflow:
     buildable: False
     externals:
-    - spec: ecflow@5.8.4+ui+static_boost+python
+    - spec: ecflow@5.8.4+ui+static_boost
       prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
       modules:
       - ecflow/5.8.4

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -4,7 +4,7 @@ packages:
     #compiler:: [gcc@10.1.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.0]
-      #mpi:: [intel-mpi@2019.10.24]
+      #mpi:: [intel-oneapi-mpi@2021.4.0]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,6 +15,11 @@ packages:
       prefix: /usr/local/intel/oneapi/2021/
       modules:
       - mpi/impi/2021.5.0
+    externals:
+    - spec: intel-oneapi-mpi@2021.4.0%gcc@10.1.0
+      prefix: /usr/local/intel/oneapi/2021/
+      modules:
+      - mpi/impi/2021.4.0
   #intel-oneapi-tbb:
   #  externals:
   #  - spec: intel-oneapi-tbb@2022.0.1%intel@2021.5.0
@@ -23,12 +28,6 @@ packages:
   #  externals:
   #  - spec: intel-oneapi-mkl@2022.0.1%intel@2021.5.0
   #    prefix: /usr/local/intel/oneapi/2021
-  intel-mpi:
-    externals:
-    - spec: intel-mpi@2019.10.24%gcc@10.1.0
-      prefix: /usr/local/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64
-      modules:
-      - mpi/impi/20.0.0.166
 
   python:
     buildable: False
@@ -37,39 +36,6 @@ packages:
       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7/
       modules:
       - miniconda/3.9.7
-###   glib:
-###     buildable: False
-###     externals:
-###     - spec: glib@2.69.1
-###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7/
-###       modules:
-###       - miniconda/3.9.7
-###   openssl:
-###     externals:
-###     - spec: openssl@1.1.1o
-###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
-###       modules:
-###       - miniconda/3.9.7
-###   harfbuzz:
-###     externals:
-###     - spec: harfbuzz@3.1.2
-###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
-###       modules:
-###       - miniconda/3.9.7
-###   fontconfig:
-###     externals:
-###     - spec: fontconfig@2.13.1
-###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
-###       modules:
-###       - miniconda/3.9.7
-###   #font-util:
-###   #  externals:
-###   #  - spec: font-util@1.3.2
-###   #    prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
-###   #    modules:
-###   #    - miniconda/3.9.7
-
-
 
 ### Modifications of common packages
   # Version 2.12.3 doesn't compile on discover
@@ -121,14 +87,13 @@ packages:
     externals:
     - spec: diffutils@3.3
       prefix: /usr
-  # NEEDS UPDATE!!!
-  #ecflow:
-  #  buildable: False
-  #  externals:
-  #  - spec: ecflow@5.8.4+ui+static_boost+python
-  #    prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
-  #    modules:
-  #    - ecflow/5.8.4
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost+python
+      prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.22
@@ -215,12 +180,6 @@ packages:
     externals:
     - spec: pkg-config@0.28
       prefix: /usr
-  #qt:
-  #  externals:
-  #  - spec: qt@5.15.3
-  #    prefix: /discover/swdev/jcsda/spack-stack/qt-5.15.3
-  #    modules:
-  #    - qt/5.15.3
   qt:
     externals:
     - spec: qt@5.15.2

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -1,10 +1,10 @@
 packages:
   all:
     compiler:: [intel@2022.0.1]
-    #compiler:: [intel@2022.0.2]
+    #compiler:: [gcc@11.2.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.0]
-      #mpi:: [intel-oneapi-mpi@2021.5.1]
+      #mpi:: [intel-mpi@2019.10.24]
 
 ### MPI, Python, MKL
   mpi:
@@ -23,18 +23,12 @@ packages:
   #  externals:
   #  - spec: intel-oneapi-mkl@2022.0.1%intel@2021.5.0
   #    prefix: /usr/local/intel/oneapi/2021
-  # intel-oneapi-mpi:
-  #   externals:
-  #   - spec: intel-oneapi-mpi@2021.5.1%intel@2022.0.2
-  #     prefix: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1
-  #intel-oneapi-tbb:
-  #  externals:
-  #  - spec: intel-oneapi-tbb@2021.5.1%intel@2022.0.2
-  #    prefix: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1
-  #intel-oneapi-mkl:
-  #  externals:
-  #  - spec: intel-oneapi-mkl@2022.0.2%intel@2022.0.2
-  #    prefix: /discover/swdev/jcsda/spack-stack/intel-oneapi-2022.1.1
+  intel-mpi:
+    externals:
+    - spec: intel-mpi@2019.10.24%gcc@11.2.0
+      prefix: /usr/local/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64
+      modules:
+      - mpi/impi/20.0.0.166
 
   python:
     buildable: False
@@ -43,6 +37,44 @@ packages:
       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7/
       modules:
       - miniconda/3.9.7
+###   glib:
+###     buildable: False
+###     externals:
+###     - spec: glib@2.69.1
+###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7/
+###       modules:
+###       - miniconda/3.9.7
+###   openssl:
+###     externals:
+###     - spec: openssl@1.1.1o
+###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
+###       modules:
+###       - miniconda/3.9.7
+###   harfbuzz:
+###     externals:
+###     - spec: harfbuzz@3.1.2
+###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
+###       modules:
+###       - miniconda/3.9.7
+###   fontconfig:
+###     externals:
+###     - spec: fontconfig@2.13.1
+###       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
+###       modules:
+###       - miniconda/3.9.7
+###   #font-util:
+###   #  externals:
+###   #  - spec: font-util@1.3.2
+###   #    prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7
+###   #    modules:
+###   #    - miniconda/3.9.7
+
+
+
+### Modifications of common packages
+  # Version 2.12.3 doesn't compile on discover
+  mapl:
+    version:: [2.11.0]
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -89,6 +121,13 @@ packages:
     externals:
     - spec: diffutils@3.3
       prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost+python
+      prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.22
@@ -109,8 +148,6 @@ packages:
     externals:
     - spec: gettext@0.19.2
       prefix: /usr
-    - spec: gettext@0.19.7
-      prefix: /usr/local
   ghostscript:
     externals:
     - spec: ghostscript@9.26
@@ -177,10 +214,16 @@ packages:
     externals:
     - spec: pkg-config@0.28
       prefix: /usr
+  #qt:
+  #  externals:
+  #  - spec: qt@5.15.3
+  #    prefix: /discover/swdev/jcsda/spack-stack/qt-5.15.3
+  #    modules:
+  #    - qt/5.15.3
   qt:
     externals:
-    - spec: qt@5.15.3
-      prefix: /discover/swdev/jcsda/spack-stack/qt-5.15.3
+    - spec: qt@5.15.2
+      prefix: /discover/swdev/jcsda/spack-stack/qt-5.15.2/5.15.2/gcc_64
   rsync:
     externals:
     - spec: rsync@3.1.0

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -1,7 +1,7 @@
 packages:
   all:
     compiler:: [intel@2022.0.1]
-    #compiler:: [gcc@11.2.0]
+    #compiler:: [gcc@10.1.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.0]
       #mpi:: [intel-mpi@2019.10.24]
@@ -25,7 +25,7 @@ packages:
   #    prefix: /usr/local/intel/oneapi/2021
   intel-mpi:
     externals:
-    - spec: intel-mpi@2019.10.24%gcc@11.2.0
+    - spec: intel-mpi@2019.10.24%gcc@10.1.0
       prefix: /usr/local/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64
       modules:
       - mpi/impi/20.0.0.166

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -121,13 +121,14 @@ packages:
     externals:
     - spec: diffutils@3.3
       prefix: /usr
-  ecflow:
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost+python
-      prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
+  # NEEDS UPDATE!!!
+  #ecflow:
+  #  buildable: False
+  #  externals:
+  #  - spec: ecflow@5.8.4+ui+static_boost+python
+  #    prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
+  #    modules:
+  #    - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.22

--- a/configs/sites/linux.default/modules.yaml
+++ b/configs/sites/linux.default/modules.yaml
@@ -1,8 +1,8 @@
 modules:
   default:
     enable::
-    - lmod
-    lmod:
+    - tcl
+    tcl:
       whitelist:
       # List of packages for which we need modules that are blacklisted by default
       - openmpi

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -110,7 +110,7 @@ packages:
   ecflow:
     buildable: False
     externals:
-    - spec: ecflow@5.8.4+ui+static_boost+python
+    - spec: ecflow@5.8.4+ui+static_boost
       prefix: /work/noaa/da/role-da/spack-stack/ecflow-5.8.4
       modules:
       - ecflow/5.8.4

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -1,8 +1,10 @@
 packages:
   all:
     compiler:: [intel@2022.0.2]
+    #compiler:: [gcc@10.2.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1]
+      #mpi:: [mpich@3.3.2]
 
 ### MPI, Python, MKL
   mpi:
@@ -17,18 +19,6 @@ packages:
       prefix: /apps/intel-2021.2/intel-2021.2
       modules:
       - impi/2021.2
-  mpich:
-    externals:
-    - spec: mpich@3.3.2%gcc@10.2.0~hydra device=ch3
-      prefix: /apps/gcc-10.2.0/mpich-3.3.2/mpich-3.3.2
-      modules:
-      - mpich/3.3.2
-  openmpi:
-    externals:
-    - spec: openmpi@4.0.4%gcc@10.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath fabrics=ucx schedulers=slurm
-      prefix: /apps/gcc-10.2.0/openmpi-4.0.4/openmpi-4.0.4
-      modules:
-      - openmpi/4.0.4
   #intel-oneapi-tbb:
   #  externals:
   #  - spec: intel-oneapi-tbb@2021.2.0%intel@2021.2.0
@@ -41,12 +31,18 @@ packages:
   #    prefix: /apps/intel-2021.2/intel-2021.2
   #    modules:
   #    - intel/2021.2
-  #intel-mpi:
+  mpich:
+    externals:
+    - spec: mpich@3.3.2%gcc@10.2.0~hydra device=ch3
+      prefix: /apps/gcc-10.2.0/mpich-3.3.2/mpich-3.3.2
+      modules:
+      - mpich/3.3.2
+  #openmpi:
   #  externals:
-  #  - spec: intel-mpi@2018.5.274%intel@2018.4
-  #    prefix: /apps/intel-2018/intel-2018.u4
+  #  - spec: openmpi@4.0.4%gcc@10.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath fabrics=ucx schedulers=slurm
+  #    prefix: /apps/gcc-10.2.0/openmpi-4.0.4/openmpi-4.0.4
   #    modules:
-  #    - intel-mpi@2018.4
+  #    - openmpi/4.0.4
   python:
     buildable: False
     externals:

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -107,6 +107,13 @@ packages:
     externals:
     - spec: doxygen@1.8.5+graphviz~mscgen
       prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost+python
+      prefix: /work/noaa/da/role-da/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.11

--- a/configs/templates/jedi-ufs-all/spack.yaml
+++ b/configs/templates/jedi-ufs-all/spack.yaml
@@ -13,13 +13,15 @@ spack:
 
   include: []
 
+  # Notes.
   # jedi-ewok-env does not build on macOS with GCC
   # jedi-tools-env does not build with Intel
   specs:
+   - global-workflow-env
    - jedi-ewok-env 
    - jedi-fv3-env
    - jedi-tools-env
    - jedi-ufs-env
    - jedi-um-env
    - nceplibs-env
-   - soca-env  
+   - soca-env

--- a/configs/templates/jedi-ufs-all/spack.yaml
+++ b/configs/templates/jedi-ufs-all/spack.yaml
@@ -17,12 +17,11 @@ spack:
   # jedi-ewok-env does not build on macOS with GCC
   # jedi-tools-env does not build with Intel
   specs:
-#   - global-workflow-env
-#   - jedi-ewok-env 
-#   - jedi-fv3-env
-#   - jedi-tools-env
-#   - jedi-ufs-env
-#   - jedi-um-env
-#   - nceplibs-env
-#   - soca-env
-   - ecflow
+   - jedi-ewok-env 
+   - jedi-fv3-env
+   - jedi-tools-env
+   - jedi-ufs-env
+   - jedi-um-env
+   - nceplibs-env
+   - soca-env
+

--- a/configs/templates/jedi-ufs-all/spack.yaml
+++ b/configs/templates/jedi-ufs-all/spack.yaml
@@ -17,11 +17,12 @@ spack:
   # jedi-ewok-env does not build on macOS with GCC
   # jedi-tools-env does not build with Intel
   specs:
-   - global-workflow-env
-   - jedi-ewok-env 
-   - jedi-fv3-env
-   - jedi-tools-env
-   - jedi-ufs-env
-   - jedi-um-env
-   - nceplibs-env
-   - soca-env
+#   - global-workflow-env
+#   - jedi-ewok-env 
+#   - jedi-fv3-env
+#   - jedi-tools-env
+#   - jedi-ufs-env
+#   - jedi-um-env
+#   - nceplibs-env
+#   - soca-env
+   - ecflow

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -14,74 +14,67 @@ spack:
 
   specs:
 
-    # Virtual environment packages
-    - base-env@1.0.0
-    - jedi-base-env@1.0.0
-    #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
-    - jedi-ewok-env@1.0.0
-    - ecflow@5.8.3
-
-###     # Virtual environment packages
-###     - base-env@1.0.0
-###     - jedi-base-env@1.0.0
-###     #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
-###     - jedi-ewok-env@1.0.0
-###     - jedi-fv3-env@1.0.0
-###     - jedi-mpas-env@1.0.0
-###     - jedi-ufs-env@1.0.0
-###     - jedi-um-env@1.0.0
-###     - soca-env@1.0.0
-###     - ufs-weather-model-env@1.0.0
-### 
-###     # Individual packages
-###     - bacio@2.4.1
-###     - bison@3.8.2
-###     - bufr@11.7.0
-###     - crtm@2.3.0
-###     - ecbuild@3.6.5
-###     - eccodes@2.25.0
-###     - ecflow@5.8.3
-###     - eckit@1.19.0
-###     - ecmwf-atlas@0.29.0
-###     # DH* fake version number
-###     - ectrans@1.0.0
-###     - eigen@3.4.0
-###     - esmf@8.3.0b09
-###     - fckit@0.9.5
-###     # DH* fake version number
-###     - fiat@1.0.0
-###     - flex@2.6.4
-###     - fms@2022.01
-###     # DH* fake version number
-###     - fms@release-jcsda
-###     - g2@3.4.5
-###     - g2tmpl@1.10.0
-###     #- gdal@3.4.3
-###     #- geos@3.9.1
-###     - gftl-shared@1.5.0
-###     - hdf5@1.12.1
-###     - hdf@4.2.15
-###     - ip@3.3.3
-###     - jasper@2.0.32
-###     - jedi-cmake@1.3.0
-###     - libpng@1.6.37
-###     - mapl@2.12.3
-###     - nccmp@1.9.0.1
-###     - netcdf-c@4.8.1
-###     - netcdf-cxx4@4.3.1
-###     - netcdf-fortran@4.5.4
-###     - nlohmann-json-schema-validator@2.1.0
-###     - nlohmann-json@3.10.5
-###     - parallel-netcdf@1.12.2
-###     - parallelio@2.5.4
-###     - py-numpy@1.22.3
-###     - py-pandas@1.4.0
-###     - py-scipy@1.8.0
-###     - py-shapely@1.8.0
-###     # DH* fake version number
-###     - shumlib@macos_clang_linux_intel_port
-###     - sp@2.3.3
-###     - udunits@2.2.28
-###     - w3nco@2.4.1
-###     - yafyaml@0.5.1
-###     - zlib@1.2.12
+     # Virtual environment packages
+     - base-env@1.0.0
+     - jedi-base-env@1.0.0
+     #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
+     - jedi-ewok-env@1.0.0
+     - jedi-fv3-env@1.0.0
+     - jedi-mpas-env@1.0.0
+     - jedi-ufs-env@1.0.0
+     - jedi-um-env@1.0.0
+     - soca-env@1.0.0
+     - ufs-weather-model-env@1.0.0
+ 
+     # Individual packages
+     - bacio@2.4.1
+     - bison@3.8.2
+     - bufr@11.7.0
+     - crtm@2.3.0
+     - ecbuild@3.6.5
+     - eccodes@2.25.0
+     - ecflow@5
+     - eckit@1.19.0
+     - ecmwf-atlas@0.29.0
+     # DH* fake version number
+     - ectrans@1.0.0
+     - eigen@3.4.0
+     - esmf@8.3.0b09
+     - fckit@0.9.5
+     # DH* fake version number
+     - fiat@1.0.0
+     - flex@2.6.4
+     - fms@2022.01
+     # DH* fake version number
+     - fms@release-jcsda
+     - g2@3.4.5
+     - g2tmpl@1.10.0
+     #- gdal@3.4.3
+     #- geos@3.9.1
+     - gftl-shared@1.5.0
+     - hdf5@1.12.1
+     - hdf@4.2.15
+     - ip@3.3.3
+     - jasper@2.0.32
+     - jedi-cmake@1.3.0
+     - libpng@1.6.37
+     - mapl@2.12.3
+     - nccmp@1.9.0.1
+     - netcdf-c@4.8.1
+     - netcdf-cxx4@4.3.1
+     - netcdf-fortran@4.5.4
+     - nlohmann-json-schema-validator@2.1.0
+     - nlohmann-json@3.10.5
+     - parallel-netcdf@1.12.2
+     - parallelio@2.5.4
+     - py-numpy@1.22.3
+     - py-pandas@1.4.0
+     - py-scipy@1.8.0
+     - py-shapely@1.8.0
+     # DH* fake version number
+     - shumlib@macos_clang_linux_intel_port
+     - sp@2.3.3
+     - udunits@2.2.28
+     - w3nco@2.4.1
+     - yafyaml@0.5.1
+     - zlib@1.2.12

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -14,67 +14,66 @@ spack:
 
   specs:
 
-     # Virtual environment packages
-     - base-env@1.0.0
-     - jedi-base-env@1.0.0
-     #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
-     - jedi-ewok-env@1.0.0
-     - jedi-fv3-env@1.0.0
-     - jedi-mpas-env@1.0.0
-     - jedi-ufs-env@1.0.0
-     - jedi-um-env@1.0.0
-     - soca-env@1.0.0
-     - ufs-weather-model-env@1.0.0
- 
-     # Individual packages
-     - bacio@2.4.1
-     - bison@3.8.2
-     - bufr@11.7.0
-     - crtm@2.3.0
-     - ecbuild@3.6.5
-     - eccodes@2.25.0
-     - ecflow@5
-     - eckit@1.19.0
-     - ecmwf-atlas@0.29.0
-     # DH* fake version number
-     - ectrans@1.0.0
-     - eigen@3.4.0
-     - esmf@8.3.0b09
-     - fckit@0.9.5
-     # DH* fake version number
-     - fiat@1.0.0
-     - flex@2.6.4
-     - fms@2022.01
-     # DH* fake version number
-     - fms@release-jcsda
-     - g2@3.4.5
-     - g2tmpl@1.10.0
-     #- gdal@3.4.3
-     #- geos@3.9.1
-     - gftl-shared@1.5.0
-     - hdf5@1.12.1
-     - hdf@4.2.15
-     - ip@3.3.3
-     - jasper@2.0.32
-     - jedi-cmake@1.3.0
-     - libpng@1.6.37
-     - mapl@2.12.3
-     - nccmp@1.9.0.1
-     - netcdf-c@4.8.1
-     - netcdf-cxx4@4.3.1
-     - netcdf-fortran@4.5.4
-     - nlohmann-json-schema-validator@2.1.0
-     - nlohmann-json@3.10.5
-     - parallel-netcdf@1.12.2
-     - parallelio@2.5.4
-     - py-numpy@1.22.3
-     - py-pandas@1.4.0
-     - py-scipy@1.8.0
-     - py-shapely@1.8.0
-     # DH* fake version number
-     - shumlib@macos_clang_linux_intel_port
-     - sp@2.3.3
-     - udunits@2.2.28
-     - w3nco@2.4.1
-     - yafyaml@0.5.1
-     - zlib@1.2.12
+    # Virtual environment packages
+    - base-env@1.0.0
+    - jedi-base-env@1.0.0
+    - jedi-ewok-env@1.0.0
+    - jedi-fv3-env@1.0.0
+    - jedi-mpas-env@1.0.0
+    - jedi-ufs-env@1.0.0
+    - jedi-um-env@1.0.0
+    - soca-env@1.0.0
+    - ufs-weather-model-env@1.0.0
+
+    # Individual packages
+    - bacio@2.4.1
+    - bison@3.8.2
+    - bufr@11.7.0
+    - crtm@2.3.0
+    - ecbuild@3.6.5
+    - eccodes@2.25.0
+    - ecflow@5
+    - eckit@1.19.0
+    - ecmwf-atlas@0.29.0
+    # DH* fake version number
+    - ectrans@1.0.0
+    - eigen@3.4.0
+    - esmf@8.3.0b09
+    - fckit@0.9.5
+    # DH* fake version number
+    - fiat@1.0.0
+    - flex@2.6.4
+    - fms@2022.01
+    # DH* fake version number
+    - fms@release-jcsda
+    - g2@3.4.5
+    - g2tmpl@1.10.0
+    #- gdal@3.4.3
+    #- geos@3.9.1
+    - gftl-shared@1.5.0
+    - hdf5@1.12.1
+    - hdf@4.2.15
+    - ip@3.3.3
+    - jasper@2.0.32
+    - jedi-cmake@1.3.0
+    - libpng@1.6.37
+    - mapl@2.12.3
+    - nccmp@1.9.0.1
+    - netcdf-c@4.8.1
+    - netcdf-cxx4@4.3.1
+    - netcdf-fortran@4.5.4
+    - nlohmann-json-schema-validator@2.1.0
+    - nlohmann-json@3.10.5
+    - parallel-netcdf@1.12.2
+    - parallelio@2.5.4
+    - py-numpy@1.22.3
+    - py-pandas@1.4.0
+    - py-scipy@1.8.0
+    - py-shapely@1.8.0
+    # DH* fake version number
+    - shumlib@macos_clang_linux_intel_port
+    - sp@2.3.3
+    - udunits@2.2.28
+    - w3nco@2.4.1
+    - yafyaml@0.5.1
+    - zlib@1.2.12

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -19,62 +19,69 @@ spack:
     - jedi-base-env@1.0.0
     #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
     - jedi-ewok-env@1.0.0
-    - jedi-fv3-env@1.0.0
-    - jedi-mpas-env@1.0.0
-    - jedi-ufs-env@1.0.0
-    - jedi-um-env@1.0.0
-    - soca-env@1.0.0
-    - ufs-weather-model-env@1.0.0
-
-    # Individual packages
-    - bacio@2.4.1
-    - bison@3.8.2
-    - bufr@11.7.0
-    - crtm@2.3.0
-    - ecbuild@3.6.5
-    - eccodes@2.25.0
     - ecflow@5.8.3
-    - eckit@1.19.0
-    - ecmwf-atlas@0.29.0
-    # DH* fake version number
-    - ectrans@1.0.0
-    - eigen@3.4.0
-    - esmf@8.3.0b09
-    - fckit@0.9.5
-    # DH* fake version number
-    - fiat@1.0.0
-    - flex@2.6.4
-    - fms@2022.01
-    # DH* fake version number
-    - fms@release-jcsda
-    - g2@3.4.5
-    - g2tmpl@1.10.0
-    #- gdal@3.4.3
-    #- geos@3.9.1
-    - gftl-shared@1.5.0
-    - hdf5@1.12.1
-    - hdf@4.2.15
-    - ip@3.3.3
-    - jasper@2.0.32
-    - jedi-cmake@1.3.0
-    - libpng@1.6.37
-    - mapl@2.12.3
-    - nccmp@1.9.0.1
-    - netcdf-c@4.8.1
-    - netcdf-cxx4@4.3.1
-    - netcdf-fortran@4.5.4
-    - nlohmann-json-schema-validator@2.1.0
-    - nlohmann-json@3.10.5
-    - parallel-netcdf@1.12.2
-    - parallelio@2.5.4
-    - py-numpy@1.22.3
-    - py-pandas@1.4.0
-    - py-scipy@1.8.0
-    - py-shapely@1.8.0
-    # DH* fake version number
-    - shumlib@macos_clang_linux_intel_port
-    - sp@2.3.3
-    - udunits@2.2.28
-    - w3nco@2.4.1
-    - yafyaml@0.5.1
-    - zlib@1.2.12
+
+###     # Virtual environment packages
+###     - base-env@1.0.0
+###     - jedi-base-env@1.0.0
+###     #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
+###     - jedi-ewok-env@1.0.0
+###     - jedi-fv3-env@1.0.0
+###     - jedi-mpas-env@1.0.0
+###     - jedi-ufs-env@1.0.0
+###     - jedi-um-env@1.0.0
+###     - soca-env@1.0.0
+###     - ufs-weather-model-env@1.0.0
+### 
+###     # Individual packages
+###     - bacio@2.4.1
+###     - bison@3.8.2
+###     - bufr@11.7.0
+###     - crtm@2.3.0
+###     - ecbuild@3.6.5
+###     - eccodes@2.25.0
+###     - ecflow@5.8.3
+###     - eckit@1.19.0
+###     - ecmwf-atlas@0.29.0
+###     # DH* fake version number
+###     - ectrans@1.0.0
+###     - eigen@3.4.0
+###     - esmf@8.3.0b09
+###     - fckit@0.9.5
+###     # DH* fake version number
+###     - fiat@1.0.0
+###     - flex@2.6.4
+###     - fms@2022.01
+###     # DH* fake version number
+###     - fms@release-jcsda
+###     - g2@3.4.5
+###     - g2tmpl@1.10.0
+###     #- gdal@3.4.3
+###     #- geos@3.9.1
+###     - gftl-shared@1.5.0
+###     - hdf5@1.12.1
+###     - hdf@4.2.15
+###     - ip@3.3.3
+###     - jasper@2.0.32
+###     - jedi-cmake@1.3.0
+###     - libpng@1.6.37
+###     - mapl@2.12.3
+###     - nccmp@1.9.0.1
+###     - netcdf-c@4.8.1
+###     - netcdf-cxx4@4.3.1
+###     - netcdf-fortran@4.5.4
+###     - nlohmann-json-schema-validator@2.1.0
+###     - nlohmann-json@3.10.5
+###     - parallel-netcdf@1.12.2
+###     - parallelio@2.5.4
+###     - py-numpy@1.22.3
+###     - py-pandas@1.4.0
+###     - py-scipy@1.8.0
+###     - py-shapely@1.8.0
+###     # DH* fake version number
+###     - shumlib@macos_clang_linux_intel_port
+###     - sp@2.3.3
+###     - udunits@2.2.28
+###     - w3nco@2.4.1
+###     - yafyaml@0.5.1
+###     - zlib@1.2.12

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -36,12 +36,10 @@ spack:
     - ecflow@5.8.3
     - eckit@1.19.0
     - ecmwf-atlas@0.29.0
-    # DH*
+    # DH* fake version number
     - ectrans@1.0.0
     - eigen@3.4.0
     - esmf@8.3.0b09
-    # DH* fake version number
-    - ewok@1.0.0
     - fckit@0.9.5
     # DH* fake version number
     - fiat@1.0.0
@@ -74,11 +72,7 @@ spack:
     - py-scipy@1.8.0
     - py-shapely@1.8.0
     # DH* fake version number
-    - r2d2@1.0.0
-    # DH* fake version number
     - shumlib@macos_clang_linux_intel_port
-    # DH* fake version number
-    - solo@1.0.0
     - sp@2.3.3
     - udunits@2.2.28
     - w3nco@2.4.1

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -3,6 +3,13 @@ spack:
     unify: when_possible
 
   view: false
+
+  packages:
+    fiat:
+      version:: [1.0.0]
+    ectrans:
+      version:: [1.0.0]
+
   include: []
 
   specs:
@@ -10,7 +17,8 @@ spack:
     # Virtual environment packages
     - base-env@1.0.0
     - jedi-base-env@1.0.0
-    - jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
+    #- jedi-ewok-env@1.0.0 +solo +r2d2 +ewok
+    - jedi-ewok-env@1.0.0
     - jedi-fv3-env@1.0.0
     - jedi-mpas-env@1.0.0
     - jedi-ufs-env@1.0.0
@@ -31,7 +39,7 @@ spack:
     # DH*
     - ectrans@1.0.0
     - eigen@3.4.0
-    - esmf@8.3.0
+    - esmf@8.3.0b09
     # DH* fake version number
     - ewok@1.0.0
     - fckit@0.9.5

--- a/doc/modulefile_templates/ecflow
+++ b/doc/modulefile_templates/ecflow
@@ -1,0 +1,26 @@
+#%Module1.0
+
+module-whatis "Provides an ecflow-5.8.4 server+ui installation for use with spack."
+
+# Only allow one instance of compiler to load
+conflict ecflow
+
+proc ModulesHelp { } {
+puts stderr "Provides an ecflow-5.8.4 server+ui installation for use with spack."
+}
+
+if { [ module-info mode load ] && ![ is-loaded qt/5.15.2 ] } {
+    module load qt/5.15.2
+}
+
+# Set this value
+set ECFLOW_PATH "/discover/swdev/jcsda/spack-stack/ecflow-5.8.4"
+
+prepend-path PATH "${ECFLOW_PATH}/bin"
+prepend-path LD_LIBRARY_PATH "${ECFLOW_PATH}/lib"
+prepend-path LD_LIBRARY_PATH "${ECFLOW_PATH}/lib64"
+prepend-path LIBRARY_PATH "${ECFLOW_PATH}/lib"
+prepend-path LIBRARY_PATH "${ECFLOW_PATH}/lib64"
+prepend-path CPATH "${ECFLOW_PATH}/include"
+prepend-path CMAKE_PREFIX_PATH "${ECFLOW_PATH}"
+prepend-path PYTHONPATH "${ECFLOW_PATH}/lib/python3.9/site-packages"

--- a/doc/modulefile_templates/qt
+++ b/doc/modulefile_templates/qt
@@ -1,0 +1,19 @@
+#%Module1.0
+
+module-whatis "Provides a qt-5.15.2 installation for use with spack."
+
+# Only allow one instance of compiler to load
+conflict qt
+
+proc ModulesHelp { } {
+puts stderr "Provides a qt-5.15.2 installation for use with spack."
+}
+
+# Set this value
+set QT_PATH "/discover/swdev/jcsda/spack-stack/qt-5.15.2/5.15.2/gcc_64"
+
+prepend-path PATH "${QT_PATH}/bin"
+prepend-path LD_LIBRARY_PATH "${QT_PATH}/lib"
+prepend-path LIBRARY_PATH "${QT_PATH}/lib"
+prepend-path CPATH "${QT_PATH}/include"
+prepend-path CMAKE_PREFIX_PATH "${QT_PATH}"

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -16,6 +16,12 @@ General
    There are several build errors with Python 3.10, for example Python packages being installed in nested subdirectories ``local`` of what is supposed to be the target installation directory. We therefore strongly recommend using Python 3.8 or 3.9.
 
 ==============================
+NASA Discover
+==============================
+
+1. ``mapl@2.12.3`` currently does not build on Discover. After creating an environment that uses ``mapl@2.12.3``, run ``spack remove mapl@2.12.3`` followed by ``spack add mapl@2.11.0``. If ``spack concretize`` was run before, remove ``/path/to/env/spack.lock`` and rerun ``spack concretize``.
+
+==============================
 NOAA Parallel Works
 ==============================
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -32,9 +32,7 @@ qt (qt@5)
    :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.2`` in ``/discover/swdev/jcsda/spack-stack/qt-5.15.2``.
 
 ecflow
-   MISSING
-  
-  after qt5 and after miniconda
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `miniconda`, `qt5`, and loading the following modules, follow the instructions in :numref:`Section %s <Prerequisites_ecFlow>`.
 
 .. code-block:: console
 
@@ -43,8 +41,6 @@ ecflow
    module load cmake/3.21.0
    module load qt/5.15.2
    module load comp/gcc/10.1.0
-
-Then follow the instructions in :numref:`Section %s <Prerequisites_Qt5>`.
 
 .. _MaintainersSection_Cheyenne:
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -28,18 +28,23 @@ miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
 
 qt (qt@5)
-
-qt (qt@5)
    The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to 
-   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.3`` in ``/discover/swdev/jcsda/spack-stack/qt-5.15.3``.
+   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.2`` in ``/discover/swdev/jcsda/spack-stack/qt-5.15.2``.
+
+ecflow
+   MISSING
+  
+  after qt5 and after miniconda
 
 .. code-block:: console
 
-   module purge
    module use /discover/swdev/jcsda/spack-stack/modulefiles
    module load miniconda/3.9.7
-   # Need a newer gcc compiler than the default OS compiler gcc-4.8.5
+   module load cmake/3.21.0
+   module load qt/5.15.2
    module load comp/gcc/10.1.0
+
+Then follow the instructions in :numref:`Section %s <Prerequisites_Qt5>`.
 
 .. _MaintainersSection_Cheyenne:
 
@@ -91,6 +96,18 @@ NOAA RDHPCS Hera
 
 miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
+
+qt (qt@5)
+   The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to 
+   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.3`` in ``/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/qt-5.15.3``.
+
+.. code-block:: console
+
+   module purge
+   module use /scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles
+   module load miniconda/3.9.12
+   # Need a newer gcc compiler than the default OS compiler gcc-4.8.5
+   module load gnu/9.2.0
 
 .. _MaintainersSection_Jet:
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -16,6 +16,17 @@ MSU Orion
 miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
 
+ecflow
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `miniconda`, and loading the following modules, follow the instructions in :numref:`Section %s <Prerequisites_ecFlow>`. Note that the default/system ``qt@5`` can be used on Orion.
+
+.. code-block:: console
+
+   module purge
+   module use module use /work/noaa/da/jedipara/spack-stack/modulefiles
+   module load miniconda/3.9.7
+   module load cmake/3.22.1
+   module load gcc/10.2.0
+
 .. _MaintainersSection_Discover:
 
 ------------------------------
@@ -36,6 +47,7 @@ ecflow
 
 .. code-block:: console
 
+   module purge
    module use /discover/swdev/jcsda/spack-stack/modulefiles
    module load miniconda/3.9.7
    module load cmake/3.21.0

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -51,7 +51,7 @@ spack-stack-0.0.1-rc1
 +============================+=======================================================================================================+
 | MSU Orion                  | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0-rc1/envs/skylab-1.0.0-intel-2022.0.2/install``  |
 +----------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover:sup:`*`      | coming soon                                                                                           |
+| NASA Discover :sup:`*`     | coming soon                                                                                           |
 +----------------------------+-------------------------------------------------------------------------------------------------------+
 | NCAR-Wyoming Cheyenne      |                                                                                                       |
 +----------------------------+-------------------------------------------------------------------------------------------------------+
@@ -241,14 +241,11 @@ NOAA RDHPCS Hera
 
 The following is required for building new spack environments and for using spack to build and run software.
 
-.. note::
-   Temporary location, this needs to be moved elsewhere.
-
 .. code-block:: console
 
    module purge
-   module use /scratch1/BMC/gsd-hpcs/Dom.Heinzeller/spack-stack/modulefiles
-   module load miniconda/3.9.7
+   module use /scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles
+   module load miniconda/3.9.12
 
 .. _Platforms_Jet:
 
@@ -452,7 +449,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
    export -n SPACK_SYSTEM_CONFIG_PATH
 
-6. Set default compiler and MPI library and flag Python as non-buildable
+6. Set default compiler and MPI library and flag Python as non-buildable (make sure to use the correct ``apple-clang`` version for your system and the desired ``openmpi`` version)
 
 .. code-block:: console
 
@@ -493,7 +490,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 Linux
 ------------------------------
 
-Note. Some Linux systems do not support ``lua/lmod`` environment modules, which are default in the spack-stack site configs. This can be changed to ``tcl/tk`` environment modules (see below).
+Note. Some Linux systems do not support recent ``lua/lmod`` environment modules, which are default in the spack-stack site configs. The instructions below therefore use ``tcl/tk`` environment modules.
 
 Prerequisites: Red Hat/CentOS 8 (one-off)
 -----------------------------------------
@@ -507,7 +504,7 @@ The following instructions were used to prepare a basic Red Hat 8 system as it i
    sudo su
    yum -y update
 
-   # Compilers
+   # Compilers - this includes environment module support
    yum -y install gcc-toolset-11-gcc-c++
    yum -y install gcc-toolset-11-gcc-gfortran
    yum -y install gcc-toolset-11-gdb
@@ -568,15 +565,17 @@ The following instructions were used to prepare a basic Ubuntu 20.04 system as i
 
    # Compilers
    apt install -y gcc g++ gfortran gdb
-   apt install -y gcc-10 g++-10
-   apt install -y gfortran-10
+
+   # Environment module support
+   apt install -y environment-modules
 
    # Do *not* install MPI with yum, this will be done with spack-stack
 
    # Misc
    apt install -y build-essential
    apt install -y libcurl4-openssl-dev
-   ### TRY WITHOUT apt install krb5-user
+   apt install -y libssl-dev
+   #apt install krb5-user
    apt install -y libkrb5-dev
    apt install -y m4
    # Skip cmake, default version 3.16 is too old
@@ -640,7 +639,9 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    spack external find --scope system perl
    spack external find --scope system python
    spack external find --scope system wget
-   # Do *not* use system curl, this breaks netcdf-c
+   # Red Hat: Do *not* execute the following line = do *not* use system curl, this breaks netcdf-c
+   # Ubuntu: Execute the following line = use system curl and libssl
+   spack external find curl
    # Skip qt@5 for now
    spack external find --scope system texlive
 
@@ -656,7 +657,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
    export -n SPACK_SYSTEM_CONFIG_PATH
 
-6. Set default compiler and MPI library and flag Python as non-buildable
+6. Set default compiler and MPI library and flag Python as non-buildable (make sure to use the correct ``gcc`` version for your system and the desired ``openmpi`` version)
 
 .. code-block:: console
 
@@ -664,9 +665,10 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    spack config add "packages:all:providers:mpi:[openmpi@4.1.3]"
    spack config add "packages:all:compiler:[gcc@11.2.1]"
 
-7. On Red Hat/CentOS 8, only `tcl/tk` environment modules are supported by default. Edit ``envs/jedi-ufs.mylinux/site/modules.yaml`` and replace every occurrence of ``lmod`` with ``tcl``.
+   # Ubuntu only
+   spack config add "packages:openssl:buildable:False"
 
-8. Optionally, edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/jedi-ufs.mylinux/spack.yaml``, etc.
+7. Optionally, edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/jedi-ufs.mylinux/spack.yaml``, etc.
 
 .. code-block:: console
 
@@ -674,18 +676,18 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    vi envs/jedi-ufs.mylinux/common/*.yaml
    vi envs/jedi-ufs.mylinux/site/*.yaml
 
-9. Process the specs and install
+8. Process the specs and install
 
 .. code-block:: console
 
    spack concretize
    spack install [--verbose] [--fail-fast]
 
-10. Create tcl (Red Hat 8) or lmod (Ubuntu 20.04) module files
+9. Create tcl module files
 
 .. code-block:: console
 
-   spack module [tcl|lmod] refresh
+   spack module tcl refresh
 
 11. Create meta-modules for compiler, mpi, python
 


### PR DESCRIPTION
A number of updates for spack-stack-1.0.0 release candidate 2:
- Update CI tests to use `jedi-ufs-all` template
- Fix `create-spack-mirror` CI test
- Add `yaksa` modulefile to blacklist
- Do not pin version for `py-setuptools`
- Update Discover site config
- Update Orion GNU site config
- By default, use environment modules (`tcl/tk`) instead of `lmod/lua` on AWS Ubuntu and Redhat
- Extend `jedi-ufs-all` template
- Update `skylab-1.0.0` template
- Add modulefile templates for `qt5` and `ecflow`
- Update documentation, especially instructions for building `ecflow`

Fixes #162 (see https://github.com/climbfuji/spack-stack/runs/6943697862?check_suite_focus=true)

Fixes https://github.com/NOAA-EMC/spack-stack/issues/211

Fixes https://github.com/NOAA-EMC/spack-stack/issues/213

Fixes https://github.com/NOAA-EMC/spack-stack/issues/123

Waiting on https://github.com/NOAA-EMC/spack/pull/106

CI tests all passed except for macos-apple-clang build (for some weird reason, the same test passed before - rerunning now without parallel spack installs). Rerunning macos-apple-clang now manually, check https://github.com/climbfuji/spack-stack/runs/6977275667?check_suite_focus=true for the progress.