### PR TITLE
Update spack for latest changes in crtm, esmf and mapl

### DIFF
--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -50,6 +50,9 @@ jobs:
           PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
           spack compiler find
 
+          # https://github.com/dtcenter/MET/issues/2239
+          spack remove global-workflow-env
+
           spack concretize
           spack install --fail-fast
 

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -44,9 +44,9 @@ jobs:
 
           spack external find
           spack external find perl
-          spack external find python@3
+          spack external find python
           spack external find wget
-          PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt@5
+          PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt
           PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
           spack compiler find
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = https://github.com/climbfuji/spack/pull/new/feature/update_esmf_from_develop
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = https://github.com/climbfuji/spack/pull/new/feature/update_esmf_from_develop
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -15,6 +15,9 @@ General
 
    There are several build errors with Python 3.10, for example Python packages being installed in nested subdirectories ``local`` of what is supposed to be the target installation directory. We therefore strongly recommend using Python 3.8 or 3.9.
 
+3. Issues starting/finding ``ecflow_server`` due to a mismatch of hostnames
+   On some systems, ``ecflow_server`` gets confused by multiple hostnames, e.g. ``localhost`` and ``MYORG-L-12345``. The ``ecflow_start.sh`` script reports the hostname it wants to use. This name (or both) must be in ``/etc/hosts`` in the correct address line, often the loopback address (``127.0.0.1``).
+
 ==============================
 NASA Discover
 ==============================
@@ -61,3 +64,6 @@ macOS
 
 4. Errors such as ``Symbol not found: __cg_png_create_info_struct``
    Can happen when trying to use the raster plotting scripts in ``fv3-jedi-tools``. In that case, exporting ``DYLD_LIBRARY_PATH=/usr/lib/:$DYLD_LIBRARY_PATH`` can help. If ``git`` commands fail after this, you might need to verify where ``which git`` points to (Homebrew vs module) and unload the ``git`` module.
+
+5. Error building MET 10.1.1.20220419 build error on macOS Monterey 12.1
+   See https://github.com/NOAA-EMC/spack-stack/issues/316. Note that this error does not occur in the macOS CI tests.

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -506,7 +506,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 .. code-block:: console
 
    spack config add "packages:python:buildable:False"
-   spack config add "packages:all:providers:mpi:[openmpi@4.1.3]"
+   spack config add "packages:all:providers:mpi:[openmpi@4.1.4]"
    spack config add "packages:all:compiler:[apple-clang@13.1.6]"
 
 7. Optionally, edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/jedi-ufs.mymacos/spack.yaml``, etc.
@@ -711,7 +711,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
    # Example for Red Hat 8 following the above instructions
    spack config add "packages:python:buildable:False"
-   spack config add "packages:all:providers:mpi:[openmpi@4.1.3]"
+   spack config add "packages:all:providers:mpi:[openmpi@4.1.4]"
    spack config add "packages:all:compiler:[gcc@11.2.1]"
 
    # Example for Ubuntu 20.04 following the above instructions


### PR DESCRIPTION
This PR updates the submodule pointer for spack for the latest changes in the followin spack PRs:
- https://github.com/NOAA-EMC/spack/pull/156 (Add new CRTM version v2.4_jedi)
- https://github.com/NOAA-EMC/spack/pull/157 (Bug fixes and updates of maintainers for ESMF and MAPL)
- https://github.com/NOAA-EMC/spack/pull/159 (Update ESMF from develop) - this needs to be merged first

This is a good time to run the CI tests and the self-hosted build on Dom's macOS. Changes triggered by this:
- Update GitHub actions template for Dom's macOS (similar to what was done for the other templates when the updates from the official spack repository were brought over)
    - In addition had to remove `global-workflow-env` due to `met` build error's on Dom's macOS - see https://github.com/NOAA-EMC/spack-stack/issues/316
- Update documentation: `openmpi@4.1.4` is now the default/latest version, update "Known issues" section