### PR TITLE
Add ncview to jedi-base-env, add awscli and aws-parallelcluster to jedi-tools-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_ncview_awscli_aws-parallelcluster
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_ncview_awscli_aws-parallelcluster
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -61,6 +61,7 @@ spack:
     - libpng@1.6.37
     - mapl@2.22.0
     - nccmp@1.9.0.1
+    - ncview@2.1.8
     - netcdf-c@4.8.1
     - netcdf-cxx4@4.3.1
     - netcdf-fortran@4.5.4


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for spack for the changes described in https://github.com/NOAA-EMC/spack/pull/161. It also pins the version of `ncview` in the `skylab-dev` template to 2.1.8.

- waiting on https://github.com/NOAA-EMC/spack/pull/161
- fixes #153 
- fixes #276 

## Testing

- I tested the changes manually on my macOS (installed jedi-base-env and jedi-tools-env)