### PR TITLE
Update spack submodule tag for release 1.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   #url = https://github.com/spack/spack
   #branch = develop
   url = https://github.com/NOAA-EMC/spack
-  branch = release/1.1.0
+  branch = spack-stack-1.1.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -93,8 +93,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        # Todo: Update to final tag spack-stack-1.1.0 once available
-        ref: release/1.1.0
+        ref: spack-stack-1.1.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -80,8 +80,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        # Todo: Update to final tag spack-stack-1.1.0 once available
-        ref: release/1.1.0
+        ref: spack-stack-1.1.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -94,8 +94,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        # Todo: Update to final tag spack-stack-1.1.0 once available
-        ref: release/1.1.0
+        ref: spack-stack-1.1.0
         resolve_sha: false
 
     # Whether or not to strip binaries


### PR DESCRIPTION
Update spack submodule tag in container recipes and `.gitmodules` for release 1.1.0. The spack submodule tag was created yesterday and points to the same hash as the head of branch `release/1.1.0`.