### PR TITLE
Update documentation to reflect spack-stack 1.0.2 more accurately for Orion, Discover and AWS.

### DIFF
--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -22,7 +22,7 @@ ecflow
 .. code-block:: console
 
    module purge
-   module use module use /work/noaa/da/jedipara/spack-stack/modulefiles
+   module use /work/noaa/da/jedipara/spack-stack/modulefiles
    module load miniconda/3.9.7
    module load cmake/3.22.1
    module load gcc/10.2.0

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -76,7 +76,7 @@ For ``spack-stack-1.0.2`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.1/install/modulefiles/Core
+   module use /work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.2/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.7

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -69,24 +69,24 @@ The following is required for building new spack environments and for using spac
 .. code-block:: console
 
    module purge
-   module use module use /work/noaa/da/jedipara/spack-stack/modulefiles
+   module use /work/noaa/da/role-da/spack-stack/modulefiles
    module load miniconda/3.9.7
 
-For ``spack-stack-1.0.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.2/install/modulefiles/Core
+   module use /discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2022.0.1/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.7
    module available
 
-For ``spack-stack-1.0.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.2`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.2.0/install/modulefiles/Core
+   module use /work/noaa/da/role-da/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.2.0-openmpi-4.0.4/install/modulefiles/Core
    module load stack-gcc/10.2.0
    module load stack-openmpi/4.0.4
    module load stack-python/3.9.7
@@ -106,7 +106,7 @@ The following is required for building new spack environments and for using spac
    module use /discover/swdev/jcsda/spack-stack/modulefiles
    module load miniconda/3.9.7
 
-For ``spack-stack-1.0.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
@@ -117,12 +117,12 @@ For ``spack-stack-1.0.0`` with Intel, load the following modules after loading m
    module load stack-python/3.9.7
    module available
 
-For ``spack-stack-1.0.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.2`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
    ulimit -s unlimited
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
+   module use /discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-openmpi/4.1.3
    module load stack-python/3.9.7
@@ -311,13 +311,13 @@ The following is required for building new spack environments and for using spac
 Amazon Web Services Ubuntu 20.04
 --------------------------------
 
-For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-ubuntu20". After logging in, run:
+For ``spack-stack-1.0.2``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-ubuntu20". After logging in, run:
 
 .. code-block:: console
 
    ulimit -s unlimited
    module use /home/ubuntu/spack-stack-v1/envs/skylab-1.0.0/install/modulefiles/Core
-   module load stack-gcc/10.3.0
+   module load stack-gcc/9.4.0
    module load stack-mpich/4.0.2
    module load stack-python/3.8.10
    module available
@@ -326,7 +326,7 @@ For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab
 Amazon Web Services Red hat 8
 -----------------------------
 
-For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-redhat8". After logging in, run:
+For ``spack-stack-1.0.2``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-redhat8". After logging in, run:
 
 .. code-block:: console
 
@@ -493,7 +493,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. code-block:: console
 
-   export -n SPACK_SYSTEM_CONFIG_PATH
+   unset SPACK_SYSTEM_CONFIG_PATH
 
 6. Set default compiler and MPI library and flag Python as non-buildable (make sure to use the correct ``apple-clang`` version for your system and the desired ``openmpi`` version)
 

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -697,7 +697,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   export -n SPACK_SYSTEM_CONFIG_PATH
+   unset SPACK_SYSTEM_CONFIG_PATH
 
 6. Set default compiler and MPI library and flag Python as non-buildable (make sure to use the correct ``gcc`` version for your system and the desired ``openmpi`` version)
 

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -72,7 +72,7 @@ The following is required for building new spack environments and for using spac
    module use /work/noaa/da/role-da/spack-stack/modulefiles
    module load miniconda/3.9.7
 
-For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.0`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
@@ -82,7 +82,7 @@ For ``spack-stack-1.0.2`` with Intel, load the following modules after loading m
    module load stack-python/3.9.7
    module available
 
-For ``spack-stack-1.0.2`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.0`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
@@ -311,7 +311,7 @@ The following is required for building new spack environments and for using spac
 Amazon Web Services Ubuntu 20.04
 --------------------------------
 
-For ``spack-stack-1.0.2``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-ubuntu20". After logging in, run:
+For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-ubuntu20". After logging in, run:
 
 .. code-block:: console
 
@@ -326,7 +326,7 @@ For ``spack-stack-1.0.2``, use a t2.2xlarge instance or similar with AMI "skylab
 Amazon Web Services Red hat 8
 -----------------------------
 
-For ``spack-stack-1.0.2``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-redhat8". After logging in, run:
+For ``spack-stack-1.0.0``, use a t2.2xlarge instance or similar with AMI "skylab-1.0.0-redhat8". After logging in, run:
 
 .. code-block:: console
 


### PR DESCRIPTION
This PR fixes several mistakes or out-of-date information on in the instructions for Orion, Discover, AWS and MacOS instructions.