### PR TITLE
Update container recipes for JEDI

### DIFF
--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -14,7 +14,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.2, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
-    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.4_jedi]
+    yafyaml@0.5.1, zlib@1.2.12, odc@1.4.5, crtm@v2.4_jedi, shumlib@macos_clang_linux_intel_port]
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
     # https://github.com/NOAA-EMC/spack-stack/issues/326

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -36,6 +36,8 @@ apt update
 apt -y upgrade
 reboot
 # ... wait for the instance to come back up again ...
+
+# Install Docker, SingularityCE, and other basic packages
 sudo su
 apt install -y gnome-terminal
 apt install -y \
@@ -63,9 +65,24 @@ python3 -c "import poetry"
 python3 -m pip install awscli
 aws configure
 
+cd ~
+wget https://github.com/sylabs/singularity/releases/download/v3.9.9/singularity-ce_3.9.9-focal_amd64.deb
+apt install ./singularity-ce_3.9.7-bionic_amd64.deb
+# Ignore "N: Download is performed unsandboxed as root as file '/root/singularity-ce_3.9.9-focal_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)"
+# Test:
+singularity version
+
 exit
 
 # Run as user ubuntu
 systemctl --user start docker-desktop
 ```
-Then, build/run/upload containers as root user
+Then, build, run, upload containers as root user
+
+### Converting spack-stack docker images to singularity
+As root user:
+```
+#SINGULARITY_NOHTTPS=1 singularity build docker-intel-oneapi-dev.simg docker-daemon://469205354006.dkr.ecr.us-east-1.amazonaws.com/docker-intel-oneapi-dev:latest
+singularity build docker-intel-oneapi-dev.sif docker-daemon://469205354006.dkr.ecr.us-east-1.amazonaws.com/docker-intel-oneapi-dev:latest
+singularity shell docker-intel-oneapi-dev.sif
+```

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -28,6 +28,7 @@ spack:
   # Additional package config for container
   packages:
     all:
+      target: [x86_64]
       providers:
         mpi: [mpich@4.0.2]
       compiler: [clang@10.0.0]
@@ -79,13 +80,13 @@ spack:
     format: docker
     # How to use:
     #$ spack containerize > Dockerfile
-    #$ docker build -t myimage .
-    #$ docker run -it myimage
+    #$ sudo docker build -t myimage .
+    #$ sudo docker run -it myimage
 
     #format: singularity
     # How to use:
-    #$ spack containerize > hdf5.def
-    #$ sudo singularity build hdf5.sif hdf5.def
+    #$ spack containerize > singularity.def
+    #$ sudo singularity build singularity.sif singularity.def
 
     # Sets the base images for the stages where Spack builds the
     # software or where the software gets installed after being built..

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -4,6 +4,7 @@ spack:
   view: false
 
   config:
+    checksum: false
     build_jobs: 2
     connect_timeout: 60
 

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -185,7 +185,7 @@ spack:
         ENV CPATH=/opt/mpich-${MPICH_VERSION}/include:${CPATH}
         ENV LD_LIBRARY_PATH=/opt/mpich-${MPICH_VERSION}/lib:${LD_LIBRARY_PATH}
       final: |
-        #Create symbolic links for clang compilers
+        # Create symbolic links for clang compilers
         RUN cd /usr/bin && \
         ln -svf clang-10 clang && \
         ln -svf clang++-10 clang++ && \
@@ -194,7 +194,7 @@ spack:
         ln -svf libc++abi.so.1.0 libc++abi.so
         # Copy mpich-4.0.2 installation from builder
         COPY --from=builder /opt/mpich-4.0.2 /opt/mpich-4.0.2
-        #Make a non-root user:nonroot / group:nonroot for running MPI
+        # Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
         echo "ulimit -s unlimited" >> /home/nonroot/.bashrc && \
         echo "ulimit -v unlimited" >> /home/nonroot/.bashrc && \
@@ -203,6 +203,15 @@ spack:
         echo "export FC=gfortran" >> /home/nonroot/.bashrc && \
         printf "[credential]\n    helper = cache --timeout=7200\n" >> /home/nonroot/.gitconfig && \
         chown -R nonroot:nonroot /home/nonroot/.gitconfig
+        # Replicate settings for root user
+        RUN echo "ulimit -s unlimited" >> /root/.bashrc && \
+        echo "ulimit -v unlimited" >> /root/.bashrc && \
+        echo "export CC=clang" >> /root/.bashrc && \
+        echo "export CXX=clang++" >> /root/.bashrc && \
+        echo "export FC=gfortran" >> /root/.bashrc && \
+        printf "[credential]\n    helper = cache --timeout=7200\n" >> /root/.gitconfig
+        # Source spack environment script for root
+        RUN echo "source /etc/profile.d/z10_spack_environment.sh\n" >> /root/.bashrc
 
     # Labels for the image
     labels:

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -102,6 +102,7 @@ spack:
     ## Additional system packages that are needed at runtime
     os_packages:
       build:
+      - bc
       - clang-10
       - libclang-10-dev
       - libc++-10-dev
@@ -118,6 +119,7 @@ spack:
       - wget
 
       final:
+      - bc
       - clang-10
       - libclang-10-dev
       - libc++-10-dev

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -149,7 +149,7 @@ spack:
         echo "rmaps_base_oversubscribe = 1" >> /home/nonroot/.openmpi/mca-params.conf && \
         chown -R nonroot:nonroot /home/nonroot/.gitconfig /home/nonroot/.openmpi
         # Replicate settings for root user
-        echo "ulimit -s unlimited" >> /root/.bashrc && \
+        RUN echo "ulimit -s unlimited" >> /root/.bashrc && \
         echo "ulimit -v unlimited" >> /root/.bashrc && \
         echo "export CC=gcc" >> /root/.bashrc && \
         echo "export CXX=g++" >> /root/.bashrc && \

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -26,6 +26,7 @@ spack:
   # Additional package config for container
   packages:
     all:
+      target: [x86_64]
       providers:
         mpi: [openmpi@4.1.4]
       compiler: [gcc@9.4.0]
@@ -66,13 +67,13 @@ spack:
     format: docker
     # How to use:
     #$ spack containerize > Dockerfile
-    #$ docker build -t myimage .
-    #$ docker run -it myimage
+    #$ sudo docker build -t myimage .
+    #$ sudo docker run -it myimage
 
     #format: singularity
     # How to use:
-    #$ spack containerize > hdf5.def
-    #$ sudo singularity build hdf5.sif hdf5.def
+    #$ spack containerize > singularity.def
+    #$ sudo singularity build singularity.sif singularity.def
 
     # Sets the base images for the stages where Spack builds the
     # software or where the software gets installed after being built..

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -4,6 +4,7 @@ spack:
   view: false
 
   config:
+    checksum: false
     build_jobs: 2
     connect_timeout: 60
 

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -137,7 +137,7 @@ spack:
         ENV CXX=g++
         ENV FC=gfortran
       final: |
-        #Make a non-root user:nonroot / group:nonroot for running MPI
+        # Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
         echo "ulimit -s unlimited" >> /home/nonroot/.bashrc && \
         echo "ulimit -v unlimited" >> /home/nonroot/.bashrc && \
@@ -148,10 +148,21 @@ spack:
         mkdir /home/nonroot/.openmpi && \
         echo "rmaps_base_oversubscribe = 1" >> /home/nonroot/.openmpi/mca-params.conf && \
         chown -R nonroot:nonroot /home/nonroot/.gitconfig /home/nonroot/.openmpi
-        #Also set the necessary environment variables to run as root
+        # Replicate settings for root user
+        echo "ulimit -s unlimited" >> /root/.bashrc && \
+        echo "ulimit -v unlimited" >> /root/.bashrc && \
+        echo "export CC=gcc" >> /root/.bashrc && \
+        echo "export CXX=g++" >> /root/.bashrc && \
+        echo "export FC=gfortran" >> /root/.bashrc && \
+        printf "[credential]\n    helper = cache --timeout=7200\n" >> /root/.gitconfig && \
+        mkdir /root/.openmpi && \
+        echo "rmaps_base_oversubscribe = 1" >> /root/.openmpi/mca-params.conf
+        # Also set necessary environment variables for openmpi
         RUN echo "export OMPI_ALLOW_RUN_AS_ROOT=1" >> /root/.bashrc && \
         echo "export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1" >> /root/.bashrc && \
         echo "export OMPI_MCA_rmaps_base_oversubscribe=1" >> /root/.bashrc
+        # Source spack environment script for root
+        RUN echo "source /etc/profile.d/z10_spack_environment.sh\n" >> /root/.bashrc
 
     # Labels for the image
     labels:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -89,6 +89,7 @@ spack:
     ## Additional system packages that are needed at runtime
     os_packages:
       build:
+      - bc
       - cpp
       - g++
       - gcc
@@ -102,6 +103,7 @@ spack:
       - wget
 
       final:
+      - bc
       - cpp
       - g++
       - gcc

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -4,6 +4,7 @@ spack:
   view: false
 
   config:
+    checksum: false
     build_jobs: 2
     connect_timeout: 60
 
@@ -30,7 +31,7 @@ spack:
   # Additional package config for container
   packages:
     all:
-      target: [x86_64]
+      target: [core2]
       providers:
         mpi: [intel-oneapi-mpi@2021.6.0]
       compiler: [intel@2022.1.0]

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -30,6 +30,7 @@ spack:
   # Additional package config for container
   packages:
     all:
+      target: [x86_64]
       providers:
         mpi: [intel-oneapi-mpi@2021.6.0]
       compiler: [intel@2022.1.0]
@@ -80,13 +81,13 @@ spack:
     format: docker
     # How to use:
     #$ spack containerize > Dockerfile
-    #$ docker build -t myimage .
-    #$ docker run -it myimage
+    #$ sudo docker build -t myimage .
+    #$ sudo docker run -it myimage
 
     #format: singularity
     # How to use:
-    #$ spack containerize > hdf5.def
-    #$ sudo singularity build hdf5.sif hdf5.def
+    #$ spack containerize > singularity.def
+    #$ sudo singularity build singularity.sif singularity.def
 
     # Sets the base images for the stages where Spack builds the
     # software or where the software gets installed after being built..

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -103,6 +103,7 @@ spack:
     ## Additional system packages that are needed at runtime
     os_packages:
       build:
+      - bc
       - cpp
       - g++
       - gcc
@@ -117,6 +118,7 @@ spack:
       - wget
 
       final:
+      - bc
       - cpp
       - g++
       - gcc

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -159,15 +159,12 @@ spack:
         ENV CXX=icpc
         ENV FC=ifort
       final: |
-        # Mark Potts had this:
-        # RUN export TZ=America/New_York && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
-        # && echo $TZ > /etc/timezone && apt update && apt install -y tzdata
         RUN apt update  && apt install apt-utils && \
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
         apt update && \
         apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 intel-oneapi-mpi-devel-2021.6.0 -y
-        #Make a non-root user:nonroot / group:nonroot for running MPI
+        # Make a non-root user:nonroot / group:nonroot for running MPI
         RUN useradd -U -k /etc/skel -s /bin/bash -d /home/nonroot -m nonroot --uid 43891 && \
         echo "ulimit -s unlimited" >> /home/nonroot/.bashrc && \
         echo "ulimit -v unlimited" >> /home/nonroot/.bashrc && \
@@ -178,6 +175,17 @@ spack:
         echo "source /opt/intel/oneapi/mpi/latest/env/vars.sh" >> /home/nonroot/.bashrc && \
         printf "[credential]\n    helper = cache --timeout=7200\n" >> /home/nonroot/.gitconfig && \
         chown -R nonroot:nonroot /home/nonroot/.gitconfig
+        # Replicate settings for root user
+        RUN echo "ulimit -s unlimited" >> /root/.bashrc && \
+        echo "ulimit -v unlimited" >> /root/.bashrc && \
+        echo "export CC=icc" >> /root/.bashrc && \
+        echo "export CXX=icpc" >> /root/.bashrc && \
+        echo "export FC=ifort" >> /root/.bashrc && \
+        echo "source /opt/intel/oneapi/compiler/latest/env/vars.sh" >> /root/.bashrc && \
+        echo "source /opt/intel/oneapi/mpi/latest/env/vars.sh" >> /root/.bashrc && \
+        printf "[credential]\n    helper = cache --timeout=7200\n" >> /root/.gitconfig
+        # Source spack environment script for root
+        RUN echo "source /etc/profile.d/z10_spack_environment.sh\n" >> /root/.bashrc
 
     # Labels for the image
     labels:


### PR DESCRIPTION
Update container recipes:
- add `bc` (basic calculator) to OS packages
- add `shumlib` to list of packages to install when following `config/containers/README.md`
- replicate the environment settings from nonroot user to root
- add `checksum: false` to all three container configs
- set target to generic `x86-64` for gnu/clang, and to `core2` for Intel to avoid illegal instructions running the spack-stack containers on older systems / systems with non-Intel CPUs

New Docker test containers were uploaded to JCSDA AWS ECR, singularity containers to JCSDA S3 privatecontainers for testing.

Tested successfully with soca-science bundle for gcc-openmpi container by @climbfuji.

Fixes https://github.com/JCSDA-internal/containers (to be confirmed by @mer-a-o)