### PR TITLE
Support different versions of CRTM and FMS for JEDI and UFS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/crtm_jedi_tag
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/crtm_jedi_tag
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -18,13 +18,16 @@
     # Attention - when updating also check orion site config
     boost:
       version: [1.78.0]
-      # Install only the minimum needed (JEDI packages need headers only, but ecflow needs several libraries)
+      # Install only the minimum needed (JEDI packages need headers only,
+      # but ecflow needs several libraries)
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
     bufr:
       version: [11.7.0]
       variants: +python
     cmake:
       version: [3.22.1]
+    # Attention - when updating also check the ufs-weather-model-env, 
+    # jedi-fv3-env, jedi-ufs-env packages
     crtm:
       version: [2.3.0]
     diffutils:
@@ -48,7 +51,8 @@
       variants: ~enable_mkl
     eigen:
       version: [3.4.0]
-    # Attention - when updating the version also check the common modules.yaml config and update the projections for lmod/tcl
+    # Attention - when updating the version also check the common modules.yaml
+    # config and update the projections for lmod/tcl
     esmf:
       version: [8.3.0b09]
       variants: ~xerces ~pnetcdf
@@ -63,7 +67,8 @@
       version: [4.8.0]
     flex:
       version: [2.6.3]
-    # Attention - when updating also check macos.default and macos--monterey-llvm-clang-openmpi-reference site configs
+    # Attention - when updating also check the macos.default site config and
+    # the ufs-weather-model-env, jedi-fv3-env, jedi-ufs-env packages.
     fms:
       version: [2022.01]
       variants: +64bit +quad_precision +gfs_phys +openmp +pic

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -30,6 +30,7 @@ spack:
     - bison@3.8.2
     - bufr@11.7.0
     - crtm@2.3.0
+    - crtm@v2.3-jedi.4
     - ecbuild@3.6.5
     - eccodes@2.25.0
     - ecflow@5


### PR DESCRIPTION
- Update submodule pointer for spack for changes in https://github.com/NOAA-EMC/spack/pull/144
    -  Need merge of https://github.com/NOAA-EMC/spack/pull/144 and then subsequent submodule pointer update
- Add crtm@v2.3-jedi.4 to configs/templates/skylab-dev/spack.yaml

Fixes https://github.com/NOAA-EMC/spack-stack/issues/292

Tested on my macOS for the various combinations: request both `jedi-ufs-env` and `ufs-weather-model-env`, or just one of them.