### PR TITLE
Add skylab-1.0.0-public template to avoid license issues, complete documentation on chaining spack environments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = release/jcsda_emc_release_v1
-  url = https://github.com/climbfuji/spack
-  branch = feature/fftw_variant_for_jedi-base-env
+  url = https://github.com/NOAA-EMC/spack
+  branch = spack-stack-1.0.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = release/jcsda_emc_release_v1
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = release/jcsda_emc_release_v1
+  url = https://github.com/climbfuji/spack
+  branch = feature/fftw_variant_for_jedi-base-env
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -4,7 +4,7 @@ packages:
     #compiler:: [gcc@10.1.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.0]
-      #mpi:: [intel-oneapi-mpi@2021.4.0]
+      #mpi:: [openmpi@4.1.3]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,11 +15,13 @@ packages:
       prefix: /usr/local/intel/oneapi/2021/
       modules:
       - mpi/impi/2021.5.0
+  openmpi::
     externals:
-    - spec: intel-oneapi-mpi@2021.4.0%gcc@10.1.0
-      prefix: /usr/local/intel/oneapi/2021/
+    - spec: openmpi@4.1.3%gcc@10.1.0 fabrics=ucx +gpfs +pmi +two_level_namespace schedulers=slurm ~internal-hwloc
+      prefix: /discover/swdev/jcsda/spack-stack/openmpi-4.1.3/gcc-10.1.0
       modules:
-      - mpi/impi/2021.4.0
+      - openmpi/4.1.3-gcc-10.1.0
+
   #intel-oneapi-tbb:
   #  externals:
   #  - spec: intel-oneapi-tbb@2022.0.1%intel@2021.5.0
@@ -28,6 +30,7 @@ packages:
   #  externals:
   #  - spec: intel-oneapi-mkl@2022.0.1%intel@2021.5.0
   #    prefix: /usr/local/intel/oneapi/2021
+
   python:
     buildable: False
     externals:

--- a/configs/templates/skylab-1.0.0-public/spack.yaml
+++ b/configs/templates/skylab-1.0.0-public/spack.yaml
@@ -1,0 +1,85 @@
+spack:
+  concretizer:
+    unify: when_possible
+
+  view: false
+
+  packages:
+    fiat:
+      version: [1.0.0]
+    ectrans:
+      version: [1.0.0]
+
+  include: []
+
+  specs:
+
+    # Virtual environment packages
+    - base-env@1.0.0
+    - jedi-base-env@1.0.0 ~fftw
+    - jedi-ewok-env@1.0.0
+    - jedi-fv3-env@1.0.0
+    - jedi-mpas-env@1.0.0
+    - jedi-ufs-env@1.0.0
+    #- jedi-um-env@1.0.0
+    #- soca-env@1.0.0
+    - ufs-weather-model-env@1.0.0
+
+    # Individual packages
+    - bacio@2.4.1
+    - bison@3.8.2
+    - bufr@11.7.0
+    - crtm@2.3.0
+    - ecbuild@3.6.5
+    - eccodes@2.25.0
+    - ecflow@5
+    - eckit@1.19.0
+    - ecmwf-atlas@0.29.0 ~trans ~fftw
+    # DH* fake version number
+    #- ectrans@1.0.0
+    - eigen@3.4.0
+    - esmf@8.3.0b09
+    # DH* fake version number
+    - ewok@1.0.0
+    - fckit@0.9.5
+    # DH* fake version number
+    #- fiat@1.0.0
+    - flex@2.6.4
+    - fms@2022.01
+    # DH* fake version number
+    - fms@release-jcsda
+    - g2@3.4.5
+    - g2tmpl@1.10.0
+    #- gdal@3.4.3
+    #- geos@3.9.1
+    - gftl-shared@1.5.0
+    - hdf5@1.12.1
+    - hdf@4.2.15
+    - ip@3.3.3
+    - jasper@2.0.32
+    - jedi-cmake@1.3.0
+    - libpng@1.6.37
+    - mapl@2.12.3
+    - nccmp@1.9.0.1
+    - netcdf-c@4.8.1
+    - netcdf-cxx4@4.3.1
+    - netcdf-fortran@4.5.4
+    - nlohmann-json-schema-validator@2.1.0
+    - nlohmann-json@3.10.5
+    - parallel-netcdf@1.12.2
+    - parallelio@2.5.4
+    - py-numpy@1.22.3
+    - py-pandas@1.4.0
+    - py-scipy@1.8.0
+    - py-shapely@1.8.0
+    # DH* fake version number
+    - r2d2@1.0.0
+    # DH* fake version number
+    #- shumlib@macos_clang_linux_intel_port
+    # DH* fake version number
+    - solo@1.0.0
+    - sp@2.3.3
+    - udunits@2.2.28
+    - w3nco@2.4.1
+    - yafyaml@0.5.1
+    - zlib@1.2.12

--- a/configs/templates/skylab-1.0.0-public/spack.yaml
+++ b/configs/templates/skylab-1.0.0-public/spack.yaml
@@ -4,11 +4,11 @@ spack:
 
   view: false
 
-  packages:
-    fiat:
-      version: [1.0.0]
-    ectrans:
-      version: [1.0.0]
+  #packages:
+  #  fiat:
+  #    version: [1.0.0]
+  #  ectrans:
+  #    version: [1.0.0]
 
   include: []
 

--- a/configs/templates/skylab-1.0.0-public/spack.yaml
+++ b/configs/templates/skylab-1.0.0-public/spack.yaml
@@ -40,7 +40,7 @@ spack:
     - eigen@3.4.0
     - esmf@8.3.0b09
     # DH* fake version number
-    - ewok@1.0.0
+    - ewok@0.0.1
     - fckit@0.9.5
     # DH* fake version number
     #- fiat@1.0.0
@@ -73,10 +73,9 @@ spack:
     - py-scipy@1.8.0
     - py-shapely@1.8.0
     # DH* fake version number
-    - r2d2@1.0.0
+    - r2d2@0.0.1
     # DH* fake version number
     #- shumlib@macos_clang_linux_intel_port
-    # DH* fake version number
     - solo@1.0.0
     - sp@2.3.3
     - udunits@2.2.28

--- a/configs/templates/skylab-1.0.0/spack.yaml
+++ b/configs/templates/skylab-1.0.0/spack.yaml
@@ -40,7 +40,7 @@ spack:
     - eigen@3.4.0
     - esmf@8.3.0b09
     # DH* fake version number
-    - ewok@1.0.0
+    - ewok@0.0.1
     - fckit@0.9.5
     # DH* fake version number
     - fiat@1.0.0
@@ -73,10 +73,9 @@ spack:
     - py-scipy@1.8.0
     - py-shapely@1.8.0
     # DH* fake version number
-    - r2d2@1.0.0
+    - r2d2@0.0.1
     # DH* fake version number
     - shumlib@macos_clang_linux_intel_port
-    # DH* fake version number
     - solo@1.0.0
     - sp@2.3.3
     - udunits@2.2.28

--- a/doc/modulefile_templates/openmpi
+++ b/doc/modulefile_templates/openmpi
@@ -1,0 +1,33 @@
+#%Module1.0
+
+module-whatis "Provides an openmpi-4.1.3 installation for use with spack and gcc-10.1.0."
+
+# Only allow one instance of compiler to load
+conflict openmpi
+conflict mpich
+conflict mpi
+
+proc ModulesHelp { } {
+puts stderr "Provides an openmpi-4.1.3 installation for use with spack and gcc-10.1.0."
+}
+
+if { [ module-info mode load ] && ![ is-loaded comp/gcc/10.1.0 ] } {
+    module load comp/gcc/10.1.0
+}
+
+# Set this value
+set OPENMPI_PATH "/discover/swdev/jcsda/spack-stack/openmpi-4.1.3/gcc-10.1.0"
+
+prepend-path PATH "${OPENMPI_PATH}/bin"
+prepend-path LD_LIBRARY_PATH "${OPENMPI_PATH}/lib"
+prepend-path LIBRARY_PATH "${OPENMPI_PATH}/lib"
+prepend-path CPATH "${OPENMPI_PATH}/include"
+prepend-path CMAKE_PREFIX_PATH "${OPENMPI_PATH}"
+prepend-path MANPATH "${OPENMPI_PATH}/share/man"
+
+# Settings specific for Discover
+setenv MPIHOME ${OPENMPI_PATH}
+setenv MPI_HOME ${OPENMPI_PATH}
+unsetenv SLURM_EXPORT_ENV
+setenv PSM2_PATH_SELECTION "static_base"
+setenv SLURM_CPU_BIND "none"

--- a/doc/source/Environments.rst
+++ b/doc/source/Environments.rst
@@ -11,7 +11,7 @@ Environments can be constructed in two ways in spack-stack:
 
     - Configure the environment as shown in :numref:`Sections %s <Quickstart>` and :numref:`%s <Platforms>`.
 
-    - Add spack packages (also referred to as ``specs``) to the environment using ``spack add``. These packages can be virtual environments described in :numref:`Section %s <EnvironmentsVirtualEnvironments>` below, or individual packages, e.g. ``esmf`` or ``atlas``. Examples:
+    - Add spack packages (also referred to as ``specs``) to the environment using ``spack add``. These packages can be virtual environments described in :numref:`Section %s <EnvironmentsVirtualPackages>` below, or individual packages, e.g. ``esmf`` or ``atlas``. Examples:
 
         .. code-block:: console
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -250,30 +250,27 @@ Chaining spack-stack installations is a powerful way to test adding new packages
 
     spack install -v --reuse esmf@8.3.0b09+debug
 
-5. Create modulefiles - do not create the meta modules
+5. Create modulefiles
 
 .. code-block:: console
 
     spack module [lmod|tcl] refresh
 
-6. Do *not* run the `spack stack setup-meta-modules` script. *** MAYBE ***
+6. When using `tcl` module files, run the `spack stack setup-meta-modules` script. This is not needed when using `lmod` modulefiles, because the meta modules in ``/path/to/spack-stack-1.0.0/envs/jedi-ufs-chain-test/install/modulefiles/Core`` will be ignored entirely.
 
-To use the chained spack environment, first load the usual modules from the upstream spack environment. Then add the full path to the newly created modules manually, for example:
+To use the chained spack environment, first load the usual modules from the upstream spack environment. Then add the full path to the newly created modules manually, ignoring the meta modules (``.../Core``), for example:
 
 .. code-block:: console
 
     module use /path/to/spack-stack-1.0.0/envs/jedi-ufs-chain-test/install/modulefiles/openmpi/4.1.3/apple-clang/13.1.6
 
-Load the newly created modules 
-and meta modules as usual. Note that the call to `spack stack setup-meta-modules` is only required to update the automatic ``tcl/tk`` environment modules.
+7. Load the newly created modules. When using `tcl` module files, make sure that conflicting modules are unloaded (`lmod` takes care of this).
 
+.. note::
+   After activating the chained environment, ``spack find`` doesn't show the packages installed in upstream, unfortunately.
 
-
-Note. Spack find doesn't show the packages installed in upstream, unfortunately.
-
-**DOM WORK IN PROGRESS**  Note that it is not necessary to create the meta modules. Simply add the directory to which the new modules a???A? HOW ABOUT TCL????
-
-More details and a few words of caution can be found in the  `Spack documentation <https://spack.readthedocs.io/en/latest/chain.html?highlight=chaining%20spack%20installations>`_
+.. note::
+   More details and a few words of caution can be found in the  `Spack documentation <https://spack.readthedocs.io/en/latest/chain.html?highlight=chaining%20spack%20installations>`_. Those words of caution need to be taken seriously, especially those referring to not deleting modulefiles and dependencies in the upstream spack environment (if having permissions to do so)!
 
 ----------------------------------------
 Testing/adding packages outside of spack

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -33,7 +33,7 @@ ecflow
 NASA Discover
 ------------------------------
 
-On Discover, ``miniconda`` and ``qt`` need to be installed as a one-off before spack can be used.
+On Discover, ``miniconda``, ``qt``, and ``ecflow`` need to be installed as a one-off before spack can be used. When using the GNU compiler, it is also necessary to build your own ``openmpi`` or other MPI library, which requires adapting the installation to the network hardware and ``slurm`` scheduler.
 
 miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
@@ -53,6 +53,26 @@ ecflow
    module load cmake/3.21.0
    module load qt/5.15.2
    module load comp/gcc/10.1.0
+
+openmpi
+   Installing ``openmpi`` requires adapting the installation to the network hardware and ``slurm`` scheduler. It is easier to build and test ``openmpi`` manually and use it as an external package, instead of building it as part of spack-stack. These instructions were used to build the ``openmpi@4.1.3`` MPI library with ``gcc@10.1.0`` as referenced in the Discover site config. After the installation, create modulefile `openmpi/4.1.3-gcc-10.1.0` using the template ``doc/modulefile_templates/openmpi``. Note the site-specific module settings at the end of the template, this will likely be different for other HPCs.
+
+.. code-block:: console
+
+   module purge
+   module use /discover/swdev/jcsda/spack-stack/modulefiles
+   module load miniconda/3.9.7
+   module load comp/gcc/10.1.0
+   CPATH="/usr/include/slurm:$CPATH" ./configure \
+       --prefix=/discover/swdev/jcsda/spack-stack/openmpi-4.1.3/gcc-10.1.0/ \
+       --with-pmi=/usr/slurm \
+       --with-ucx \
+       --without-ofi \
+       --without-verbs \
+       --with-gpfs
+   CPATH="/usr/include/slurm:$CPATH" make VERBOSE=1 -j4
+   CPATH="/usr/include/slurm:$CPATH" make check
+   CPATH="/usr/include/slurm:$CPATH" make install
 
 .. _MaintainersSection_Cheyenne:
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -109,7 +109,7 @@ On Gaea, ``qt`` needs to be installed as a one-off before spack can be used.
 
 qt (qt@5)
    The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to 
-   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.3`` in ``/lustre/f2/pdata/esrl/gsd/spack-stack/qt-5.15.3``.
+   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.2`` in ``/lustre/f2/pdata/esrl/gsd/spack-stack/qt-5.15.2``.
 
 .. code-block:: console
 
@@ -127,7 +127,7 @@ miniconda
 
 qt (qt@5)
    The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to 
-   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.3`` in ``/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/qt-5.15.3``.
+   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.2`` in ``/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/qt-5.15.2``.
 
 .. code-block:: console
 
@@ -153,17 +153,6 @@ TACC Stampede2
 
 Several packages need to be installed as a one-off before spack can be used.
 
-Intel oneAPI compilers
-   The latest version of the Intel compiler on Stampede2 is 19.1.1, and the default modulefile created by the system administrators ties it to `gcc-9.1.0`. The way the module file has been written is incompatible with spack. We therefore recommend installing the latest Intel oneAPI compiler suite (Intel oneAPI Base and HPC Toolkits). The following instructions install Intel oneAPI 2022.2 in ``/work2/06146/tg854455/stampede2/spack-stack``.
-
-.. code-block:: console
-
-   wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191.sh
-   wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18673/l_BaseKit_p_2022.2.0.262.sh
-   # Customize the installations to install in /work2/06146/tg854455/stampede2/spack-stack/intel-oneapi-2022.2
-   sh l_BaseKit_p_2022.2.0.262.sh
-   sh l_HPCKit_p_2022.2.0.191.sh
-
 miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
 
@@ -180,7 +169,7 @@ git-lfs
    rpm2cpio git-lfs-1.2.1-1.el7.x86_64.rpm | cpio -idmv
    mv usr/* ../
 
-   Create modulefile ``/work2/06146/tg854455/stampede2/spack-stack/modulefiles/git-lfs/1.2.1`` from template ``doc/modulefile_templates/git-lfs`` and update ``GITLFS_PATH`` in this file.
+Create modulefile ``/work2/06146/tg854455/stampede2/spack-stack/modulefiles/git-lfs/1.2.1`` from template ``doc/modulefile_templates/git-lfs`` and update ``GITLFS_PATH`` in this file.
 
 .. _MaintainersSection_S4:
 
@@ -193,7 +182,7 @@ miniconda
 
 qt (qt@5)
    The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to 
-   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.3`` in ``/data/prod/jedi/spack-stack/qt-5.15.3``.
+   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.2`` in ``/data/prod/jedi/spack-stack/qt-5.15.2``.
 
 .. code-block:: console
 
@@ -256,7 +245,7 @@ Chaining spack-stack installations is a powerful way to test adding new packages
 
     spack module [lmod|tcl] refresh
 
-6. When using `tcl` module files, run the `spack stack setup-meta-modules` script. This is not needed when using `lmod` modulefiles, because the meta modules in ``/path/to/spack-stack-1.0.0/envs/jedi-ufs-chain-test/install/modulefiles/Core`` will be ignored entirely.
+6. When using ``tcl`` module files, run the ``spack stack setup-meta-modules`` script. This is not needed when using ``lmod`` modulefiles, because the meta modules in ``/path/to/spack-stack-1.0.0/envs/jedi-ufs-chain-test/install/modulefiles/Core`` will be ignored entirely.
 
 To use the chained spack environment, first load the usual modules from the upstream spack environment. Then add the full path to the newly created modules manually, ignoring the meta modules (``.../Core``), for example:
 

--- a/doc/source/Overview.rst
+++ b/doc/source/Overview.rst
@@ -7,7 +7,7 @@ spack-stack is a collaborative effort between the NOAA Environmental Modeling Ce
 
  `Spack <https://github.com/spack/spack>`_ is a community-supported, multi-platform, Python-based package manager originally developed by the Lawrence Livermore National Laboratory (LLNL; https://computing.llnl.gov/projects/spack-hpc-package-manager). It is provided as a submodule so that a stable version can be referenced. See the `Spack Documentation <https://spack.readthedocs.io/en/latest>`_ for more information.
 
-spack-stack is mainly a collection of Spack configuration files, but provides a Spack extension to simplify the installation process (see :numref:`Section %s <SpackStackExtension` for details):
+spack-stack is mainly a collection of Spack configuration files, but provides a Spack extension to simplify the installation process (see :numref:`Section %s <SpackStackExtension>` for details):
 
 - ``spack stack create`` is provided to copy common, site-specific, and application-specific configuration files into a coherent Spack environment and to create container recipes
 

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -11,10 +11,10 @@ Pre-configured sites
 
 Directory ``configs/sites`` contains site configurations for several HPC systems, as well as reference configurations for macOS and Linux. The reference configurations are **not** meant to be used as is, as user setups and package versions vary considerably. They are merely for comparing new site configurations that are created following the instructions below to working setups.
 
-Ready-to-use spack-stack installations are available on the following platforms:
+Ready-to-use spack-stack installations are available on the following platforms. This table will be expanded as more platforms are added.
 
 ---------------------
-spack-stack-1.0.0-rc2
+spack-stack-1.0.0
 ---------------------
 
 .. note::
@@ -23,51 +23,31 @@ spack-stack-1.0.0-rc2
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
 | System                                   | Maintained by (temporary) | Location                                                                                              |
 +==========================================+===========================+=======================================================================================================+
-| MSU Orion Intel                          | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-intel-2022.0.2/install``  |
+| MSU Orion Intel                          | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.2/install``      |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| MSU Orion GNU                            | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-gnu-10.2.0/install``      |
+| MSU Orion GNU                            | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.2.0/install``          |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover Intel                      | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-intel-2022.0.1/install``  |
+| NASA Discover Intel                      | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.1/install``      |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover GNU                        | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-gnu-10.1.0/install``      |
+| NASA Discover GNU                        | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.1.0/install``          |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Ubuntu 20.04 GNU | Dom Heinzeller            | ami-0c878bf50bf2d99af - ``/home/ubuntu/sandpit/spack-stack-1.0.0-rc2/envs/skylab-1.0.0/install``      |
+| NCAR-Wyoming Cheyenne                    |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Red Hat 8 GNU    | Dom Heinzeller            | ami-0710429b6c78a0eab - ``/home/ec2-user/sandpit/spack-stack-1.0.0-rc2/envs/skylab-1.0.0/install``    |
+| NOAA Parallel Works (AWS, Azure, Gcloud) |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-
--------------------------
-spack-stack-1.0.0 release
--------------------------
-
+| NOAA RDHPCS Gaea                         |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| System                                   | Maintained by (temporary) | Location                                                                                              |
-+==========================================+===========================+=======================================================================================================+
-| MSU Orion Intel                          | Dom Heinzeller            | coming soon                                                                                           |
+| NOAA RDHPCS Hera                         |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| MSU Orion GNU                            | Dom Heinzeller            | coming soon                                                                                           |
+| NOAA RDHPCS Jet                          |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover Intel                      | Dom Heinzeller            | coming soon                                                                                           |
+| TACC Stampede2                           |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover GNU                        | Dom Heinzeller            | coming soon                                                                                           |
+| UW (Univ. of Wisc.) S4                   |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NCAR-Wyoming Cheyenne                    |                           | currently not supported                                                                               |
+| Amazon Web Services AMI Ubuntu 20.04 GNU | Dom Heinzeller            | NEED TO UPDATE - ``/home/ubuntu/spack-stack-1.0.0/envs/skylab-1.0.0/install``                         |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NOAA Parallel Works (AWS, Azure, Gcloud) |                           | currently not supported                                                                               |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Gaea                         |                           | currently not supported                                                                               |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Hera                         |                           | currently not supported                                                                               |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Jet                          |                           | currently not supported                                                                               |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| TACC Stampede2                           |                           | currently not supported                                                                               |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| UW (Univ. of Wisc.) S4                   |                           | currently not supported                                                                               |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Ubuntu 20.04 GNU | Dom Heinzeller            | coming soon                                                                                           |
-+------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Red Hat 8 GNU    | Dom Heinzeller            | coming soon                                                                                           |
+| Amazon Web Services AMI Red Hat 8 GNU    | Dom Heinzeller            | NEED TO UPDATE - ``/home/ec2-user/spack-stack-1.0.0/envs/skylab-1.0.0/install``                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
 
 For questions or problems, please consult the known issues in :numref:`Chapter %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/noaa-emc/spack-stack/issues>`_ and `discussions <https://github.com/noaa-emc/spack-stack/discussions>`_ first.
@@ -92,8 +72,7 @@ For ``spack-stack-1.0.0`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   ulimit -s unlimited
-   module use /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-intel-2022.0.2/install/modulefiles/Core
+   module use /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.2/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.7
@@ -103,8 +82,7 @@ For ``spack-stack-1.0.0`` with GNU, load the following modules after loading min
 
 .. code-block:: console
 
-   ulimit -s unlimited
-   module use /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-gnu-10.2.0/install/modulefiles/Core
+   module use /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.2.0/install/modulefiles/Core
    module load stack-gcc/10.2.0
    module load stack-mpich/3.3.2
    module load stack-python/3.9.7
@@ -131,7 +109,7 @@ For ``spack-stack-1.0.0`` with Intel, load the following modules after loading m
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /discover/swdev/jcsda/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-intel-2022.0.1/install/modulefiles/Core
+   module use /discover/swdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.1/install/modulefiles/Core
    module load stack-intel/2022.0.1
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.9.7
@@ -142,7 +120,7 @@ For ``spack-stack-1.0.0`` with GNU, load the following modules after loading min
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-intel-oneapi-mpi/2021.4.0
    module load stack-python/3.9.7
@@ -286,7 +264,7 @@ For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with `ami-0c878b
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /home/ubuntu/sandpit/spack-stack-1.0.0-rc2/envs/skylab-1.0.0/install/modulefiles/Core
+   module use /home/ubuntu/spack-stack-1.0.0/envs/skylab-1.0.0/install/modulefiles/Core
    module load stack-gcc/10.3.0
    module load stack-mpich/4.0.2
    module load stack-python/3.8.10
@@ -302,7 +280,7 @@ For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with `ami-071042
 
    scl enable gcc-toolset-11 bash
    ulimit -s unlimited
-   module use /home/ec2-user/sandpit/spack-stack-1.0.0-rc2/envs/skylab-1.0.0/install/modulefiles/Core
+   module use /home/ec2-user/spack-stack-1.0.0/envs/skylab-1.0.0/install/modulefiles/Core
    module load stack-gcc/11.2.1
    module load stack-openmpi/4.1.3
    module load stack-python/3.9.7

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -9,27 +9,27 @@ Platforms
 Pre-configured sites
 ==============================
 
-Directory ``configs/sites`` contains site configurations for several HPC systems, as well as reference configurations for macOS and Linux. The reference configurations are **not** meant to be used as is, as user setups and package versions vary considerably. They are merely for comparing new site configurations that are created following the instructions below to working setups.
+Directory ``configs/sites`` contains site configurations for several HPC systems, as well as minimal configurations for macOS and Linux. The macOS and Linux configurations are **not** meant to be used as is, as user setups and package versions vary considerably. Instructions for adding this information can be found further down in :numref:`Section %s <Platform_New_Site_Configs>`.
 
 Ready-to-use spack-stack installations are available on the following platforms. This table will be expanded as more platforms are added.
 
----------------------
+-----------------
 spack-stack-1.0.0
----------------------
+-----------------
 
 .. note::
-   These versions are for friendly users and developers in preparation for a JEDI release on June 30, 2022. Amazon Web Services AMI are available in the US East 1 region.
+   This version supports the JEDI Skylab release end of June/beginning of July 2022, and can be used for testing spack-stack with other applications (e.g. the UFS Weather Model). Amazon Web Services AMI are available in the US East 1 region.
 
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
 | System                                   | Maintained by (temporary) | Location                                                                                              |
 +==========================================+===========================+=======================================================================================================+
-| MSU Orion Intel                          | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.2/install``      |
+| MSU Orion Intel                          | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.2/install``         |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| MSU Orion GNU                            | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.2.0/install``          |
+| MSU Orion GNU                            | Dom Heinzeller            | ``/work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.2.0/install``             |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover Intel                      | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.1/install``      |
+| NASA Discover Intel                      | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.1/install``         |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| NASA Discover GNU                        | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.1.0/install``          |
+| NASA Discover GNU                        | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install``             |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
 | NCAR-Wyoming Cheyenne                    |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
@@ -45,12 +45,12 @@ spack-stack-1.0.0
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
 | UW (Univ. of Wisc.) S4                   |                           | not yet supported - coming soon                                                                       |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Ubuntu 20.04 GNU | Dom Heinzeller            | NEED TO UPDATE - ``/home/ubuntu/spack-stack-1.0.0/envs/skylab-1.0.0/install``                         |
+| Amazon Web Services AMI Ubuntu 20.04 GNU | Dom Heinzeller            | AMI: skylab-1.0.0-ubuntu20 - ``/home/ubuntu/spack-stack-v1/envs/skylab-1.0.0/install``                |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Red Hat 8 GNU    | Dom Heinzeller            | NEED TO UPDATE - ``/home/ec2-user/spack-stack-1.0.0/envs/skylab-1.0.0/install``                       |
+| Amazon Web Services AMI Red Hat 8 GNU    | Dom Heinzeller            | AMI: skylab-1.0.0-redhat8 - ``/home/ec2-user/spack-stack-v1/envs/skylab-1.0.0/install``               |
 +------------------------------------------+---------------------------+-------------------------------------------------------------------------------------------------------+
 
-For questions or problems, please consult the known issues in :numref:`Chapter %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/noaa-emc/spack-stack/issues>`_ and `discussions <https://github.com/noaa-emc/spack-stack/discussions>`_ first.
+For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/noaa-emc/spack-stack/issues>`_ and `discussions <https://github.com/noaa-emc/spack-stack/discussions>`_ first.
 
 .. _Platforms_Orion:
 
@@ -72,7 +72,7 @@ For ``spack-stack-1.0.0`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.2/install/modulefiles/Core
+   module use /work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.2/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.7
@@ -82,7 +82,7 @@ For ``spack-stack-1.0.0`` with GNU, load the following modules after loading min
 
 .. code-block:: console
 
-   module use /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.2.0/install/modulefiles/Core
+   module use /work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.2.0/install/modulefiles/Core
    module load stack-gcc/10.2.0
    module load stack-mpich/3.3.2
    module load stack-python/3.9.7
@@ -109,7 +109,7 @@ For ``spack-stack-1.0.0`` with Intel, load the following modules after loading m
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /discover/swdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-intel-2022.0.1/install/modulefiles/Core
+   module use /discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.1/install/modulefiles/Core
    module load stack-intel/2022.0.1
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.9.7
@@ -120,7 +120,7 @@ For ``spack-stack-1.0.0`` with GNU, load the following modules after loading min
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.0.0/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-intel-oneapi-mpi/2021.4.0
    module load stack-python/3.9.7
@@ -132,6 +132,9 @@ For ``spack-stack-1.0.0`` with GNU, load the following modules after loading min
 NCAR-Wyoming Cheyenne
 ------------------------------
 
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
+
 The following is required for building new spack environments and for using spack to build and run software.
 
 .. code-block:: console
@@ -142,14 +145,14 @@ The following is required for building new spack environments and for using spac
    module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
    module load python/3.7.9
 
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
-
 .. _Platforms_Acorn:
 
 -------------------------------
 NOAA Acorn (WCOSS2 test system)
 -------------------------------
+
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
 
 On WCOSS2 OpenSUSE sets `CONFIG_SITE` which causes libraries to be installed in `lib64`, breaking the `lib` assumption made by some packages.
 
@@ -164,6 +167,9 @@ CONFIG_SITE should be set to empty in `compilers.yaml`.
 NOAA Parallel Works (AWS, Azure, Gcloud)
 ----------------------------------------
 
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
+
 The following is required for building new spack environments and for using spack to build and run software. The default module path needs to be removed, otherwise spack detect the system as Cray. It is also necessary to add ``git-lfs`` and some other utilities to the search path.
 
 .. code-block:: console
@@ -174,14 +180,15 @@ The following is required for building new spack environments and for using spac
    module use /contrib/spack-stack/modulefiles/core
    module load miniconda/3.9.7
 
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
 
 .. _Platforms_Gaea:
 
 ------------------------------
 NOAA RDHPCS Gaea
 ------------------------------
+
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
 
 The following is required for building new spack environments and for using spack to build and run software. Don't use ``module purge`` on Gaea!
 
@@ -196,14 +203,14 @@ The following is required for building new spack environments and for using spac
 .. note::
    On Gaea, a current limitation is that any executable that is linked against the MPI library (``cray-mpich``) must be run through ``srun`` on a compute node, even if it is run serially (one process). This is in particular a problem when using ``ctest`` for unit testing created by the ``ecbuild add_test`` macro. Work is in progress to augment ``ecbuild`` with the ability to prefix serial runs with a launcher, e.g. ``srun -n1`` on Gaea.
 
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
-
 .. _Platforms_Hera:
 
 ------------------------------
 NOAA RDHPCS Hera
 ------------------------------
+
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
 
 The following is required for building new spack environments and for using spack to build and run software.
 
@@ -212,9 +219,6 @@ The following is required for building new spack environments and for using spac
    module purge
    module use /scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles
    module load miniconda/3.9.12
-
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
 
 .. _Platforms_Jet:
 
@@ -228,6 +232,9 @@ NOAA RDHPCS Jet
 TACC Stampede2
 ------------------------------
 
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
+
 The following is required for building new spack environments and for using spack to build and run software.
 
 .. code-block:: console
@@ -237,12 +244,12 @@ The following is required for building new spack environments and for using spac
    module use /work2/06146/tg854455/stampede2/spack-stack/modulefiles
    module load miniconda/3.9.7
 
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
-
 ------------------------------
 UW (Univ. of Wisconsin) S4
 ------------------------------
+
+.. note::
+   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
 
 The following is required for building new spack environments and for using spack to build and run software.
 
@@ -252,19 +259,16 @@ The following is required for building new spack environments and for using spac
    module use /data/prod/jedi/spack-stack/modulefiles
    module load miniconda/3.9.7
 
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
-
 --------------------------------
 Amazon Web Services Ubuntu 20.04
 --------------------------------
 
-For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with `ami-0c878bf50bf2d99af <https://us-east-1.console.aws.amazon.com/ec2/v2/home?region=us-east-1#ImageDetails:imageId=ami-0c878bf50bf2d99af>`_. After logging in, run:
+For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-ubuntu20". After logging in, run:
 
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /home/ubuntu/spack-stack-1.0.0/envs/skylab-1.0.0/install/modulefiles/Core
+   module use /home/ubuntu/spack-stack-v1/envs/skylab-1.0.0/install/modulefiles/Core
    module load stack-gcc/10.3.0
    module load stack-mpich/4.0.2
    module load stack-python/3.8.10
@@ -274,13 +278,13 @@ For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with `ami-0c878b
 Amazon Web Services Red hat 8
 -----------------------------
 
-For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with `ami-0710429b6c78a0eab <https://us-east-1.console.aws.amazon.com/ec2/v2/home?region=us-east-1#ImageDetails:imageId=ami-0710429b6c78a0eab>`_. After logging in, run:
+For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-redhat8". After logging in, run:
 
 .. code-block:: console
 
    scl enable gcc-toolset-11 bash
    ulimit -s unlimited
-   module use /home/ec2-user/spack-stack-1.0.0/envs/skylab-1.0.0/install/modulefiles/Core
+   module use /home/ec2-user/spack-stack-v1/envs/skylab-1.0.0/install/modulefiles/Core
    module load stack-gcc/11.2.1
    module load stack-openmpi/4.1.3
    module load stack-python/3.9.7
@@ -489,7 +493,7 @@ Note. Some Linux systems do not support recent ``lua/lmod`` environment modules,
 Prerequisites: Red Hat/CentOS 8 (one-off)
 -----------------------------------------
 
-The following instructions were used to prepare a basic Red Hat 8 system as it is available on Amazon Web Services to build and install all of the environments available in spack-stack (see :numref:`Sections %s <Prerequisites_Environments>`).
+The following instructions were used to prepare a basic Red Hat 8 system as it is available on Amazon Web Services to build and install all of the environments available in spack-stack (see :numref:`Sections %s <Environments>`).
 
 1. Install basic OS packages as `root`
 
@@ -544,7 +548,7 @@ This environment enables working with spack and building new software environmen
 Prerequisites: Ubuntu 20.04 (one-off)
 -------------------------------------
 
-The following instructions were used to prepare a basic Ubuntu 20.04 system as it is available on Amazon Web Services to build and install all of the environments available in spack-stack (see :numref:`Sections %s <Prerequisites_Environments>`).
+The following instructions were used to prepare a basic Ubuntu 20.04 system as it is available on Amazon Web Services to build and install all of the environments available in spack-stack (see :numref:`Sections %s <Environments>`).
 
 1. Install basic OS packages as `root`
 

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -122,7 +122,7 @@ For ``spack-stack-1.0.0`` with GNU, load the following modules after loading min
    ulimit -s unlimited
    module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
    module load stack-gcc/10.1.0
-   module load stack-intel-oneapi-mpi/2021.4.0
+   module load stack-openmpi/4.1.3
    module load stack-python/3.9.7
    module available
 

--- a/doc/source/Prerequisites.rst
+++ b/doc/source/Prerequisites.rst
@@ -78,6 +78,7 @@ On HPC systems without a sufficient Qt5 installation, we install it outside of s
 **New method** (SO FAR ONLY ON DISCOVER)
 
 .. code-block:: console
+
    mkdir -p /discover/swdev/jcsda/spack-stack/qt-5.15.2/src
    cd /discover/swdev/jcsda/spack-stack/qt-5.15.2/src
    wget --no-check-certificate http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run
@@ -86,7 +87,7 @@ On HPC systems without a sufficient Qt5 installation, we install it outside of s
 
 Sign into qt, select customized installation, choose qt@5.15.2 only (uncheck all other boxes) and set install prefix to ``/discover/swdev/jcsda/spack-stack/qt-5.15.2``. After the successful installation, create modulefile ``/discover/swdev/jcsda/spack-stack/modulefiles/qt/5.15.2`` from template ``doc/modulefile_templates/qt`` and update ``QT_PATH`` in this file.
 
-**Old method** (DOES NOT WORK ON DISCOVER, CHEYENNE, POSSIBLY HERA)
+**Old method** (DOES NOT WORK ON DISCOVER AND OTHER PLATFORMS, DON'T USE)
 
 .. code-block:: console
 

--- a/doc/source/Quickstart.rst
+++ b/doc/source/Quickstart.rst
@@ -72,7 +72,7 @@ The following instructions install a new spack environment on a pre-configured s
     spack install [--verbose] [--fail-fast] 2>&1 | tee log.install
 
 .. note::
-  For platforms with multiple compilers in the site config, make sure that the correct compiler and corresponding MPI library are set correctly in ``envs/jedi-fv3.hera/site/packages.yaml`` before running ``spack concretize``. Also, check the output of ``spack concretize`` to make sure that the correct compiler is used (e.g. %intel-2022.0.1). If not, edit ``envs/jedi-fv3.hera/site/compilers.yaml`` and remove the offending compiler. Then, remove ``envs/jedi-fv3.hera/spack.lock`` and rerun ``spack concretize``.
+  For platforms with multiple compilers in the site config, make sure that the correct compiler and corresponding MPI library are set correctly in ``envs/jedi-fv3.hera/site/packages.yaml`` before running ``spack concretize``. Also, check the output of ``spack concretize`` to make sure that the correct compiler is used (e.g. ``%intel-2022.0.1``). If not, edit ``envs/jedi-fv3.hera/site/compilers.yaml`` and remove the offending compiler. Then, remove ``envs/jedi-fv3.hera/spack.lock`` and rerun ``spack concretize``.
 
 ----------------
 Create container
@@ -136,6 +136,9 @@ In the simplest case, a new package (and its basic dependencies) or a new versio
    spack install [--verbose] [--fail-fast]
 
 Further information on how to define variants for new packages, how to use these non-standard versions correctly as dependencies, ..., can be found in the `Spack Documentation <https://spack.readthedocs.io/en/latest>`_. Details on the ``spack stack`` extension of the ``spack`` are provided in :numref:`Section %s <SpackStackExtension>`.
+
+.. note::
+   Instead of ``spack add ecmwf-atlas@0.29.0``, ``spack concretize`` and ``spack install``, one can also just use ``spack install ecmwf-atlas@0.29.0`` after checking in the first step (``spack spec``) that the package will be installed as desired.
 
 .. _QuickstartUseSpackStack:
 


### PR DESCRIPTION
This PR:
- add `configs/templates/skylab-1.0.0-public/spack.yaml` - same as `configs/templates/skylab-1.0.0/spack.yaml` but with software that uses licenses that are incompatible with the JCSDA Apache 2 license turned off (basically only `fftw` --> `fiat`, `ectrans`, and build `ecmwf-atlas` without `ectrans` and without `fftw`)
- last documentation updates, including referencing `spack-stack-1.0.0` instead of a release candidate so that the code can be tagged after the upstream PR https://github.com/NOAA-EMC/spack/pull/113 is merged, the submodule pointer updated here, and `.gitmodules` reverted
- updates of the tag names for `solo`, `r2d2`, `ewok` - tested locally, because they are not built as part of the CI system.

Notes:
- waiting on https://github.com/NOAA-EMC/spack/pull/113
    - this spack PR adds the variant to turn off `fftw` for `jedi-base-env`
- fixes #230 
- full CI tests passed for https://github.com/NOAA-EMC/spack-stack/pull/233/commits/92e449a63bba52a01b1d8a962a6981687e2691fa
- manually tested on macOS - the installed software is sufficient to build everything that is required for this release (everything for `ufs-weather-model`, and everything for `jedi-ewok-env` and `jedi-fv3-env`)