### PR TITLE
Frontera Intel site config

### DIFF
--- a/configs/sites/frontera/compilers.yaml
+++ b/configs/sites/frontera/compilers.yaml
@@ -16,8 +16,9 @@ compilers::
           PATH: '/opt/apps/gcc/9.1.0/bin'
           CPATH: '/opt/apps/gcc/9.1.0/include'
           LD_LIBRARY_PATH: '/opt/intel/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64_lin:/opt/apps/gcc/9.1.0/lib64:/opt/apps/gcc/9.1.0/lib'
-        set:
-          I_MPI_ROOT: '/opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64'
+        # Don't set, the MPI library module does that for us
+        #set:
+        #  I_MPI_ROOT: '/opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64'
       extra_rpaths: []
   - compiler:
       spec: gcc@9.1.0

--- a/configs/sites/frontera/packages.yaml
+++ b/configs/sites/frontera/packages.yaml
@@ -60,11 +60,12 @@ packages:
     externals:
     - spec: bzip2@1.0.6
       prefix: /usr
-  cmake:
-    externals:
-    - spec: cmake@3.20.3
-      modules:
-      - cmake/3.20.3
+  # Don't use, problems w/ Intel compiler module
+  #cmake:
+  #  externals:
+  #  - spec: cmake@3.20.3
+  #    modules:
+  #    - cmake/3.20.3
   cpio:
     externals:
     - spec: cpio@2.11
@@ -90,6 +91,7 @@ packages:
     - spec: doxygen@1.8.5+graphviz~mscgen
       prefix: /usr
   ecflow:
+    buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
       prefix: /work2/06146/tg854455/frontera/spack-stack/ecflow-5.8.4

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -47,7 +47,7 @@ spack-stack-v1
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA RDHPCS Jet GNU                      | Kyle Gerheiser            | ``/lfs4/HFIP/hfv3gfs/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-9.2.0/install``                        |
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
-| TACC Frontera Intel                      |                           | not yet supported - coming soon                                                                              |
+| TACC Frontera Intel                      | Dom Heinzeller            | ``/work2/06146/tg854455/frontera/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install``     |
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
 | TACC Frontera GNU                        | Dom Heinzeller            | ``/work2/06146/tg854455/frontera/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-9.1.0/install``            |
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -280,7 +280,12 @@ The following is required for building new spack environments and for using spac
 
 For ``spack-stack-1.0.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
-**MISSING**
+   ulimit -s unlimited
+   module use /work2/06146/tg854455/frontera/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install/modulefiles/Core
+   module load stack-intel/19.1.1.217
+   module load stack-intel-mpi/2020.4.304
+   module load stack-python/3.9.12
+   module available
 
 For ``spack-stack-1.0.1`` with GNU, load the following modules after loading miniconda and ecflow:
 


### PR DESCRIPTION
This PR adds the Frontera site config to support the Intel compiler. The external `cmake/3.20.3` package was commented out, because loading it together with the Intel compiler module resulted in weird errors. @benjamin-cash did you create an issue for this somewhere?

Also fixes https://github.com/NOAA-EMC/spack-stack/issues/285

I was able to compile the ufs-weather-model code, top-level hash bb294814d0aac011ed94e28c4770121588402447, using:
```
module purge
module use /work2/06146/tg854455/frontera/spack-stack/modulefiles
module load miniconda/3.9.12
module load ecflow/5.8.4

module use /work2/06146/tg854455/frontera/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install/modulefiles/Core
module load stack-intel/19.1.1.217
module load stack-intel-mpi/2020.4.304
module load stack-python/3.9.12

module load ufs-weather-model-env/1.0.0
module load fms/2022.01

cmake -DAPP=S2SW -DDEBUG=OFF -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DINLINE_POST=ON .. 2>&1 | tee log.cmake
make 2>&1 | tee log.make
```