### PR TITLE
Update Narwhal documentation

### DIFF
--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -111,7 +111,7 @@ qt (qt@5)
    module load gcc/10.3.0
 
 ecflow
-  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `qt5`, and loading the following modules, follow the instructions in :numref:`Section %s <Prerequisites_ecFlow>` to install ``ecflow`` in ``/p/app/projects/NEPTUNE/spack-stack/ecflow-5.8.4-cray-python-3.9.7.1``. Ensure to follow the extra instructions in that section for Narwhal.
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `qt5`, and loading the following modules, follow the instructions in :numref:`Section %s <Prerequisites_ecFlow>` to install ``ecflow`` in ``/p/app/projects/NEPTUNE/spack-stack/ecflow-5.8.4``. Ensure to follow the extra instructions in that section for Narwhal.
 
    module unload PrgEnv-cray
    module load PrgEnv-intel/8.1.0
@@ -123,6 +123,7 @@ ecflow
    module load cray-libsci/22.08.1.1
 
    module load gcc/10.3.0
+   module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
    module load qt/5.15.2
 
 .. _MaintainersSection_Casper:

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -31,7 +31,7 @@ spack-stack-v1
 +----------------------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------+
 | NASA Discover GNU                                        | Dom Heinzeller            | ``/discover/swdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-2.0.0-gnu-10.1.0/install``                          |
 +----------------------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------+
-| NAVY HPCMP Narwhal                                       | Dom Heinzeller            | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-2021.3.0-cray-python-3.9.7.1/install``|
+| NAVY HPCMP Narwhal                                       | Dom Heinzeller            | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-2021.3.0/install``                    |
 +----------------------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------+
 | NCAR-Wyoming Casper                                      | Dom Heinzeller            | ``/glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-19.1.1.217-casper/install``     |
 +----------------------------------------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------+
@@ -157,13 +157,13 @@ The following is required for building new spack environments and for using spac
    module load cray-libsci/22.08.1.1
 
    module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
-   module load ecflow/5.8.4-cray-python-3.9.7.1
+   module load ecflow/5.8.4
 
 For ``spack-stack-2.0.0`` with Intel, load the following modules after loading the above modules.
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-2021.3.0-cray-python-3.9.7.1/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-2021.3.0/install/modulefiles/Core
    module load stack-intel/2021.3.0
    module load stack-cray-mpich/8.1.14
    module load stack-python/3.9.7


### PR DESCRIPTION
Rebuilt the environment using `cray-python` in the default env path - update documentation. No CI testing required, can be merged once approved.