### PR TITLE
Update spack fork/branch with release 0.18.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/pull_in_spack_v0p18p1
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/pull_in_spack_v0p18p1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
 Update submodule pointer for spack for the changes described in https://github.com/NOAA-EMC/spack/pull/149 (Pull in spack release v0.18.1).

- waiting on https://github.com/NOAA-EMC/spack/pull/149
- fixes https://github.com/NOAA-EMC/spack/issues/136

Dependent PR https://github.com/NOAA-EMC/spack/pull/149 was merged, `.gitmodules` reverted and submodule pointer for `spack` updated. Ready for review and merging - just want to wait for the CI tests to complete.