### PR TITLE
Update jedi-cmake to version 1.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/jedi-cmake-140
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/jedi-cmake-140
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -110,7 +110,7 @@
     jasper:
       version: [2.0.32]
     jedi-cmake:
-      version: [1.3.0]
+      version: [1.4.0]
     jpeg:
       version: [9.1.0]
     landsfcutil:

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -8,7 +8,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.6.5, eccodes@2.27.0, ecflow@5,
     eckit@1.19.0, ecmwf-atlas@0.30.0 +trans ~fftw, ectrans@1.0.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
-    gsibec@1.0.5, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.3.0,
+    gsibec@1.0.5, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.2, py-numpy@1.22.3,

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -92,7 +92,7 @@ spack:
     jasper:
       version: [2.0.32]
     jedi-cmake:
-      version: [1.3.0]
+      version: [1.4.0]
     jpeg:
       version: [9.1.0]
     landsfcutil:

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -84,7 +84,7 @@ spack:
     jasper:
       version: [2.0.25]
     jedi-cmake:
-      version: [1.3.0]
+      version: [1.4.0]
     jpeg:
       version: [9.1.0]
     landsfcutil:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -58,7 +58,7 @@ spack:
     - hdf@4.2.15
     - ip@3.3.3
     - jasper@2.0.32
-    - jedi-cmake@1.3.0
+    - jedi-cmake@1.4.0
     - libpng@1.6.37
     - mapl@2.22.0
     - nccmp@1.9.0.1


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack-stack/issues/352

Waiting on https://github.com/NOAA-EMC/spack/pull/179

**Note.** It seems that GitHub actions changed something in their Linux images and now the build of `nccmp` is failing for Ubuntu+GCC (and maybe others, still running). This is unrelated to this PR, I checked https://github.com/NOAA-EMC/spack-stack/actions/runs/3113820345/jobs/5048922763 and `jedi-cmake@1.4.0` built fine.

I suggest to defer fixing the CI failure for `nccmp` as a bug fix in the release branch.