### PR TITLE
Update GNU container recipe, add Clang container

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_xarray_f90nml
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_xarray_f90nml
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/container_prebuild_docker_and_singularity
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/container_prebuild_docker_and_singularity
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -1,0 +1,23 @@
+## Overview
+
+To avoid hardcoding specs in the generic container recipes, we keep the specs list empty (`specs: []`) and manually add the specs for the particular spack-stack release and application as listed below, *after* running `spack stack create ctr`.
+
+### spack-stack-1.1.0 / skylab-2.0.0 containers
+```
+  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
+    jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
+    bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
+    fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
+    gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
+    libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
+    netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
+    parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,
+    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
+    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
+    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
+    # Don't build ESMF and MAPL for now:
+    # https://github.com/JCSDA-internal/MPAS-Model/issues/38
+    # https://github.com/NOAA-EMC/spack-stack/issues/326
+    # esmf@8.3.0b09, mapl@2.12.3
+```

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -67,13 +67,14 @@ spack:
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
     bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
     gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
-    parallel-netcdf@1.12.2, parallelio@2.5.4, py-numpy@1.22.3, py-pandas@1.4.0, py-scipy@1.8.0,
-    py-shapely@1.8.0, sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
+    parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,
+    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
+    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -100,8 +100,8 @@ spack:
     images:
       os: ubuntu:20.04
       spack:
-        url: https://github.com/climbfuji/spack
-        ref: feature/container_prebuild_docker_and_singularity
+        url: https://github.com/noaa-emc/spack
+        ref: jcsda_emc_spack_stack
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -65,14 +65,18 @@ spack:
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
     bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0, esmf@8.3.0b09,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
     gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
-    libpng@1.6.37, mapl@2.12.3, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
+    libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.4, py-numpy@1.22.3, py-pandas@1.4.0, py-scipy@1.8.0,
     py-shapely@1.8.0, sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
+    # Don't build ESMF and MAPL for now:
+    # https://github.com/JCSDA-internal/MPAS-Model/issues/38
+    # https://github.com/NOAA-EMC/spack-stack/issues/326
+    # esmf@8.3.0b09, mapl@2.12.3
 
   container:
 
@@ -99,7 +103,6 @@ spack:
         resolve_sha: false
 
     # Whether or not to strip binaries
-    #strip: true
     strip: false
 
     ## Additional system packages that are needed at runtime

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -64,22 +64,7 @@ spack:
         prefix: /usr
       version: [1.21.2]
 
-  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
-    jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
-    bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
-    fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
-    gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
-    libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
-    netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
-    parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,
-    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
-    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
-    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
-    # Don't build ESMF and MAPL for now:
-    # https://github.com/JCSDA-internal/MPAS-Model/issues/38
-    # https://github.com/NOAA-EMC/spack-stack/issues/326
-    # esmf@8.3.0b09, mapl@2.12.3
+  specs: []
 
   container:
 

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -116,6 +116,7 @@ spack:
       - make
       - qt5-default
       - libqt5svg5-dev
+      - qt5dxcb-plugin
       - wget
 
       final:
@@ -130,6 +131,7 @@ spack:
       - make
       - qt5-default
       - libqt5svg5-dev
+      - qt5dxcb-plugin
       - wget
       # Implicitly included in build step
       - build-essential

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -19,7 +19,9 @@ spack:
       operating_system: ubuntu20.04
       target: any
       modules: []
-      environment: {}
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: '/usr/lib/llvm-10/lib'
       extra_rpaths: []
 
   # Basic package config from configs/common/packages.yaml
@@ -110,6 +112,7 @@ spack:
       build:
       - clang-10
       - libclang-10-dev
+      - libc++-10-dev
       - cpp
       - g++
       - gcc
@@ -125,6 +128,7 @@ spack:
       final:
       - clang-10
       - libclang-10-dev
+      - libc++-10-dev
       - cpp
       - g++
       - gcc
@@ -155,20 +159,32 @@ spack:
       pre_build: |
         #Create symbolic links for clang compilers
         RUN cd /usr/bin && \
-        ln -sf clang-10 clang && \
-        ln -sf clang++-10 clang++ && \
-        ln -sf clang-cpp-10 clang-cpp
+        ln -svf clang-10 clang && \
+        ln -svf clang++-10 clang++ && \
+        ln -svf clang-cpp-10 clang-cpp && \
+        cd /usr/lib/llvm-10/lib && \
+        ln -svf libc++abi.so.1.0 libc++abi.so
       pre_final: |
         #Set environment variables for installing tzdata
-        ENV DEBIAN_FRONTEND=noninteractive &&\
-        TZ=Etc/UTC
+        ENV DEBIAN_FRONTEND=noninteractive && \
+        TZ=Etc/UTC && \
+        #Create symbolic links for clang compilers
+        RUN cd /usr/bin && \
+        ln -svf clang-10 clang && \
+        ln -svf clang++-10 clang++ && \
+        ln -svf clang-cpp-10 clang-cpp && \
+        cd /usr/lib/llvm-10/lib && \
+        ln -svf libc++abi.so.1.0 libc++abi.so
       final: |
         #Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
-        echo "ulimit -s unlimited" >> ~nonroot/.bashrc && \
-        echo "ulimit -v unlimited" >> ~nonroot/.bashrc && \
-        printf "[credential]\n    helper = cache --timeout=7200\n" >> ~nonroot/.gitconfig && \
-        chown -R nonroot:nonroot ~nonroot/.gitconfig
+        echo "ulimit -s unlimited" >> /home/nonroot/.bashrc && \
+        echo "ulimit -v unlimited" >> /home/nonroot/.bashrc && \
+        echo "export CC=clang" >> /home/nonroot/.bashrc && \
+        echo "export CXX=clang++" >> /home/nonroot/.bashrc && \
+        echo "export FC=gfortran" >> /home/nonroot/.bashrc && \
+        printf "[credential]\n    helper = cache --timeout=7200\n" >> /home/nonroot/.gitconfig && \
+        chown -R nonroot:nonroot /home/nonroot/.gitconfig
 
     # Labels for the image
     labels:

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -166,8 +166,9 @@ spack:
         ln -svf libc++abi.so.1.0 libc++abi.so
       pre_final: |
         #Set environment variables for installing tzdata
-        ENV DEBIAN_FRONTEND=noninteractive && \
-        TZ=Etc/UTC && \
+        ENV DEBIAN_FRONTEND=noninteractive
+        ENV TZ=Etc/UTC
+      final: |
         #Create symbolic links for clang compilers
         RUN cd /usr/bin && \
         ln -svf clang-10 clang && \
@@ -175,7 +176,6 @@ spack:
         ln -svf clang-cpp-10 clang-cpp && \
         cd /usr/lib/llvm-10/lib && \
         ln -svf libc++abi.so.1.0 libc++abi.so
-      final: |
         #Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
         echo "ulimit -s unlimited" >> /home/nonroot/.bashrc && \

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -1,0 +1,171 @@
+spack:
+  concretizer:
+    unify: true
+  view: false
+
+  config:
+    build_jobs: 2
+    connect_timeout: 60
+
+  compilers:
+  - compiler:
+      spec: clang@10.0.0
+      paths:
+        cc: /usr/bin/clang
+        cxx: /usr/bin/clang++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: ubuntu20.04
+      target: any
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  # Basic package config from configs/common/packages.yaml
+  # Additional package config for container
+  packages:
+    all:
+      providers:
+        mpi: [mpich@4.0.2]
+      compiler: [clang@10.0.0]
+    gcc:
+      buildable: false
+      externals:
+      - spec: gcc@9.4.0
+        prefix: /usr
+    git:
+      buildable: false
+      externals:
+      - spec: git@2.25.1~tcltk
+        prefix: /usr
+    git-lfs:
+      buildable: false
+      externals:
+      - spec: git-lfs@2.9.2
+        prefix: /usr
+    llvm:
+      buildable: false
+      externals:
+      - spec: llvm@10.0.0 +clang
+        prefix: /usr
+    qt:
+      buildable: false
+      externals:
+      - spec: qt@5.12.8
+        prefix: /usr
+      version: [5.15.3]
+    wget:
+      buildable: false
+      externals:
+      - spec: wget@1.20.3
+        prefix: /usr
+      version: [1.21.2]
+
+  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
+    jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
+    bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0, esmf@8.3.0b09,
+    fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
+    gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
+    libpng@1.6.37, mapl@2.12.3, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
+    netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
+    parallel-netcdf@1.12.2, parallelio@2.5.4, py-numpy@1.22.3, py-pandas@1.4.0, py-scipy@1.8.0,
+    py-shapely@1.8.0, sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
+    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
+
+  container:
+
+    # Select the format of the recipe e.g. docker,
+    # singularity or anything else that is currently supported
+    format: docker
+    # How to use:
+    #$ spack containerize > Dockerfile
+    #$ docker build -t myimage .
+    #$ docker run -it myimage
+
+    #format: singularity
+    # How to use:
+    #$ spack containerize > hdf5.def
+    #$ sudo singularity build hdf5.sif hdf5.def
+
+    # Sets the base images for the stages where Spack builds the
+    # software or where the software gets installed after being built..
+    images:
+      os: ubuntu:20.04
+      spack:
+        url: https://github.com/climbfuji/spack
+        ref: feature/container_prebuild_docker_and_singularity
+        resolve_sha: false
+
+    # Whether or not to strip binaries
+    #strip: true
+    strip: false
+
+    ## Additional system packages that are needed at runtime
+    os_packages:
+      build:
+      - clang-10
+      - libclang-10-dev
+      - cpp
+      - g++
+      - gcc
+      - gfortran
+      - git
+      - git-lfs
+      - make
+      - qt5-default
+      - libqt5svg5-dev
+      - wget
+
+      final:
+      - clang-10
+      - libclang-10-dev
+      - cpp
+      - g++
+      - gcc
+      - gfortran
+      - git
+      - git-lfs
+      - make
+      - qt5-default
+      - libqt5svg5-dev
+      - wget
+      # Implicitly included in build step
+      - build-essential
+      - ca-certificates
+      - curl
+      - file
+      - gnupg2
+      - iproute2
+      - locales
+      - python3
+      - python3-pip
+      - python3-setuptools
+      - unzip
+      - vim
+
+    # Extra instructions
+    extra_instructions:
+      pre_build: |
+        #Create symbolic links for clang compilers
+        RUN cd /usr/bin && \
+        ln -sf clang-10 clang && \
+        ln -sf clang++-10 clang++ && \
+        ln -sf clang-cpp-10 clang-cpp
+      pre_final: |
+        #Set environment variables for installing tzdata
+        ENV DEBIAN_FRONTEND=noninteractive &&\
+        TZ=Etc/UTC
+      final: |
+        #Make a non-root user:nonroot / group:nonroot for running MPI
+        RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
+        echo "ulimit -s unlimited" >> ~nonroot/.bashrc && \
+        echo "ulimit -v unlimited" >> ~nonroot/.bashrc && \
+        printf "[credential]\n    helper = cache --timeout=7200\n" >> ~nonroot/.gitconfig && \
+        chown -R nonroot:nonroot ~nonroot/.gitconfig
+
+    # Labels for the image
+    labels:
+      app: ""
+      mpi: "mpich"

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -60,14 +60,18 @@ spack:
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
     bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0, esmf@8.3.0b09,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
     gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
-    libpng@1.6.37, mapl@2.12.3, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
+    libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.4, py-numpy@1.22.3, py-pandas@1.4.0, py-scipy@1.8.0,
     py-shapely@1.8.0, sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
+    # Don't build ESMF and MAPL for now:
+    # https://github.com/JCSDA-internal/MPAS-Model/issues/38
+    # https://github.com/NOAA-EMC/spack-stack/issues/326
+    # esmf@8.3.0b09, mapl@2.12.3
 
   container:
 

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -145,8 +145,8 @@ spack:
     extra_instructions:
       pre_final: |
         #Set environment variables for installing tzdata
-        ENV DEBIAN_FRONTEND=noninteractive &&\
-        TZ=Etc/UTC
+        ENV DEBIAN_FRONTEND=noninteractive
+        ENV TZ=Etc/UTC
       final: |
         #Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -57,22 +57,7 @@ spack:
         prefix: /usr
       version: [1.21.2]
 
-  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
-    jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
-    bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
-    fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
-    gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
-    libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
-    netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
-    parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,
-    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
-    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
-    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
-    # Don't build ESMF and MAPL for now:
-    # https://github.com/JCSDA-internal/MPAS-Model/issues/38
-    # https://github.com/NOAA-EMC/spack-stack/issues/326
-    # esmf@8.3.0b09, mapl@2.12.3
+  specs: []
 
   container:
 

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -93,8 +93,8 @@ spack:
     images:
       os: ubuntu:20.04
       spack:
-        url: https://github.com/climbfuji/spack
-        ref: feature/container_prebuild_docker_and_singularity
+        url: https://github.com/noaa-emc/spack
+        ref: jcsda_emc_spack_stack
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -150,12 +150,19 @@ spack:
       final: |
         #Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
-        echo "ulimit -s unlimited" >> ~nonroot/.bashrc && \
-        echo "ulimit -v unlimited" >> ~nonroot/.bashrc && \
-        printf "[credential]\n    helper = cache --timeout=7200\n" >> ~nonroot/.gitconfig && \
-        mkdir ~nonroot/.openmpi && \
-        echo "rmaps_base_oversubscribe = 1" >> ~nonroot/.openmpi/mca-params.conf && \
-        chown -R nonroot:nonroot ~nonroot/.gitconfig ~nonroot/.openmpi
+        echo "ulimit -s unlimited" >> /home/nonroot/.bashrc && \
+        echo "ulimit -v unlimited" >> /home/nonroot/.bashrc && \
+        echo "export CC=gcc" >> /home/nonroot/.bashrc && \
+        echo "export CXX=g++" >> /home/nonroot/.bashrc && \
+        echo "export FC=gfortran" >> /home/nonroot/.bashrc && \
+        printf "[credential]\n    helper = cache --timeout=7200\n" >> /home/nonroot/.gitconfig && \
+        mkdir /home/nonroot/.openmpi && \
+        echo "rmaps_base_oversubscribe = 1" >> /home/nonroot/.openmpi/mca-params.conf && \
+        chown -R nonroot:nonroot /home/nonroot/.gitconfig /home/nonroot/.openmpi && \
+        #Also set the necessary environment variables to run as root && \
+        echo "export OMPI_ALLOW_RUN_AS_ROOT=1" >> /root/.bashrc && \
+        echo "export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1" >> /root/.bashrc && \
+        echo "export OMPI_MCA_rmaps_base_oversubscribe=1" >> /root/.bashrc
 
     # Labels for the image
     labels:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -108,6 +108,7 @@ spack:
       - make
       - qt5-default
       - libqt5svg5-dev
+      - qt5dxcb-plugin
       - wget
 
       final:
@@ -120,6 +121,7 @@ spack:
       - make
       - qt5-default
       - libqt5svg5-dev
+      - qt5dxcb-plugin
       - wget
       # Implicitly included in build step
       - build-essential

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -16,8 +16,8 @@ spack:
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
       flags: {}
-      operating_system: any
-      target: x86_64
+      operating_system: ubuntu20.04
+      target: any
       modules: []
       environment: {}
       extra_rpaths: []
@@ -25,6 +25,10 @@ spack:
   # Basic package config from configs/common/packages.yaml
   # Additional package config for container
   packages:
+    all:
+      providers:
+        mpi: [openmpi@4.1.4]
+      compiler: [gcc@9.4.0]
     gcc:
       buildable: false
       externals:
@@ -52,10 +56,6 @@ spack:
       - spec: wget@1.20.3
         prefix: /usr
       version: [1.21.2]
-    all:
-      providers:
-        mpi: [openmpi@4.1.4]
-      compiler: [gcc@9.4.0]
 
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
@@ -94,7 +94,7 @@ spack:
         resolve_sha: false
 
     # Whether or not to strip binaries
-    strip: true
+    strip: false
 
     ## Additional system packages that are needed at runtime
     os_packages:
@@ -137,6 +137,10 @@ spack:
 
     # Extra instructions
     extra_instructions:
+      pre_final: |
+        #Set environment variables for installing tzdata
+        ENV DEBIAN_FRONTEND=noninteractive &&\
+        TZ=Etc/UTC
       final: |
         #Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -1,6 +1,6 @@
 spack:
   concretizer:
-    unify: when_possible
+    unify: true
   view: false
 
   config:
@@ -9,12 +9,12 @@ spack:
 
   compilers:
   - compiler:
-      spec: gcc@10
+      spec: gcc@9.4.0
       paths:
-        cc: /usr/bin/gcc-10
-        cxx: /usr/bin/g++-10
-        f77: /usr/bin/gfortran-10
-        fc: /usr/bin/gfortran-10
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
       flags: {}
       operating_system: any
       target: x86_64
@@ -26,22 +26,48 @@ spack:
   # Additional package config for container
   packages:
     gcc:
-      buildable: False
+      buildable: false
       externals:
-      - spec: gcc@10
+      - spec: gcc@9.4.0
         prefix: /usr
     git:
-      buildable: False
+      buildable: false
       externals:
-      - spec: git@2
+      - spec: git@2.25.1~tcltk
         prefix: /usr
     git-lfs:
-      buildable: False
+      buildable: false
       externals:
-      - spec: git-lfs@2
+      - spec: git-lfs@2.9.2
         prefix: /usr
+    qt:
+      buildable: false
+      externals:
+      - spec: qt@5.12.8
+        prefix: /usr
+      version: [5.15.3]
+    wget:
+      buildable: false
+      externals:
+      - spec: wget@1.20.3
+        prefix: /usr
+      version: [1.21.2]
+    all:
+      providers:
+        mpi: [openmpi@4.1.4]
+      compiler: [gcc@9.4.0]
 
-  specs: []
+  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
+    jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
+    bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0, esmf@8.3.0b09,
+    fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
+    gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
+    libpng@1.6.37, mapl@2.12.3, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
+    netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
+    parallel-netcdf@1.12.2, parallelio@2.5.4, py-numpy@1.22.3, py-pandas@1.4.0, py-scipy@1.8.0,
+    py-shapely@1.8.0, sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
+    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
 
   container:
 
@@ -63,8 +89,8 @@ spack:
     images:
       os: ubuntu:20.04
       spack:
-        url: https://github.com/noaa-emc/spack
-        ref: jcsda_emc_spack_stack
+        url: https://github.com/climbfuji/spack
+        ref: feature/container_prebuild_docker_and_singularity
         resolve_sha: false
 
     # Whether or not to strip binaries
@@ -73,21 +99,41 @@ spack:
     ## Additional system packages that are needed at runtime
     os_packages:
       build:
-      - gcc-10
-      - g++-10
-      - gfortran-10
-      - cpp-10
+      - cpp
+      - g++
+      - gcc
+      - gfortran
       - git
       - git-lfs
       - make
+      - qt5-default
+      - libqt5svg5-dev
+      - wget
+
       final:
-      - gcc-10
-      - g++-10
-      - gfortran-10
-      - cpp-10
+      - cpp
+      - g++
+      - gcc
+      - gfortran
       - git
       - git-lfs
       - make
+      - qt5-default
+      - libqt5svg5-dev
+      - wget
+      # Implicitly included in build step
+      - build-essential
+      - ca-certificates
+      - curl
+      - file
+      - gnupg2
+      - iproute2
+      - locales
+      - python3
+      - python3-pip
+      - python3-setuptools
+      - unzip
+      - vim
 
     # Extra instructions
     extra_instructions:
@@ -100,21 +146,6 @@ spack:
         mkdir ~nonroot/.openmpi && \
         echo "rmaps_base_oversubscribe = 1" >> ~nonroot/.openmpi/mca-params.conf && \
         chown -R nonroot:nonroot ~nonroot/.gitconfig ~nonroot/.openmpi
-
-        RUN cd /usr/bin/ && \
-        ln -sf cpp-10 cpp && \
-        ln -sf gcc-10 gcc && \
-        ln -sf g++-10 g++ && \
-        ln -sf gfortran-10 gfortran
-
-    ## Extra instructions
-    #extra_instructions:
-    #  build:
-    #    # Needed for gfortran-11
-    #    RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-    #    RUN apt-get install gfortran-11
-    #  final: |
-    #    RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ "' >> ~/.bashrc
 
     # Labels for the image
     labels:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -60,13 +60,14 @@ spack:
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, jedi-ufs-env@1.0.0, bacio@2.4.1,
     bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 ~trans ~fftw, eigen@3.4.0,
+    eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0,
     gftl-shared@1.5.0, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
-    parallel-netcdf@1.12.2, parallelio@2.5.4, py-numpy@1.22.3, py-pandas@1.4.0, py-scipy@1.8.0,
-    py-shapely@1.8.0, sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
+    parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,
+    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
+    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.3-jedi.4]
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -70,10 +70,13 @@ spack:
     - odc@1.4.5
     - parallel-netcdf@1.12.2
     - parallelio@2.5.4
+    - py-f90nml@1.4.2
     - py-numpy@1.22.3
     - py-pandas@1.4.0
+    - py-pyyaml@6.0
     - py-scipy@1.8.0
     - py-shapely@1.8.0
+    - py-xarray@2022.3.0
     # DH* fake version number
     - r2d2@0.0.1
     # DH* fake version number

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -648,11 +648,9 @@ The following instructions were used to prepare a basic Ubuntu 20.04 system as i
    # Exit root session
    exit
 
-2. Log out and back in to be able to use the `lmod/lua` environment modules
+2. Log out and back in to be able to use the environment modules
 
 3. As regular user, set up the environment to build spack-stack environments
-
-.. code-block:: console
 
 This environment enables working with spack and building new software environments, as well as loading modules that are created by spack for building JEDI and UFS software.
 


### PR DESCRIPTION
## Description

1. Update ubuntu-gnu-openmpi docker recipe:
    - use the default `gnu@9.4.0` compiler instead of `gnu@10.0.0` - there were problems with both of them in the container build
    - use a few more external packages such as `qt@5` and `wget`
    - set environment variable `TZ` to avoid the container build hanging indefinitely in the final phase when installing `tzdata`
    - do not strip binaries after build to avoid warnings at end of build process
    - Use new functionality of extra instructions in pre-build and pre-final phases
2. Add ubuntu-clang-mpich docker recipe, almost identical to ubuntu-gnu-openmpi with minimal necessary changes
3. Add `README.md` in `configs/containers` to list the specs to install for each spack-stack release and application

**Notes**
- CI tests passed for https://github.com/NOAA-EMC/spack-stack/pull/320/commits/5f89cd003c7360c73a09e66f12d9e20610197aaf (this includes installing `py-f90nml` and `py-xarray`)
- Also fixed two small errors in `doc/source/Platforms.rst`
- Waiting on https://github.com/NOAA-EMC/spack/pull/162 (merged)
- Waiting on https://github.com/NOAA-EMC/spack/pull/169 (merged)
- Fixes https://github.com/NOAA-EMC/spack/issues/163