### PR TITLE
Bug fix for py-scipy with Intel (error loading scipy with Intel compilers)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/scipy_intel
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/bugfix_scipy_from_spack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
   #url = https://github.com/NOAA-EMC/spack
   #branch = jcsda_emc_spack_stack
   url = https://github.com/climbfuji/spack
-  branch = bugfix/scipy_intel
+  branch = feature/bugfix_scipy_from_spack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -144,6 +144,8 @@
       version: [4.3.1]
     netcdf-fortran:
       version: [4.5.4]
+    # ninja - when adding information here, also check Cheyenne
+    # and Discover site configs
     nlohmann-json:
       version: [3.10.5]
     nlohmann-json-schema-validator:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -131,6 +131,8 @@
     nco:
       version: [5.0.6]
       variants: ~doc
+    # ncview - when adding information here, also check Orion
+    # and Discover site configs
     nemsio:
       version: [2.5.2]
     nemsiogfs:

--- a/configs/sites/discover/modules.yaml
+++ b/configs/sites/discover/modules.yaml
@@ -5,3 +5,4 @@ modules:
     lmod:
       blacklist:
       - ecflow
+      - ncview

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -165,6 +165,9 @@ packages:
     externals:
     - spec: openssh@7.2p2
       prefix: /usr
+  # Old re2c on Discover unable to build newer versions of ninja
+  ninja:
+    version:: [1.10.2]
   openssl:
     externals:
     - spec: openssl@1.0.2j-fips

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -165,6 +165,11 @@ packages:
     externals:
     - spec: openssh@7.2p2
       prefix: /usr
+  ncview:
+    externals:
+    - spec: ncview@2.1.7
+      modules:
+      - ncview/2.1.7
   # Old re2c on Discover unable to build newer versions of ninja
   ninja:
     version:: [1.10.2]

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -75,6 +75,7 @@ The following is required for building new spack environments and for using spac
    module purge
    module use /work/noaa/da/role-da/spack-stack/modulefiles
    module load miniconda/3.9.7
+   module load ncview/2.1.5
 
 For ``spack-stack-1.0.0`` with Intel, load the following modules after loading miniconda and ecflow:
 
@@ -109,6 +110,7 @@ The following is required for building new spack environments and for using spac
    module purge
    module use /discover/swdev/jcsda/spack-stack/modulefiles
    module load miniconda/3.9.7
+   module load ncview/2.1.7
 
 For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
 


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack-stack/issues/291 by updating the submodule pointer for spack for the changes described in https://github.com/NOAA-EMC/spack/pull/178. Also needed to pin `ninja` to a slightly older version due to incompatibilities with Discover's old `re2c` (exactly the same change was needed on Cheyenne a few weeks ago).

Tested on Discover with Intel, for which the problem was originally reported in https://github.com/NOAA-EMC/spack-stack/issues/291. CI tests all passed for https://github.com/NOAA-EMC/spack-stack/pull/350/commits/3ac6cc15ba24c36e12f39e189db52044180d4547

Waiting on https://github.com/NOAA-EMC/spack/pull/178
