### PR TITLE
Prevent overlinking against MPI libraries in ECMWF software and add support for different build types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/release_v1p0p2_ecmwf_packages_build_type_prevent_overlinking
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/release_v1p0p2_ecmwf_packages_build_type_prevent_overlinking
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -100,6 +100,7 @@ modules:
             '{name}_ROOT': '{prefix}'
         suffixes:
           +debug: 'debug'
+          build_type=Debug:  'debug'
       ecmwf-atlas:
         environment:
           set:
@@ -322,6 +323,7 @@ modules:
             '{name}_ROOT': '{prefix}'
         suffixes:
           +debug: 'debug'
+          build_type=Debug:  'debug'
       ecmwf-atlas:
         environment:
           set:


### PR DESCRIPTION
## Description

This PR only updates the submodule pointer for spack - needs updating after the corresponding spack PR https://github.com/NOAA-EMC/spack/pull/128 is merged.

Note that the submodule pointer update shows many more changes than just the 5 files that I changed - from previous PRs going in yesterday.

## Dependencies

- waiting on https://github.com/NOAA-EMC/spack/pull/128

## Issues

- fixes #231 

## Testing

Tested on Discover with Intel, on Orion with GNU, and on my local macOS with apple-clang+gfortran. Full CI tests passed for https://github.com/NOAA-EMC/spack-stack/pull/256/commits/49e700f15920893d63c57bf724a985ad0f62b31f.

I also installed all the packages with build type `Debug` and verified that `CMAKE_BUILD_TYPE=Debug` got passed to each of them. Then I verified that the modules are created with suffix `-debug`, as expected.
```
spack install --reuse --verbose ecmwf-atlas build_type=Debug ^fckit build_type=Debug ^ eckit build_type=Debug ^ fiat build_type=Debug ^ ectrans build_type=Debug 2>&1 | tee log.install.ecmwf-packages-debug
```