### PR TITLE
Update ecmwf-atlas to 0.30.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_ecmwf_atlas
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_ecmwf_atlas
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -47,7 +47,7 @@
       version: [1.19.0]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.29.0]
+      version: [0.30.0]
       variants: +fckit +trans
     ectrans:
       version: [develop]

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.6.5, eccodes@2.27.0, ecflow@5,
-    eckit@1.19.0, ecmwf-atlas@0.29.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
+    eckit@1.19.0, ecmwf-atlas@0.30.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.0.5, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -43,7 +43,7 @@ spack:
       version: [1.19.0]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.29.0]
+      version: [0.30.0]
       variants: +fckit +trans
     ectrans:
       version: [develop]

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -37,7 +37,7 @@ spack:
       version: [1.19.0]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.29.0]
+      version: [0.30.0]
       variants: +fckit +trans
     ectrans:
       version: [1.0.0]

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -34,7 +34,7 @@ spack:
     - eccodes@2.27.0
     - ecflow@5
     - eckit@1.19.0
-    - ecmwf-atlas@0.29.0
+    - ecmwf-atlas@0.30.0
     # DH* fake version number
     - ectrans@1.0.0
     - eigen@3.4.0


### PR DESCRIPTION
## Description

Bump `ecmwf-atlas` to version `0.30.0` and update submodule pointer for `spack` for the corresponding changes.

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/177

## Issues

Fixes #349 