### PR TITLE
By default, enable OpenMP for fms, eckit, fckit, ecmwf-atlas on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/fms_openmp_macos
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/fms_openmp_macos
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/macos.default/packages.yaml
+++ b/configs/sites/macos.default/packages.yaml
@@ -1,15 +1,5 @@
 packages:
   wgrib2:
     variants: ~openmp
-  fms:
-    variants: ~openmp
-  fms-jcsda:
-    variants: ~openmp
-  eckit:
-    variants: ~openmp
-  fckit:
-    variants: ~openmp
-  ecmwf-atlas:
-    variants: ~openmp
   cairo:
     variants: ~png ~svg


### PR DESCRIPTION
## Description

Recent changes in spack (https://github.com/NOAA-EMC/spack/pull/196 and https://github.com/NOAA-EMC/spack/pull/197) should allow us to build fms, eckit, fckit, ecmwf-atlas on macOS with OpenMP enabled. This PR removes the hardcoded switch to turn off OpenMP from the macOS site config.

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/197

## Testing

- Successful build on @climbfuji's macOS (using self-hosted runner), the CI job however timed out in the "Cleaning up orphan processes" task - looks like that the runner got confused because it disconnected and then reconnected during the job. See https://github.com/NOAA-EMC/spack-stack/actions/runs/3481533059/jobs/5822749036
- Regular CI tests all passed