### PR TITLE
release/1.1.0: Site config updates from installation of release/1.1.0 on HPCs, cloud, macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = release/1.1.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/jedicmake_git
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = release/1.1.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = release/1.1.0
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = release/1.1.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/jedicmake_git
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -93,7 +93,8 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        ref: jcsda_emc_spack_stack
+        # Todo: Update to final tag spack-stack-1.1.0 once available
+        ref: release/1.1.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -80,7 +80,8 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        ref: jcsda_emc_spack_stack
+        # Todo: Update to final tag spack-stack-1.1.0 once available
+        ref: release/1.1.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -94,7 +94,8 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        ref: jcsda_emc_spack_stack
+        # Todo: Update to final tag spack-stack-1.1.0 once available
+        ref: release/1.1.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -162,6 +162,10 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
+  libxpm:
+    externals:
+    - spec: libxpm@4.11.0
+      prefix: /usr
   m4:
     externals:
     - spec: m4@1.4.16

--- a/configs/sites/discover/modules.yaml
+++ b/configs/sites/discover/modules.yaml
@@ -5,4 +5,3 @@ modules:
     lmod:
       blacklist:
       - ecflow
-      - ncview

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -64,14 +64,16 @@ packages:
     externals:
     - spec: ccache@3.1.9
       prefix: /usr
-  cmake:
-    externals:
-    - spec: cmake@3.5.2
-      prefix: /usr
-    - spec: cmake@3.21.0
-      prefix: /usr/local/other/cmake/3.21.0
-      modules:
-      - cmake/3.21.0
+  # Don't use external cmake, this confuses the spack concretizer
+  # leading to duplicate packages being installed.
+  #cmake:
+  #  externals:
+  #  - spec: cmake@3.5.2
+  #    prefix: /usr
+  #  - spec: cmake@3.21.0
+  #    prefix: /usr/local/other/cmake/3.21.0
+  #    modules:
+  #    - cmake/3.21.0
   cpio:
     externals:
     - spec: cpio@2.11

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -153,6 +153,10 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
+  libxpm:
+    externals:
+    - spec: libxpm@4.11.0
+      prefix: /usr
   m4:
     externals:
     - spec: m4@1.4.16
@@ -165,11 +169,6 @@ packages:
     externals:
     - spec: openssh@7.2p2
       prefix: /usr
-  ncview:
-    externals:
-    - spec: ncview@2.1.7
-      modules:
-      - ncview/2.1.7
   # Old re2c on Discover unable to build newer versions of ninja
   ninja:
     version:: [1.10.2]

--- a/configs/sites/gaea/packages.yaml
+++ b/configs/sites/gaea/packages.yaml
@@ -157,6 +157,10 @@ packages:
     externals:
     - spec: libtool@2.4.6
       prefix: /usr
+  libxpm:
+    externals:
+    - spec: libxpm@4.11.0
+      prefix: /usr
   lustre:
     externals:
     - spec: lustre@2.12.0.5_cray_362_g447a87c

--- a/configs/sites/orion/modules.yaml
+++ b/configs/sites/orion/modules.yaml
@@ -5,4 +5,3 @@ modules:
     lmod:
       blacklist:
       - ecflow
-      - ncview

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -231,7 +231,8 @@ packages:
   wget:
     externals:
     - spec: wget@1.14
-      prefix: /usr  xz:
+      prefix: /usr
+  xz:
     externals:
     - spec: xz@5.2.2
       prefix: /usr

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -164,6 +164,10 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
+  libxpm:
+    externals:
+    - spec: libxpm@4.11.0
+      prefix: /usr
   lustre:
     externals:
     - spec: lustre@2.12.6_ddn51
@@ -176,11 +180,6 @@ packages:
     externals:
     - spec: ncurses@5.9.20130511+termlib abi=5
       prefix: /usr
-  ncview:
-    externals:
-    - spec: ncview@2.1.5
-      modules:
-      - ncview/2.1.5
   openssh:
     externals:
     - spec: openssh@7.4p1
@@ -232,8 +231,7 @@ packages:
   wget:
     externals:
     - spec: wget@1.14
-      prefix: /usr
-  xz:
+      prefix: /usr  xz:
     externals:
     - spec: xz@5.2.2
       prefix: /usr

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -57,10 +57,12 @@ packages:
     externals:
     - spec: bzip2@1.0.6
       prefix: /usr
-  cmake:
-    externals:
-    - spec: cmake@3.20.5
-      prefix: /usr
+  # Don't use external cmake, this confuses the spack concretizer
+  # leading to duplicate packages being installed
+  #cmake:
+  #  externals:
+  #  - spec: cmake@3.20.5
+  #    prefix: /usr
   cpio:
     externals:
     - spec: cpio@2.11

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -147,6 +147,10 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
+  libxpm:
+    externals:
+    - spec: libxpm@4.11.0
+      prefix: /usr
   lustre:
     externals:
     - spec: lustre@2.10.5

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -13,10 +13,13 @@ General
 
 2. Build errors with Python 3.10
 
-   There are several build errors with Python 3.10, for example Python packages being installed in nested subdirectories ``local`` of what is supposed to be the target installation directory. We therefore strongly recommend using Python 3.8 or 3.9.
+   There are several build errors with Python 3.10, for example Python packages being installed in nested subdirectories ``local`` of what is supposed to be the target installation directory. We therefore strongly recommend using Python 3.9 until we can confirm that everything works with Python 3.10.
 
 3. Issues starting/finding ``ecflow_server`` due to a mismatch of hostnames
    On some systems, ``ecflow_server`` gets confused by multiple hostnames, e.g. ``localhost`` and ``MYORG-L-12345``. The ``ecflow_start.sh`` script reports the hostname it wants to use. This name (or both) must be in ``/etc/hosts`` in the correct address line, often the loopback address (``127.0.0.1``).
+
+4. Installation of duplicate packages `ecbuild`, `hdf5`
+   One reason for this is an external `cmake@3.20` installation, which confuses the concretizer when building a complex environment such as the `skylab-dev` or `jedi-ufs-all` environment. For certain packages (and thus their dependencies), a newer version than `cmake@3.20` is required, for others `cmake@3.20` works, and spack then thinks that it needs to build two identical versions of the same package with different versions of `cmake`. The solution is to remove any external `cmake@3.20` package in the site config and run the concretization step again.
 
 ==============================
 NASA Discover

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -27,14 +27,6 @@ ecflow
    module load cmake/3.22.1
    module load gcc/10.2.0
 
-ncview
-  After creating the environment and before concretizing, replace `ncview@2.1.8` (if in your specs) with `ncview@2.1.5`:
-
-.. code-block:: console
-
-   spack remove ncview@2.1.8
-   spack add ncview@2.1.5
-
 .. _MaintainersSection_Discover:
 
 ------------------------------

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -75,7 +75,7 @@ The following is required for building new spack environments and for using spac
    module purge
    module use /work/noaa/da/role-da/spack-stack/modulefiles
    module load miniconda/3.9.7
-   module load ncview/2.1.5
+   module load ecflow/5.8.4
 
 For ``spack-stack-1.0.0`` with Intel, load the following modules after loading miniconda and ecflow:
 
@@ -110,7 +110,7 @@ The following is required for building new spack environments and for using spac
    module purge
    module use /discover/swdev/jcsda/spack-stack/modulefiles
    module load miniconda/3.9.7
-   module load ncview/2.1.7
+   module load ecflow/5.8.4
 
 For ``spack-stack-1.0.2`` with Intel, load the following modules after loading miniconda and ecflow:
 


### PR DESCRIPTION
## Description
Changes required to build spack-stack-1.1.0 on HPCs, the cloud and macOS
- Update submodule pointer for spack for the changes described in https://github.com/NOAA-EMC/spack/pull/180
- Add `libXpm` as an external package on all supported systems so that `ncview` can be built as part of spack-stack
- Remove external `ncview` from systems that have it. External `ncview` packages often load other `hdf5` or `netcdf4` modules, which interfere with the spack-stack modules. Update documentation accordingly.
- Remove external `cmake@3.20`, because this confuses the spack concretizer, leading to duplicate `ecbuild` and `hdf5`/`netcdf-c`/`netcdf-fortran` packages being installed (this took a while to decipher). Update documentation accordingly.
- Update branch/tag in spack container recipes to use branch `release/1.1.0` for now. Later, this needs to be changed to the final tag `spack-stack-1.1.0` of the spack submodule.

*Note* Further documentation updates specific to release 1.1.0 (install locations etc) will be made in a separate PR.

## Issues

Working towards #339 

## Dependencies
Waiting on https://github.com/NOAA-EMC/spack/pull/180

## Testing
This version was installed on @climbfuji's macOS, on Cheyenne, S4, Discover, Orion with Intel and GNU.

Full CI tests passed for https://github.com/NOAA-EMC/spack-stack/pull/360/commits/cdce3dd06649a38363c3d387670c451e6826a492 except that the macos-gcc skylab-2.0.0 build timed out after 6hrs (almost complete installation).