### PR TITLE
Use NCEPLIBS-bufr version 11.7.1 in development templates and as default version

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -22,7 +22,7 @@
       # but ecflow needs several libraries)
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
     bufr:
-      version: [11.7.0]
+      version: [11.7.1]
       variants: +python
     # Newer versions of CDO require the C++-17 standard, which doesn't
     # work with all compilers that are currently in use in spack-stack

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -23,7 +23,7 @@ spack:
       version: [1.78.0]
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
     bufr:
-      version: [11.7.1]
+      version: [11.7.0]
       variants: +python
     cmake:
       version: [3.22.1]

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -23,7 +23,7 @@ spack:
       version: [1.78.0]
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
     bufr:
-      version: [11.7.0]
+      version: [11.7.1]
       variants: +python
     cmake:
       version: [3.22.1]

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -27,7 +27,7 @@ spack:
     # Individual packages
     - bacio@2.4.1
     - bison@3.8.2
-    - bufr@11.7.0
+    - bufr@11.7.1
     - crtm@2.3.0
     - crtm@v2.3-jedi.4
     - ecbuild@3.6.5

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -31,7 +31,7 @@ spack:
   - parallelio@2.5.3
   - esmf@8.3.0b09
   - fms@2022.01
-  - bufr@11.7.0
+  - bufr@11.7.1
   - bacio@2.4.1
   - crtm@2.3.0
   - g2@3.4.5


### PR DESCRIPTION
This PR changes the NCEPLIBS-bufr version to 11.7.1 in the development templates, as well as in the default common/packages.yaml configuration.

I not completely sure I've got updated version number in all of the correct files - please double check this.

Please note that jcsda-internal/ioda-converters/pull/1006 is good with version 11.7.0, and it is subsequent PRs that require 11.7.1. If we already have 11.7.0 in the test containers, then we are good for PR 1006. However, if we don't have 11.7.0 in the test containers, then we might as well wait and update to 11.7.1.

Fixes #289 