### PR TITLE
Remove deprecated variant 'ensurepip' from external Python declarations

### DIFF
--- a/configs/sites/aws-pcluster/packages.yaml
+++ b/configs/sites/aws-pcluster/packages.yaml
@@ -16,7 +16,7 @@ packages:
   python:
     buildable: false
     externals:
-    - spec: python@3.8.10+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
+    - spec: python@3.8.10+bz2+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
       prefix: /usr
 
 ### All other external packages listed alphabetically

--- a/configs/sites/casper/packages.yaml
+++ b/configs/sites/casper/packages.yaml
@@ -16,7 +16,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
       modules:
       - miniconda/3.9.12

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -45,7 +45,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
       modules:
       - miniconda/3.9.12

--- a/configs/sites/frontera/packages.yaml
+++ b/configs/sites/frontera/packages.yaml
@@ -24,7 +24,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
 
 ### All other external packages listed alphabetically

--- a/configs/sites/gaea/packages.yaml
+++ b/configs/sites/gaea/packages.yaml
@@ -27,7 +27,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /lustre/f2/pdata/esrl/gsd/spack-stack/miniconda-3.9.12
       modules:
       - miniconda/3.9.12

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -28,7 +28,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /scratch1/NCEPDEV/global/spack-stack/apps/miniconda/py39_4.12.0
       modules:
       - miniconda/3.9.12

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -21,7 +21,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /lfs4/HFIP/hfv3gfs/spack-stack/apps/miniconda/py39_4.12.0
       modules:
       - miniconda/3.9.12

--- a/configs/sites/narwhal/packages.yaml
+++ b/configs/sites/narwhal/packages.yaml
@@ -27,7 +27,7 @@ packages:
   python:
     buildable: False
     externals:
-    - spec: python@3.9.7+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.7+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /opt/cray/pe/python/3.9.7.1
       modules:
       - cray-python/3.9.7.1

--- a/configs/sites/noaa-aws/packages.yaml
+++ b/configs/sites/noaa-aws/packages.yaml
@@ -109,7 +109,7 @@ packages:
       prefix: /usr
   python:
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /contrib/spack-stack/apps/miniconda/miniconda3
   rsync:
     externals:

--- a/configs/sites/noaa-azure/packages.yaml
+++ b/configs/sites/noaa-azure/packages.yaml
@@ -153,7 +153,7 @@ packages:
       prefix: /usr
   python:
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /contrib/spack-stack/apps/miniconda/miniconda3
   rsync:
     externals:

--- a/configs/sites/noaa-gcloud/packages.yaml
+++ b/configs/sites/noaa-gcloud/packages.yaml
@@ -113,7 +113,7 @@ packages:
       prefix: /usr
   python:
     externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+ensurepip+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
       prefix: /contrib/spack-stack/apps/miniconda/miniconda3
   rsync:
     externals:


### PR DESCRIPTION
## Description

The latest update of the spack submodule from the authoritative repo removed the `ensurepip` variant for Python. We need to remove this variant from all external Python package declarations (`configs/sites/*/packages.yaml`).

See https://github.com/NOAA-EMC/spack-stack/issues/397 for an example of the error (https://github.com/NOAA-EMC/spack-stack/issues/397#issuecomment-1306269234)