### PR TITLE
Enable two level namespace with openmpi on MacOS in spack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/srherbener/spack
+  branch = feature/mac-openmpi-two-level-namespace
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/srherbener/spack
-  branch = feature/mac-openmpi-two-level-namespace
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
Bug fix in spack to build openmpi correctly with two-level namespace (from @srherbener). This PR only handles the submodule pointer update.

