### PR TITLE
Update spack and CMakeModules submodules from authoritative develop branches as of 2022/10/24

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -54,9 +54,9 @@ runs:
         # Needed for the following apt-get install calls to work
         sudo apt-get update
 
-        # Don't do this, breaks several packages
-        ## Install Curl headers. Executable exists by default in spack external find.
-        #sudo apt-get install libcurl4-openssl-dev
+        # Install Curl/ssl headers. Executables exist by default in spack external find.
+        sudo apt-get install libcurl4-openssl-dev
+        sudo apt-get install libssl-dev
 
         # Install git-lfs to avoid compilation errors of "go" with Intel
         sudo apt-get install git-lfs
@@ -227,7 +227,9 @@ runs:
       # Make homebrew qt@5 detectable on macOS
       PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt
 
-      if [[ "$RUNNER_OS" == "macOS" ]]; then
+      if [[ "$RUNNER_OS" == "Linux" ]]; then
+        spack external find curl
+      elif [[ "$RUNNER_OS" == "macOS" ]]; then
         # Make homebrew curl detectable on macOS
         PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
       fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_spack_from_authoritative_20221024
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_spack_from_authoritative_20221024
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -197,6 +197,11 @@
       version: [3.0.3]
     py-pandas:
       version: [1.4.0]
+    # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
+    # versions of py-poetry-core when using external/homebrew Python as
+    # we do at the moment in spack-stack.
+    py-poetry-core:
+      version: [1.0.8]
     py-pybind11:
       version: [2.8.1]
     py-pycodestyle:

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -14,7 +14,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.2, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
-    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.4_jedi]
+    yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4_jedi]
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
     # https://github.com/NOAA-EMC/spack-stack/issues/326

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -11,7 +11,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     gsibec@1.0.5, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
-    parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.2, py-numpy@1.22.3,
+    parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.3, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4_jedi]

--- a/configs/templates/gfs-v16.2/spack.yaml
+++ b/configs/templates/gfs-v16.2/spack.yaml
@@ -5,6 +5,7 @@ spack:
   config:
     install_tree:
       root: $env/install
+    deprecated: true
   modules:
     default:
       roots:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -215,7 +215,7 @@ spack:
     yafyaml:
       version: [0.5.1]
     zlib:
-      version: [1.2.12]
+      version: [1.2.13]
 
   definitions:
   - compilers: ['%gcc', '%intel']

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -88,4 +88,4 @@ spack:
     - udunits@2.2.28
     - w3nco@2.4.1
     - yafyaml@0.5.1
-    - zlib@1.2.12
+    - zlib@1.2.13

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -72,7 +72,7 @@ spack:
     - parallel-netcdf@1.12.2
     - parallelio@2.5.7
     - py-eccodes@1.4.2
-    - py-f90nml@1.4.2
+    - py-f90nml@1.4.3
     - py-numpy@1.22.3
     - py-pandas@1.4.0
     - py-pyyaml@6.0

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -53,4 +53,3 @@ spack:
   - ncio@1.1.2
   - met@10.1.0
   - metplus@4.1.0
-  

--- a/configs/templates/ufs-srw-public-v2/spack.yaml
+++ b/configs/templates/ufs-srw-public-v2/spack.yaml
@@ -2,6 +2,7 @@ spack:
   config:
     install_tree:
       root: $env/install
+    deprecated: true
   modules:
     default:
       roots:
@@ -19,7 +20,7 @@ spack:
 
   specs:
   - jasper@2.0.25
-  - zlib@1.2.13
+  - zlib@1.2.11
   - libpng@1.6.37
   - hdf5@1.10.6
   - netcdf-c@4.7.4

--- a/configs/templates/ufs-srw-public-v2/spack.yaml
+++ b/configs/templates/ufs-srw-public-v2/spack.yaml
@@ -19,7 +19,7 @@ spack:
 
   specs:
   - jasper@2.0.25
-  - zlib@1.2.12
+  - zlib@1.2.13
   - libpng@1.6.37
   - hdf5@1.10.6
   - netcdf-c@4.7.4


### PR DESCRIPTION
## Description

- Update spack and CMakeModules submodules from authoritative develop branches as of 2022/10/24
- Fix CI tests - revert back to a previous version where we use external curl and openssl on Ubuntu
- Bump `py-f90nml` version in `configs/containers/README.md` and `configs/templates/skylab-dev/spack.yaml`
- Bump `zlib` version to `1.12.13` or add `deprecated: true` in several templates, since the previous default `1.2.12` is now marked as deprecated.

### Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/188

### Testing

- All CI tests pass
- Installed `skylab-dev` on Dom's macOS with both the old and new version of `py-f90nml`, and with all available versions of `parallelio` (2.5.2 to 2.5.9) to make sure that the changes in the `parallelio` package are correct