### PR TITLE
Cancel duplicate workflows in same PR

### DIFF
--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -9,6 +9,10 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
   run:

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -9,6 +9,10 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
   run:

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -9,6 +9,10 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
   run:

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -9,6 +9,10 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Use custom shell with -l so .bash_profile is sourced
 defaults:
   run:


### PR DESCRIPTION
When a push is made to a branch it will cancel in-progress workflows. I think this is usually the desired behavior, and prevents multiple long-running workflows from running at once which can stall workflows in other PRs. I often find myself manually canceling workflows as I add new commits to a branch.

With this when a push is made to a branch in-progress workflows will be canceled.

Fix #261 