### PR TITLE
Create Github workflow on Dom's macOS laptop using a self-hosted runner

### DIFF
--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -1,17 +1,17 @@
 name: macos-dom-build
 on:
-  pull_request:
+  #pull_request:
   #push:
   workflow_dispatch:
-  #  inputs:
-  #    template:
-  #      description: 'Base spack.yaml template. Default is an empty environment.'
-  #      required: false
-  #      default: 'empty'
-  #    specs:
-  #      description: 'Which specs to add to the template'
-  #      required: false
-  #      default: 'jedi-ufs-env'
+    inputs:
+      template:
+        description: 'Base spack.yaml template. Default is an empty environment.'
+        required: false
+        default: 'jedi-ufs-all'
+      specs:
+        description: 'Which specs to add to the template. Default is none (empty string).'
+        required: false
+        default: ''
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
@@ -31,10 +31,9 @@ jobs:
       - name: create-env
         run: |
           source ./setup.sh
-          ### spack stack create env --site macos.default --template ${{ github.event.inputs.template }} --name mirror
-          spack stack create env --site macos.default --template jedi-ufs-all --name jedi-ufs-all.macos-dom
-          spack env activate -d envs/jedi-ufs-all.macos-dom
-          ### spack add ${{ github.event.inputs.specs }}
+          spack stack create env --site macos.default --template ${{ github.event.inputs.template }} --name ${{ github.event.inputs.template }}.macos-dom
+          spack env activate -d envs/${{ github.event.inputs.template }}.macos-dom
+          spack add ${{ github.event.inputs.specs }}
 
           spack external find
           spack external find perl
@@ -45,7 +44,7 @@ jobs:
           spack compiler find
 
           spack concretize
-          spack install --verbose --fail-fast
+          spack install --fail-fast
 
       - name: upload-mirror
         uses: actions/upload-artifact@v2

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -45,6 +45,7 @@ jobs:
           spack compiler find
 
           spack concretize
+          spack install --verbose --fail-fast
 
       - name: upload-mirror
         uses: actions/upload-artifact@v2

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -40,8 +40,8 @@ jobs:
           spack external find perl
           spack external find python@3
           spack external find wget
-          "PATH=/usr/local/opt/qt@5/bin:${PATH}" spack external find qt@5
-          "PATH=/usr/local/opt/curl/bin:${PATH}" spack external find curl
+          PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt@5
+          PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
           spack compiler find
 
           spack concretize

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -3,15 +3,15 @@ on:
   pull_request:
   #push:
   workflow_dispatch:
-    inputs:
-      template:
-        description: 'Base spack.yaml template. Default is an empty environment.'
-        required: false
-        default: 'empty'
-      specs:
-        description: 'Which specs to add to the template'
-        required: false
-        default: 'jedi-ufs-env'
+  #  inputs:
+  #    template:
+  #      description: 'Base spack.yaml template. Default is an empty environment.'
+  #      required: false
+  #      default: 'empty'
+  #    specs:
+  #      description: 'Which specs to add to the template'
+  #      required: false
+  #      default: 'jedi-ufs-env'
 
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
@@ -31,9 +31,10 @@ jobs:
       - name: create-env
         run: |
           source ./setup.sh
-          spack stack create env --site macos.default --template ${{ github.event.inputs.template }} --name mirror
-          spack env activate -d envs/mirror
-          spack add ${{ github.event.inputs.specs }}
+          ### spack stack create env --site macos.default --template ${{ github.event.inputs.template }} --name mirror
+          spack stack create env --site macos.default --template jedi-ufs-all --name jedi-ufs-all.macos-dom
+          spack env activate -d envs/jedi-ufs-all.macos-dom
+          ### spack add ${{ github.event.inputs.specs }}
 
           spack external find
           spack external find perl

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -1,0 +1,50 @@
+name: macos-dom-build
+on:
+  workflow_dispatch:
+    inputs:
+      template:
+        description: 'Base spack.yaml template. Default is an empty environment.'
+        required: false
+        default: 'empty'
+      specs:
+        description: 'Which specs to add to the template'
+        required: false
+        default: 'jedi-ufs-env'
+
+# Use custom shell with -l so .bash_profile is sourced
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+jobs:
+  macos-dom-build:
+    runs-on: self-hosted
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: create-env
+        run: |
+          source ./setup.sh
+          spack stack create env --site macos.default --template ${{ github.event.inputs.template }} --name mirror
+          spack env activate -d envs/mirror
+          spack add ${{ github.event.inputs.specs }}
+
+          spack external find
+          spack external find perl
+          spack external find python@3
+          spack external find wget
+          "PATH=/usr/local/opt/qt@5/bin:${PATH}" spack external find qt@5
+          "PATH=/usr/local/opt/curl/bin:${PATH}" spack external find curl
+          spack compiler find
+
+          spack concretize
+
+      - name: upload-mirror
+        uses: actions/upload-artifact@v2
+        with:
+          name: spack_mirror
+          path: cache/source_cache

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -20,7 +20,7 @@ defaults:
 
 jobs:
   macos-dom-build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, X64, macos-dom]
 
     steps:
       - name: checkout
@@ -31,9 +31,9 @@ jobs:
       - name: create-env
         run: |
           source ./setup.sh
-          spack stack create env --site macos.default --template ${{ github.event.inputs.template }} --name ${{ github.event.inputs.template }}.macos-dom
-          spack env activate -d envs/${{ github.event.inputs.template }}.macos-dom
-          spack add ${{ github.event.inputs.specs }}
+          spack stack create env --site macos.default --template ${{ inputs.template }} --name ${{ inputs.template }}.macos-dom
+          spack env activate -d envs/${{ inputs.template }}.macos-dom
+          spack add ${{ inputs.specs }}
 
           spack external find
           spack external find perl

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -1,5 +1,7 @@
 name: macos-dom-build
 on:
+  pull_request:
+  #push:
   workflow_dispatch:
     inputs:
       template:


### PR DESCRIPTION
A super convenient system to quickly test changes (manually through dispatch workflow) on my macOS laptop. For security reasons, only manual testing through dispatch workflow from this spack-stack repository is enabled ("To trigger a workflow in a repository, the user should be a collaborator with write permission in the repository"). Will also look into a solution labels in the future.