### PR TITLE
Enable two level namespace with openmpi on MacOS in spack (release v1)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = release/jcsda_emc_release_v1
-  url = https://github.com/srherbener/spack
-  branch = feature/mac-openmpi-two-level-namespace
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = release/jcsda_emc_release_v1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = release/jcsda_emc_release_v1
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = release/jcsda_emc_release_v1
+  url = https://github.com/srherbener/spack
+  branch = feature/mac-openmpi-two-level-namespace
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
Identical to https://github.com/NOAA-EMC/spack-stack/pull/216, but for the release v1 branch (cherry-picked the spack PR from @srherbener to make sure there are no conflicts down the road).

Waiting on https://github.com/NOAA-EMC/spack/pull/108