### PR TITLE
Ignore CI runs from docs, README, and issue template changes

### DIFF
--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -2,7 +2,11 @@ name: macos-apple-clang-build
 
 on:
   pull_request:
-  #push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -2,7 +2,11 @@ name: macos-gcc-build
 
 on:
   pull_request:
-  #push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -2,7 +2,11 @@ name: ubuntu-gcc-build
 
 on:
   pull_request:
-  #push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -2,7 +2,11 @@ name: ubuntu-intel-build
 
 on:
   pull_request:
-  #push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced


### PR DESCRIPTION
The problem with this is that required checks cannot be skipped. They'll be left hanging because the run won't be triggered.

Github's proposed workaround is to create dummy jobs with the same name that pass

https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

That is kind of hacky. There are also other tricks to detect which files have changed and skip steps based on that.

But for simplicity I think it would be best if we add these paths to the ignore list, and allow admin overrides of the status checks in the case where the workflow is not triggered (and only in that case), as @climbfuji mentioned here (https://github.com/NOAA-EMC/spack-stack/pull/252#issuecomment-1182259304).