### PR TITLE
Add ufs-srw-dev template

### DIFF
--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -1,0 +1,46 @@
+spack:
+  config:
+    install_tree:
+      root: $env/install
+  modules:
+    default:
+      roots:
+        lmod: $env/install/modulefiles
+        tcl: $env/install/modulefiles
+      lmod:
+        projections:
+          parallelio: 'parallelio/2.5.3'
+
+  include: []
+
+  concretizer:
+    unify: true
+
+  specs:
+  - jasper@2.0.25
+  - zlib@1.2.11
+  - libpng@1.6.37
+  - hdf5@1.10.6
+  - netcdf-c@4.7.4
+  - netcdf-fortran@4.5.4
+  - parallelio@2.5.3
+  - esmf@8.3.0b09
+  - fms@2022.01
+  - bufr@11.7.0
+  - bacio@2.4.1
+  - crtm@2.3.0
+  - g2@3.4.5
+  - g2tmpl@1.10.0
+  - ip@3.3.3
+  - w3nco@2.4.1
+  - gftl-shared@1.5.0
+  - yafyaml@0.5.1
+  - mapl@2.22.0
+  - nemsio@2.5.4
+  - sfcio@1.4.1
+  - sigio@2.3.2
+  - w3emc@2.9.2
+  - wgrib2@2.0.8
+  - wrf-io@1.2.0
+  - ncio@1.1.2
+  

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -2,6 +2,7 @@ spack:
   config:
     install_tree:
       root: $env/install
+    deprecated: true
   modules:
     default:
       roots:
@@ -12,7 +13,7 @@ spack:
           parallelio: pio/{version}
       tcl: 
         projections:
-          parallelio: pio/{version}
+          parallelio: {^mpi.name}/{^mpi.version}/{compiler.name}/{compiler.version}/pio/{version}
 
   include: []
 

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -10,10 +10,10 @@ spack:
         tcl: $env/install/modulefiles
       lmod:
         projections:
-          parallelio: pio/{version}
+          parallelio: 'pio/{version}'
       tcl: 
         projections:
-          parallelio: {^mpi.name}/{^mpi.version}/{compiler.name}/{compiler.version}/pio/{version}
+          parallelio: '{^mpi.name}/{^mpi.version}/{compiler.name}/{compiler.version}/pio/{version}'
 
   include: []
 

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -9,7 +9,10 @@ spack:
         tcl: $env/install/modulefiles
       lmod:
         projections:
-          parallelio: 'parallelio/2.5.3'
+          parallelio: pio/{version}
+      tcl: 
+        projections:
+          parallelio: pio/{version}
 
   include: []
 


### PR DESCRIPTION
Create ufs-srw-dev template to match the module version numbers found in the UFS-SRW develop branch srw_common module file: https://github.com/ufs-community/ufs-srweather-app/blob/develop/modulefiles/srw_common. These modules reflect the most recently tested and utilized module set for the UFS-WM & SRW application.

This template was successfully installed on Orion and can be found here: /work/noaa/epic-ps/tools/spack-stack/spack-stack/envs/ufs-srw-dev.orion. 

To load: 

module use /work/noaa/epic-ps/tools/modulefiles
module load miniconda/3.9.7

module use /work/noaa/epic-ps/tools/spack-stack/spack-stack/envs/ufs-srw-dev.orion/install/modulefiles/Core
module load stack-intel
module load stack-intel-oneapi-mpi
module load cmake
module load srw_common.spack

Module file "srw_common.spack" loads:

module load jasper/2.0.25
module load zlib/1.2.11
module load libpng/1.6.37

module load hdf5/1.10.6
module load netcdf-c/4.7.4
module load netcdf-fortran/4.5.4
module load parallelio/2.5.3
module load esmf/8.3.0b09 
module load fms/2022.01

module load bufr/11.7.0
module load bacio/2.4.1
module load crtm/2.3.0
module load g2/3.4.5
module load g2tmpl/1.10.0
module load ip/3.3.3
module load sp/2.3.3
module load w3nco/2.4.1

module load gftl-shared/1.5.0
module load yafyaml/0.5.1
module load mapl/2.22.0-esmf-8.3.0b09-esmf-8.3.0

module load nemsio/2.5.4
module load sfcio/1.4.1
module load sigio/2.3.2
module load wgrib2/2.0.8

module load w3emc/2.9.2
module load wrf-io/1.2.0
module load ncio/1.1.2

The effort to determine and test the module & module versions in this template was done in collaboration with @EdwardSnyder-NOAA.