### PR TITLE
Update Discover site config for GNU

### DIFF
--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -4,7 +4,7 @@ packages:
     #compiler:: [gcc@10.1.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.0]
-      #mpi:: [intel-oneapi-mpi@2021.4.0]
+      #mpi:: [openmpi@4.1.3]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,11 +15,13 @@ packages:
       prefix: /usr/local/intel/oneapi/2021/
       modules:
       - mpi/impi/2021.5.0
+  openmpi::
     externals:
-    - spec: intel-oneapi-mpi@2021.4.0%gcc@10.1.0
-      prefix: /usr/local/intel/oneapi/2021/
+    - spec: openmpi@4.1.3%gcc@10.1.0 fabrics=ucx +gpfs +pmi +two_level_namespace schedulers=slurm ~internal-hwloc
+      prefix: /discover/swdev/jcsda/spack-stack/openmpi-4.1.3/gcc-10.1.0
       modules:
-      - mpi/impi/2021.4.0
+      - openmpi/4.1.3-gcc-10.1.0
+
   #intel-oneapi-tbb:
   #  externals:
   #  - spec: intel-oneapi-tbb@2022.0.1%intel@2021.5.0
@@ -28,6 +30,7 @@ packages:
   #  externals:
   #  - spec: intel-oneapi-mkl@2022.0.1%intel@2021.5.0
   #    prefix: /usr/local/intel/oneapi/2021
+
   python:
     buildable: False
     externals:

--- a/doc/modulefile_templates/openmpi
+++ b/doc/modulefile_templates/openmpi
@@ -1,0 +1,33 @@
+#%Module1.0
+
+module-whatis "Provides an openmpi-4.1.3 installation for use with spack and gcc-10.1.0."
+
+# Only allow one instance of compiler to load
+conflict openmpi
+conflict mpich
+conflict mpi
+
+proc ModulesHelp { } {
+puts stderr "Provides an openmpi-4.1.3 installation for use with spack and gcc-10.1.0."
+}
+
+if { [ module-info mode load ] && ![ is-loaded comp/gcc/10.1.0 ] } {
+    module load comp/gcc/10.1.0
+}
+
+# Set this value
+set OPENMPI_PATH "/discover/swdev/jcsda/spack-stack/openmpi-4.1.3/gcc-10.1.0"
+
+prepend-path PATH "${OPENMPI_PATH}/bin"
+prepend-path LD_LIBRARY_PATH "${OPENMPI_PATH}/lib"
+prepend-path LIBRARY_PATH "${OPENMPI_PATH}/lib"
+prepend-path CPATH "${OPENMPI_PATH}/include"
+prepend-path CMAKE_PREFIX_PATH "${OPENMPI_PATH}"
+prepend-path MANPATH "${OPENMPI_PATH}/share/man"
+
+# Settings specific for Discover
+setenv MPIHOME ${OPENMPI_PATH}
+setenv MPI_HOME ${OPENMPI_PATH}
+unsetenv SLURM_EXPORT_ENV
+setenv PSM2_PATH_SELECTION "static_base"
+setenv SLURM_CPU_BIND "none"

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -33,7 +33,7 @@ ecflow
 NASA Discover
 ------------------------------
 
-On Discover, ``miniconda`` and ``qt`` need to be installed as a one-off before spack can be used.
+On Discover, ``miniconda``, ``qt``, and ``ecflow`` need to be installed as a one-off before spack can be used. When using the GNU compiler, it is also necessary to build your own ``openmpi`` or other MPI library, which requires adapting the installation to the network hardware and ``slurm`` scheduler.
 
 miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
@@ -53,6 +53,26 @@ ecflow
    module load cmake/3.21.0
    module load qt/5.15.2
    module load comp/gcc/10.1.0
+
+openmpi
+   Installing ``openmpi`` requires adapting the installation to the network hardware and ``slurm`` scheduler. It is easier to build and test ``openmpi`` manually and use it as an external package, instead of building it as part of spack-stack. These instructions were used to build the ``openmpi@4.1.3`` MPI library with ``gcc@10.1.0`` as referenced in the Discover site config. After the installation, create modulefile `openmpi/4.1.3-gcc-10.1.0` using the template ``doc/modulefile_templates/openmpi``. Note the site-specific module settings at the end of the template, this will likely be different for other HPCs.
+
+.. code-block:: console
+
+   module purge
+   module use /discover/swdev/jcsda/spack-stack/modulefiles
+   module load miniconda/3.9.7
+   module load comp/gcc/10.1.0
+   CPATH="/usr/include/slurm:$CPATH" ./configure \
+       --prefix=/discover/swdev/jcsda/spack-stack/openmpi-4.1.3/gcc-10.1.0/ \
+       --with-pmi=/usr/slurm \
+       --with-ucx \
+       --without-ofi \
+       --without-verbs \
+       --with-gpfs
+   CPATH="/usr/include/slurm:$CPATH" make VERBOSE=1 -j4
+   CPATH="/usr/include/slurm:$CPATH" make check
+   CPATH="/usr/include/slurm:$CPATH" make install
 
 .. _MaintainersSection_Cheyenne:
 


### PR DESCRIPTION
Update Discover site config for GNU compiler. Add instructions and modulefile template to build openmpi on Discover. I tested this as part of spack-stack-1.0.0-rc2, built the entire skylab-1.0.0 environment, ran the fv3-bundle ctests, etc.

Ready to merge.

Fixes #229 