### PR TITLE
Create hpc-stack environment to match UFS development versions

### DIFF
--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -1,0 +1,230 @@
+spack:
+  view: false
+
+  include: []
+
+  concretizer:
+    unify: when_possible
+  
+  config:
+    install_tree:
+       root: $env/install
+
+  modules:
+    default:
+      roots:
+        lmod: $env/install/modulefiles
+        tcl: $env/install/modulefiles
+  
+  packages:
+    bacio:
+      version: [2.4.1]
+    boost:
+      version: [1.78.0]
+      variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
+    bufr:
+      version: [11.7.0]
+      variants: +python
+    cmake:
+      version: [3.22.1]
+    crtm:
+      version: [2.3.0]
+    ecbuild:
+      version: [3.6.5]
+    eccodes:
+      version: [2.25.0]
+    eckit:
+      version: [1.19.0]
+      variants: linalg=eigen,lapack compression=lz4,bzip2
+    ecmwf-atlas:
+      version: [0.29.0]
+      variants: +fckit +trans
+    ectrans:
+      version: [1.0.0]
+      variants: ~enable_mkl
+    eigen:
+      version: [3.4.0]
+    esmf:
+      version: [8.3.0b09]
+      variants: ~xerces ~pnetcdf
+    fckit:
+      version: [0.9.5]
+      variants: +eckit
+    fftw:
+      version: [3.3.10]
+    fiat:
+      version: [main]
+    fms:
+      version: [2022.01]
+      variants: +64bit +quad_precision +gfs_phys +openmp +pic
+    g2:
+      version: [3.4.5]
+    g2c:
+      version: [1.6.4]
+    g2tmpl:
+      version: [1.10.0]
+    gfsio:
+      version: [1.4.1]
+    gftl-shared:
+      version: [1.5.0]
+    grib-util:
+      version: [1.2.3]
+    gsl-lite:
+      version: [0.37.0]
+    hdf:
+      version: [4.2.15]
+      variants: ~fortran ~netcdf
+    hdf5:
+      version: [1.10.6]
+      variants: +hl +fortran +mpi +threadsafe
+    ip:
+      version: [3.3.3]
+    ip2:
+      version: [1.1.2]
+    jasper:
+      version: [2.0.25]
+    jedi-cmake:
+      version: [1.3.0]
+    jpeg:
+      version: [9.1.0]
+    landsfcutil:
+      version: [2.4.1]
+    libjpeg-turbo:
+      version: [2.1.0]
+    libpng:
+      version: [1.6.37]
+    mapl:
+      version: [2.22.0]
+    met:
+      version: [10.1.1]
+      variants: +python +grib2
+    metplus:
+      version: [4.1.1]
+    nco:
+      version: [5.0.6]
+      variants: ~doc
+    nemsio:
+      version: [2.5.4]
+    nemsiogfs:
+      version: [2.5.3]
+    nccmp:
+      version: [1.9.0.1]
+    ncio:
+      version: [1.1.2]
+    netcdf-c:
+      version: [4.7.4]
+      variants: +dap +mpi +parallel-netcdf
+    netcdf-cxx4:
+      version: [4.3.1]
+    netcdf-fortran:
+      version: [4.5.3]
+    nlohmann-json:
+      version: [3.10.5]
+    nlohmann-json-schema-validator:
+      version: [2.1.0]
+    openblas:
+      version: [0.3.19]
+      variants: +noavx512
+    parallelio:
+      version: [2.5.7]
+      variants: +pnetcdf
+    parallel-netcdf:
+      version: [1.12.2]
+    pkgconf:
+      buildable: False
+    prod-util:
+      version: [1.2.2]
+    proj:
+      version: [8.1.0]
+      variants: ~tiff
+    python:
+      version: [3.9.12]
+    py-cartopy:
+      variants: +plotting
+    py-click:
+      version: [8.0.3]
+    py-eccodes:
+      version: [1.3.2]
+    py-f90nml:
+      version: [1.4.2]
+    py-h5py:
+      version: [3.6.0]
+    py-netcdf4:
+      version: [1.5.3]
+      variants: +mpi
+    py-numpy:
+      version: [1.22.3]
+      variants: +blas +lapack
+    py-openpyxl:
+      version: [3.0.3]
+    py-pandas:
+      version: [1.4.0]
+    py-pybind11:
+      version: [2.8.1]
+    py-pycodestyle:
+      version: [2.8.0]
+    py-pygithub:
+      version: [1.55]
+    py-pygrib:
+      version: [2.1.4]
+    py-pyhdf:
+      version: [0.10.4]
+    py-pyproj:
+      version: [3.1.0]
+    py-python-dateutil:
+      version: [2.8.2]
+    py-pythran:
+      version: [0.11.0]
+    py-pyyaml:
+      version: [6.0]
+    py-scipy:
+      version: [1.8.0]
+    py-shapely:
+      version: [1.8.0]
+    sfcio:
+      version: [1.4.1]
+    shumlib:
+      version: [macos_clang_linux_intel_port]
+    sigio:
+      version: [2.3.2]
+    sp:
+      version: [2.3.3]
+    udunits:
+      version: [2.2.28]
+    upp:
+      version: [10.0.10]
+    w3emc:
+      version: [2.9.2]
+    w3nco:
+      version: [2.4.1]
+    wget:
+      version: [1.21.2]
+    wgrib2:
+      version: [3.1.1]
+    wrf-io:
+      version: [1.2.0]
+    yafyaml:
+      version: [0.5.1]
+    zlib:
+      version: [1.2.12]
+
+  definitions:
+  # Set compilers here
+  - compilers: ['%intel']
+  - packages:
+      - global-workflow-env@hpc-stack-dev
+      - ufs-weather-model-env~debug@hpc-stack-dev
+      - ufs-weather-model-env+debug@hpc-stack-dev
+      - upp-env@hpc-stack-dev
+      - ww3-env@hpc-stack-dev
+      - gsi-env@hpc-stack-dev
+      - ufs-utils-env@hpc-stack-dev
+      - nceplibs-env@hpc-stack-dev
+      - soca-env@hpc-stack-dev
+      - base-env@hpc-stack-dev
+      - jedi-base-env@hpc-stack-dev
+
+  specs:
+    - matrix:
+      - [$packages]
+      - [$compilers]


### PR DESCRIPTION
@jkbk2004 @ulmononian @BrianCurtis-NOAA I have a hpc-stack equivalent of Spack here if you want to take a look. Then, we can extend it to other machines.

The versions are mostly the same except for 

* Zlib 1.2.12 is used because earlier versions have been deprecated
* PIO 2.5.7 is used to support external PIO option in ESMF added in 8.3.0

Some notable additions are MET/METplus, METIS/ParMETIS, and ufspyenv bundle for some commonly used Python packages.

See this for some differences between Spack and hpc-stack modules:

https://github.com/NOAA-EMC/spack-stack/wiki/Transitioning-to-Spack-from-hpc-stack

There is a test installation I added on Orion at:

```
module use module use /work/noaa/da/jedipara/spack-stack/modulefiles
module load miniconda/3.9.7
module use /work/noaa/nems/gkyle/spack-stack/envs/hpc-stack-dev-test/install/modulefiles/Core
module load stack-intel/2022.0.2
module load stack-intel-oneapi-mpi/2021.5.1
module load stack-python/3.9.7
```

I tested this using UFS_UTILS chgres_cube tests and the diffs were very small:

```
Variable Group Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
w        /       955  1.40238e-09 4.53011e-08 -7.45058e-09 3.72529e-09 1.11759e-08  1.46846e-12 3.31917e-10
zh       /         1  3.05176e-05 3.05176e-05  3.05176e-05 3.05176e-05           0  3.05176e-05           0
t        /         6   0.00012207 0.000183105 -3.05176e-05 3.05176e-05 6.10352e-05  2.03451e-05 2.49175e-05
delp     /         2 -0.000366211 0.000366211 -0.000244141 -0.00012207  0.00012207 -0.000183105 8.63167e-05
sphum    /         2 -3.18323e-12 4.09273e-12 -3.63798e-12 4.54747e-13 4.09273e-12 -1.59162e-12 2.89399e-12
liq_wat  /         4 -2.84044e-14 2.84391e-14 -2.84217e-14 1.04083e-17 2.84321e-14 -7.10109e-15 1.42137e-14
ice_wat  /         5  2.22109e-16 2.22109e-16  2.11758e-22 2.22045e-16 2.22044e-16  4.44219e-17 9.92941e-17
snowwat  /        11 -1.48904e-11 4.40565e-11 -2.91038e-11 1.45519e-11 4.36557e-11 -1.35367e-12 1.01916e-11
graupel  /         1  5.55112e-17 5.55112e-17  5.55112e-17 5.55112e-17           0  5.55112e-17           0
u_w      /        63 -1.05911e-06 1.71646e-06 -4.76837e-07 1.19209e-07 5.96046e-07 -1.68113e-08  9.2701e-08
v_w      /        67  5.71255e-07 2.93117e-06 -4.76837e-07 9.53674e-07 1.43051e-06  8.52619e-09 1.45774e-07
u_s      /        53  9.79395e-07 1.29593e-06 -5.96046e-08 4.76837e-07 5.36442e-07  1.84792e-08 8.05106e-08
v_s      /        86  -5.4026e-07 4.33761e-06 -9.53674e-07 4.76837e-07 1.43051e-06  -6.2821e-09 1.55428e-07
```

Then, I ran a ufs-weather-model control_c48 test which ran to completion (output here `/work/noaa/stmp/gkyle/stmp/gkyle/FV3_RT/rt_39745`)

The modules I used are here:


https://github.com/kgerheiser/ufs-weather-model/blob/spack-stack/modulefiles/ufs_orion.intel
https://github.com/kgerheiser/ufs-weather-model/blob/spack-stack/modulefiles/ufs_common

https://github.com/kgerheiser/UFS_UTILS/blob/spack-stack/modulefiles/build.orion.intel.lua

