### PR TITLE
release/1.1.0: update .gitmodules, add skylab-2.0.0 template

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -54,8 +54,9 @@ runs:
         # Needed for the following apt-get install calls to work
         sudo apt-get update
 
-        # Install Curl headers. Executable exists by default in spack external find.
-        sudo apt-get install libcurl4-openssl-dev
+        # Don't do this, breaks several packages
+        ## Install Curl headers. Executable exists by default in spack external find.
+        #sudo apt-get install libcurl4-openssl-dev
 
         # Install git-lfs to avoid compilation errors of "go" with Intel
         sudo apt-get install git-lfs
@@ -214,8 +215,10 @@ runs:
       # Make homebrew qt@5 detectable on macOS
       PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt
 
-      # Make homebrew curl detectable on macOS
-      PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
+      if [[ "$RUNNER_OS" == "macOS" ]]; then
+        # Make homebrew curl detectable on macOS
+        PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
+      fi
 
   - name: configure-options
     shell: bash

--- a/.github/workflows/macos-apple-clang.yaml
+++ b/.github/workflows/macos-apple-clang.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
+        template: [skylab-2.0.0, ufs-weather-model, ufs-srw-dev]
         spec: ['']
     runs-on: macos-latest
     steps:

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -13,7 +13,7 @@ on:
       template:
         description: 'Base spack.yaml template. Default is a complete JEDI-UFS environment.'
         required: true
-        default: 'skylab-dev'
+        default: 'skylab-2.0.0'
       specs:
         description: 'Which specs to add to the template. Default is none (empty string).'
         required: false
@@ -38,8 +38,8 @@ jobs:
       - name: create-env
         run: |
           source ./setup.sh
-          spack stack create env --site macos.default --template ${{ inputs.template || 'skylab-dev' }} --name ${{ inputs.template || 'skylab-dev' }}.macos-dom
-          spack env activate -d envs/${{ inputs.template || 'skylab-dev' }}.macos-dom
+          spack stack create env --site macos.default --template ${{ inputs.template || 'skylab-2.0.0' }} --name ${{ inputs.template || 'skylab-2.0.0' }}.macos-dom
+          spack env activate -d envs/${{ inputs.template || 'skylab-2.0.0' }}.macos-dom
           spack add ${{ inputs.specs || '' }}
 
           spack external find

--- a/.github/workflows/macos-gcc.yaml
+++ b/.github/workflows/macos-gcc.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
+        template: [skylab-2.0.0, ufs-weather-model, ufs-srw-dev]
         spec: ['']
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ubuntu-gcc.yaml
+++ b/.github/workflows/ubuntu-gcc.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
+        template: [skylab-2.0.0, ufs-weather-model, ufs-srw-dev]
         spec: ['']
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ubuntu-intel.yaml
+++ b/.github/workflows/ubuntu-intel.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
+        template: [skylab-2.0.0, ufs-weather-model, ufs-srw-dev]
         spec: ['']
     runs-on: ubuntu-latest
     steps:

--- a/configs/templates/skylab-2.0.0/spack.yaml
+++ b/configs/templates/skylab-2.0.0/spack.yaml
@@ -1,0 +1,93 @@
+spack:
+  concretizer:
+    unify: when_possible
+
+  view: false
+
+  packages:
+    fiat:
+      version: [1.0.0]
+    ectrans:
+      version: [1.0.0]
+
+  view: false
+  include: []
+
+  specs:
+    # Virtual environment packages
+    - base-env@1.0.0
+    - jedi-base-env@1.0.0
+    - jedi-ewok-env@1.0.0
+    - jedi-fv3-env@1.0.0
+    - jedi-mpas-env@1.0.0
+    - jedi-ufs-env@1.0.0
+    - jedi-um-env@1.0.0
+    - soca-env@1.0.0
+
+    # Individual packages
+    - bacio@2.4.1
+    - bison@3.8.2
+    - bufr@11.7.1
+    - crtm@2.3.0
+    - crtm@2.4.0
+    - crtm@v2.3-jedi.4
+    - crtm@v2.4_jedi
+    - ecbuild@3.6.5
+    - eccodes@2.27.0
+    - ecflow@5
+    - eckit@1.19.0
+    - ecmwf-atlas@0.30.0
+    # DH* fake version number
+    - ectrans@1.0.0
+    - eigen@3.4.0
+    - esmf@8.3.0b09+pio
+    # DH* fake version number
+    #- ewok@0.0.1
+    - fckit@0.9.5
+    # DH* fake version number
+    - fiat@1.0.0
+    - flex@2.6.4
+    - fms@2022.01
+    # DH* fake version number
+    - fms@release-jcsda
+    - g2@3.4.5
+    - g2tmpl@1.10.0
+    #- gdal@3.4.3
+    #- geos@3.9.1
+    - gftl-shared@1.5.0
+    - gsibec@1.0.5
+    - hdf5@1.12.1
+    - hdf@4.2.15
+    - ip@3.3.3
+    - jasper@2.0.32
+    - jedi-cmake@1.4.0
+    - libpng@1.6.37
+    - mapl@2.22.0
+    - nccmp@1.9.0.1
+    - ncview@2.1.8
+    - netcdf-c@4.8.1
+    - netcdf-cxx4@4.3.1
+    - netcdf-fortran@4.5.4
+    - nlohmann-json-schema-validator@2.1.0
+    - nlohmann-json@3.10.5
+    - odc@1.4.5
+    - parallel-netcdf@1.12.2
+    - parallelio@2.5.7
+    - py-eccodes@1.4.2
+    - py-f90nml@1.4.2
+    - py-numpy@1.22.3
+    - py-pandas@1.4.0
+    - py-pyyaml@6.0
+    - py-scipy@1.8.0
+    - py-shapely@1.8.0
+    - py-xarray@2022.3.0
+    # DH* fake version number
+    #- r2d2@0.0.1
+    # DH* fake version number
+    - shumlib@macos_clang_linux_intel_port
+    #- solo@1.0.0
+    - sp@2.3.3
+    - udunits@2.2.28
+    - w3nco@2.4.1
+    - yafyaml@0.5.1
+    - zlib@1.2.12

--- a/configs/templates/skylab-2.0.0/spack.yaml
+++ b/configs/templates/skylab-2.0.0/spack.yaml
@@ -15,14 +15,12 @@ spack:
 
   specs:
     # Virtual environment packages
-    - base-env@1.0.0
-    - jedi-base-env@1.0.0
-    - jedi-ewok-env@1.0.0
-    - jedi-fv3-env@1.0.0
-    - jedi-mpas-env@1.0.0
-    - jedi-ufs-env@1.0.0
-    - jedi-um-env@1.0.0
-    - soca-env@1.0.0
+    - jedi-ewok-env
+    - jedi-fv3-env
+    - jedi-mpas-env
+    - jedi-ufs-env
+    - jedi-um-env
+    - soca-env
 
     # Individual packages
     - bacio@2.4.1

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -15,14 +15,12 @@ spack:
 
   specs:
     # Virtual environment packages
-    - base-env@1.0.0
-    - jedi-base-env@1.0.0
-    - jedi-ewok-env@1.0.0
-    - jedi-fv3-env@1.0.0
-    - jedi-mpas-env@1.0.0
-    - jedi-ufs-env@1.0.0
-    - jedi-um-env@1.0.0
-    - soca-env@1.0.0
+    - jedi-ewok-env
+    - jedi-fv3-env
+    - jedi-mpas-env
+    - jedi-ufs-env
+    - jedi-um-env
+    - soca-env
 
     # Individual packages
     - bacio@2.4.1


### PR DESCRIPTION
Three independent changes for the release branch only (not intended to be merged back to develop):

1. Template skylab-2.0.0 is required for the release branch only. It's a copy of the current skylab-dev template, but in addition contains the two older `crtm` versions (`2.3.0` and `v2.3-jedi.4`) so that users can choose between four versions altogether. The default is `2.4.0` for UFS and `v2.4-jedi` for JEDI.
2. Update `.gitmodules` to point to the release branch of the spack submodule.
3. Update CI tests to test the `skylab-2.0.0` template instead of `skylab-dev`.

Two additional changes that should find it's way back into develop:
1. Strip version numbers from virtual environment packages, and remove unnecessary ones (because they are implicitly required in the other env packages).
2. Bug fix for ubuntu CI tests - build curl instead of using OS curl (this also matches the instructions in readthedocs better). Fixes https://github.com/NOAA-EMC/spack-stack/issues/355
