### PR TITLE
Add gsibec versions 1.0.3 and 1.0.4, make 1.0.4 the default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_gsibec
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_gsibec
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -94,7 +94,7 @@
     grib-util:
       version: [1.2.3]
     gsibec:
-      version: [1.0.4]
+      version: [1.0.5]
     gsl-lite:
       version: [0.37.0]
     hdf:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -94,7 +94,7 @@
     grib-util:
       version: [1.2.3]
     gsibec:
-      version: [1.0.2]
+      version: [1.0.4]
     gsl-lite:
       version: [0.37.0]
     hdf:

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -9,7 +9,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
     eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
-    gsibec@1.0.4, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
+    gsibec@1.0.5, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -9,7 +9,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     bison@3.8.2, bufr@11.7.0, ecbuild@3.6.5, eccodes@2.25.0, ecflow@5,
     eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
-    gsibec@1.0.2, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
+    gsibec@1.0.4, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.4, py-f90nml@1.4.2, py-numpy@1.22.3,

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -76,7 +76,7 @@ spack:
     grib-util:
       version: [1.2.3]
     gsibec:
-      version: [1.0.4]
+      version: [1.0.5]
     gsl-lite:
       version: [0.37.0]
     hdf:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -76,7 +76,7 @@ spack:
     grib-util:
       version: [1.2.3]
     gsibec:
-      version: [1.0.2]
+      version: [1.0.4]
     gsl-lite:
       version: [0.37.0]
     hdf:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -53,7 +53,7 @@ spack:
     #- gdal@3.4.3
     #- geos@3.9.1
     - gftl-shared@1.5.0
-    - gsibec@1.0.2
+    - gsibec@1.0.5
     - hdf5@1.12.1
     - hdf@4.2.15
     - ip@3.3.3


### PR DESCRIPTION
## Description

Add gsibec versions 1.0.3 and 1.0.4, make 1.0.4 the default.

## Issues

Fixes https://github.com/NOAA-EMC/spack-stack/issues/346

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/175

## Testing

- Versions 1.0.3 and 1.0.4 build on my macOS with apple-clang and openmpi.
- CI tests: **STILL RUNNING**