### PR TITLE
Bump parallelio, eccodes, py-eccodes versions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_eccodes_py-eccodes
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_eccodes_py-eccodes
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -178,7 +178,7 @@
     py-click:
       version: [8.0.3]
     py-eccodes:
-      version: [1.5.0]
+      version: [1.4.2]
     py-h5py:
       version: [3.6.0]
     py-netcdf4:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -39,7 +39,7 @@
     ecbuild:
       version: [3.6.5]
     eccodes:
-      version: [2.21.0]
+      version: [2.27.0]
       #variants: +netcdf
     ecflow:
       version: [5.8.3]
@@ -158,7 +158,7 @@
     openmpi:
       variants: +internal-hwloc +two_level_namespace
     parallelio:
-      version: [2.5.4]
+      version: [2.5.7]
       variants: +pnetcdf
     parallel-netcdf:
       version: [1.12.2]
@@ -178,7 +178,7 @@
     py-click:
       version: [8.0.3]
     py-eccodes:
-      version: [1.3.2]
+      version: [1.5.0]
     py-h5py:
       version: [3.6.0]
     py-netcdf4:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -150,7 +150,7 @@ spack:
     py-click:
       version: [8.0.3]
     py-eccodes:
-      version: [1.5.0]
+      version: [1.4.2]
     py-h5py:
       version: [3.6.0]
     py-netcdf4:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -38,7 +38,7 @@ spack:
     ecbuild:
       version: [3.6.5]
     eccodes:
-      version: [2.21.0]
+      version: [2.27.0]
     eckit:
       version: [1.19.0]
       variants: linalg=eigen,lapack compression=lz4,bzip2
@@ -132,7 +132,7 @@ spack:
       version: [0.3.19]
       variants: +noavx512
     parallelio:
-      version: [2.5.4]
+      version: [2.5.7]
       variants: +pnetcdf
     parallel-netcdf:
       version: [1.12.2]
@@ -150,7 +150,7 @@ spack:
     py-click:
       version: [8.0.3]
     py-eccodes:
-      version: [1.3.2]
+      version: [1.5.0]
     py-h5py:
       version: [3.6.0]
     py-netcdf4:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -70,7 +70,7 @@ spack:
     - odc@1.4.5
     - parallel-netcdf@1.12.2
     - parallelio@2.5.7
-    - py-eccodes@1.5.0
+    - py-eccodes@1.4.2
     - py-numpy@1.22.3
     - py-pandas@1.4.0
     - py-scipy@1.8.0

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -31,7 +31,7 @@ spack:
     - crtm@2.3.0
     - crtm@v2.3-jedi.4
     - ecbuild@3.6.5
-    - eccodes@2.25.0
+    - eccodes@2.27.0
     - ecflow@5
     - eckit@1.19.0
     - ecmwf-atlas@0.29.0
@@ -69,7 +69,8 @@ spack:
     - nlohmann-json@3.10.5
     - odc@1.4.5
     - parallel-netcdf@1.12.2
-    - parallelio@2.5.4
+    - parallelio@2.5.7
+    - py-eccodes@1.5.0
     - py-numpy@1.22.3
     - py-pandas@1.4.0
     - py-scipy@1.8.0


### PR DESCRIPTION
## Description

Update eccodes to `2.27.0` and `py-eccodes` to `1.4.2` as requested by @gthompsnJCSDA. Also bump `parallelio` to `2.5.7`.

Tested to work on Orion with intel and on macOS with apple-clang, in addition to the CI tests (which test building only).

Waiting on https://github.com/NOAA-EMC/spack/pull/170

**Note.** Unit test failure https://github.com/NOAA-EMC/spack-stack/actions/runs/3047150784/jobs/4910815663 will be fixed in one of the next spack (submodule) PRs (https://github.com/NOAA-EMC/spack/pull/171)