### PR TITLE
Update S4 site config

### DIFF
--- a/configs/sites/s4/compilers.yaml
+++ b/configs/sites/s4/compilers.yaml
@@ -15,7 +15,7 @@ compilers:
     environment:
       prepend_path:
         PATH: '/data/prod/hpc-stack/gnu/9.3.0/bin'
-        LD_LIBRARY_PATH: '/data/prod/hpc-stack/gnu/9.3.0/lib64'
+        LD_LIBRARY_PATH: '/home/opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/compiler/lib/intel64_lin:/data/prod/hpc-stack/gnu/9.3.0/lib64'
         CPATH: '/data/prod/hpc-stack/gnu/9.3.0/include'
     extra_rpaths: []
 # Not yet tested:
@@ -29,6 +29,8 @@ compilers:
     flags: {}
     operating_system: centos7
     target: x86_64
+    modules:
+    - gnu/9.3.0
     prefix: /data/prod/hpc-stack/gnu/9.3.0
     modules: []
     environment: {}

--- a/configs/sites/s4/modules.yaml
+++ b/configs/sites/s4/modules.yaml
@@ -2,3 +2,6 @@ modules:
   default:
     enable::
     - lmod
+    lmod:
+      blacklist:
+      - ecflow

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -24,10 +24,10 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.7
-      prefix: /data/prod/jedi/spack-stack/miniconda-3.9.7
+    - spec: python@3.9.12
+      prefix: /data/prod/jedi/spack-stack/miniconda-3.9.12
       modules:
-      - miniconda/3.9.7
+      - miniconda/3.9.12
   # Versions 1.73+ don't compile on s4 (bootstrap.sh fails)
   boost:
     version:: [1.72.0]
@@ -78,6 +78,13 @@ packages:
     externals:
     - spec: doxygen@1.8.5+graphviz~mscgen
       prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4
+      prefix: /data/prod/jedi/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.11
@@ -166,8 +173,8 @@ packages:
       prefix: /usr
   qt:
     externals:
-    - spec: qt@5.15.3
-      prefix: /data/prod/jedi/spack-stack/qt-5.15.3
+    - spec: qt@5.9.7
+      prefix: /usr
   rsync:
     externals:
     - spec: rsync@3.1.2

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -241,22 +241,21 @@ Create modulefile ``/work2/06146/tg854455/frontera/spack-stack/modulefiles/git-l
 UW (Univ. of Wisconsin) S4
 ------------------------------
 
+gnu (module only)
+   The ``gnu/9.3.0`` module provided by the system administrators is broken (circular dependencies etc.). To create a usable version, copy ``/data/prod/hpc-stack/modulefiles/core/gnu/9.3.0.lua`` into directory ``/data/prod/jedi/spack-stack/modulefiles/gnu`.`
+
 miniconda
    Follow the instructions in :numref:`Section %s <Prerequisites_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
 
-qt (qt@5)
-   The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to 
-   :numref:`Section %s <Prerequisites_Qt5>` to install ``qt@5.15.2`` in ``/data/prod/jedi/spack-stack/qt-5.15.2``.
+ecflow
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `miniconda`, and loading the following modules, follow the instructions in :numref:`Section %s <Prerequisites_ecFlow>`.
 
 .. code-block:: console
 
    module purge
    module use /data/prod/jedi/spack-stack/modulefiles
-   module load miniconda/3.9.7
-   # Need a newer gcc compiler than the default OS compiler gcc-4.8.5
-   export PATH=/data/prod/hpc-stack/gnu/9.3.0/bin:$PATH
-   export LD_LIBRARY_PATH=/data/prod/hpc-stack/gnu/9.3.0/lib64:$LD_LIBRARY_PATH
-   export CPATH=/data/prod/hpc-stack/gnu/9.3.0/include:$CPATH
+   module load miniconda/3.9.12
+   module load gcc/9.3.0
 
 .. _MaintainersSection_Testing_New_Packages:
 

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -51,7 +51,7 @@ spack-stack-v1
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
 | TACC Frontera GNU                        | Dom Heinzeller            | ``/work2/06146/tg854455/frontera/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-9.1.0/install``            |
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
-| UW (Univ. of Wisc.) S4                   |                           | not yet supported - coming soon                                                                              |
+| UW (Univ. of Wisc.) S4                   | Dom Heinzeller            | ``/data/prod/jedi/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2021.5.0/install``                      |
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
 | Amazon Web Services AMI Ubuntu 20.04 GNU | Dom Heinzeller            | AMI: skylab-1.0.0-ubuntu20 - ``/home/ubuntu/spack-stack-v1/envs/skylab-1.0.0/install``                       |
 +------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -311,13 +311,13 @@ The following is required for building new spack environments and for using spac
    module load miniconda/3.9.12
    module load ecflow/5.8.4
 
-For ``spack-stack-1.0.1`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
 
    ulimit -s unlimited
    module use /data/prod/jedi/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2021.5.0/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.0
-   module load stack-python/
+   module load stack-python/3.9.12
    module available
 
 --------------------------------
@@ -695,7 +695,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
    # Red Hat: Do *not* execute the following line = do *not* use system curl, this breaks netcdf-c
    # Ubuntu: Execute the following line = use system curl and libssl
-   spack external find curl
+   spack external find --scope system curl
 
    # Skip qt@5 for now
    spack external find --scope system texlive

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -313,6 +313,8 @@ The following is required for building new spack environments and for using spac
 
 For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
 
+.. code-block:: console
+
    ulimit -s unlimited
    module use /data/prod/jedi/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2021.5.0/install/modulefiles/Core
    module load stack-intel/2021.5.0

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -302,16 +302,23 @@ For ``spack-stack-1.0.1`` with GNU, load the following modules after loading min
 UW (Univ. of Wisconsin) S4
 ------------------------------
 
-.. note::
-   ``spack-stack-1.0.0`` is currently not supported on this platform and will be added in the near future.
-
 The following is required for building new spack environments and for using spack to build and run software.
 
 .. code-block:: console
 
    module purge
    module use /data/prod/jedi/spack-stack/modulefiles
-   module load miniconda/3.9.7
+   module load miniconda/3.9.12
+   module load ecflow/5.8.4
+
+For ``spack-stack-1.0.1`` with Intel, load the following modules after loading miniconda and ecflow:
+
+   ulimit -s unlimited
+   module use /data/prod/jedi/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-2021.5.0/install/modulefiles/Core
+   module load stack-intel/2021.5.0
+   module load stack-intel-oneapi-mpi/2021.5.0
+   module load stack-python/
+   module available
 
 --------------------------------
 Amazon Web Services Ubuntu 20.04


### PR DESCRIPTION
## Description

This PR updates the S4 site config and associated documentation. I installed `spack-stack-1.0.2` using template `skylab-1.0.0` and used the site config from this PR (i.e. from develop). I verified that the `ecflow` GUI and the server work. I also built `jedi-bundle` and ran the `ctests`. A bunch of `soca` tests failed, but all others passed. The `soca` test failures come down to floating point mismatches compared to the reference data produced elsewhere, and the deltas look acceptable. Considering this good enough, i.e. the PR is ready to merge.
```
Test Val : 6.5488758500051123e+00
Ref  Val : 6.5488993098325086e+00
Delta    : 2.3459827396266064e-05
Relative tolerance: 6.5488875799188097e-06
Absolute tolerance: 0.0000000000000000e+00
```
No need to run CI tests - this PR only touches documentation and S4 site config files.

Fixes https://github.com/NOAA-EMC/spack-stack/issues/324