### PR TITLE
Update Hera external OpenMPI

### DIFF
--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -18,8 +18,10 @@ packages:
       prefix: /apps/oneapi
   openmpi:
     externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0~cuda+cxx+cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath fabrics=mxm schedulers=slurm
+    - spec: openmpi@3.1.4%gcc@9.2.0~cuda+cxx+cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath fabrics=mxm schedulers=slurm
+      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
       modules:
+      - gnu/9.2.0
       - openmpi/3.1.4
   python:
     buildable: False


### PR DESCRIPTION
Fix #263 

And obligatory "duh" moment. There was no `prefix`.