### PR TITLE
Configure pull_request workflow runs using labels on Dom's self-hosted runner

### DIFF
--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -1,7 +1,16 @@
 name: macos-dom-build
 on:
-  #pull_request:
+  # uncomment if we decide to run tests when merging to develop branch
   #push:
+  #  # merges to develop branch
+  #  branches: [develop]
+  pull_request:
+    # pull request to develop with a label
+    types: [labeled]
+    branches: [develop]
+    defaults:
+      template: 'jedi-ufs-all'
+      specs: ''
   workflow_dispatch:
     inputs:
       template:
@@ -20,6 +29,7 @@ defaults:
 
 jobs:
   macos-dom-build:
+    if: ${{ github.event.label.name == 'macos-dom' }}
     runs-on: [self-hosted, macOS, X64, macos-dom]
 
     steps:
@@ -46,8 +56,9 @@ jobs:
           spack concretize
           spack install --fail-fast
 
-      - name: upload-mirror
-        uses: actions/upload-artifact@v2
-        with:
-          name: spack_mirror
-          path: cache/source_cache
+      # Skip this - takes forever and isn't necessary
+      #- name: upload-mirror
+      #  uses: actions/upload-artifact@v2
+      #  with:
+      #    name: spack_mirror
+      #    path: cache/source_cache

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -8,14 +8,11 @@ on:
     # pull request to develop with a label
     types: [labeled]
     branches: [develop]
-    defaults:
-      template: 'jedi-ufs-all'
-      specs: ''
   workflow_dispatch:
     inputs:
       template:
         description: 'Base spack.yaml template. Default is an empty environment.'
-        required: false
+        required: true
         default: 'jedi-ufs-all'
       specs:
         description: 'Which specs to add to the template. Default is none (empty string).'
@@ -41,9 +38,9 @@ jobs:
       - name: create-env
         run: |
           source ./setup.sh
-          spack stack create env --site macos.default --template ${{ inputs.template }} --name ${{ inputs.template }}.macos-dom
-          spack env activate -d envs/${{ inputs.template }}.macos-dom
-          spack add ${{ inputs.specs }}
+          spack stack create env --site macos.default --template ${{ inputs.template || 'jedi-ufs-all' }} --name ${{ inputs.template || 'jedi-ufs-all' }}.macos-dom
+          spack env activate -d envs/${{ inputs.template || 'jedi-ufs-all' }}.macos-dom
+          spack add ${{ inputs.specs || '' }}
 
           spack external find
           spack external find perl

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -51,20 +51,7 @@ jobs:
           spack compiler find
 
           spack concretize
-          # DH*
-          #spack install --fail-fast
-          spack install --fail-fast zlib
-          # *DH
-
-      - name: Clean working directory
-        run: |
-          cd $RUNNER_WORKSPACE
-          pwd
-          ls
-          cd ..
-          pwd
-          ls
-          #rm -r *
+          spack install --fail-fast
 
       # Skip this - takes forever and isn't necessary
       #- name: upload-mirror

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   macos-dom-build:
-    if: ${{ github.event.label.name == 'macos-dom' }}
+    if: ${{ github.event.label.name == 'run-macos-dom' }}
     runs-on: [self-hosted, macOS, X64, macos-dom]
 
     steps:

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       template:
-        description: 'Base spack.yaml template. Default is an empty environment.'
+        description: 'Base spack.yaml template. Default is a complete JEDI-UFS environment.'
         required: true
         default: 'jedi-ufs-all'
       specs:
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   macos-dom-build:
-    if: ${{ github.event.label.name == 'run-macos-dom' }}
+    if: ${{ github.event.label.name == 'run-macos-dom' }} || ${{ inputs.template }}
     runs-on: [self-hosted, macOS, X64, macos-dom]
 
     steps:

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -53,6 +53,12 @@ jobs:
           spack concretize
           spack install --fail-fast
 
+      - name: Clean working directory
+        run: |
+          cd $RUNNER_WORKSPACE
+          cd ..
+          rm -r *
+
       # Skip this - takes forever and isn't necessary
       #- name: upload-mirror
       #  uses: actions/upload-artifact@v2

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -51,13 +51,20 @@ jobs:
           spack compiler find
 
           spack concretize
-          spack install --fail-fast
+          # DH*
+          #spack install --fail-fast
+          spack install --fail-fast zlib
+          # *DH
 
       - name: Clean working directory
         run: |
           cd $RUNNER_WORKSPACE
+          pwd
+          ls
           cd ..
-          rm -r *
+          pwd
+          ls
+          #rm -r *
 
       # Skip this - takes forever and isn't necessary
       #- name: upload-mirror


### PR DESCRIPTION
## Description
- Configure `pull_request` runs on Dom's macOS using self-hosted runners
- Use label `run-macos-dom` to trigger these runs
- Skip uploading artifacts, takes way too long (pushes the workflow past the 6h mark) and isn't needed
- Update submodule pointer for `CMakeModules` following the merge of https://github.com/NOAA-EMC/CMakeModules/pull/62 (does not affect spack-stack at all)

## Testing
- All CI tests (using Github runners and on Dom's Mac) passed for https://github.com/NOAA-EMC/spack-stack/pull/274/commits/e6a9ec92c2a8d5fac25c21724c0ba7b175de8a5d