### PR TITLE
Update versions of ectrans, eckit, fckit, atlas, fms

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -241,7 +241,12 @@ runs:
       spack external find mpich
       spack external find openmpi
       spack external find perl
-      spack external find python
+      if [[ "$RUNNER_OS" == "Linux" ]]; then
+        spack external find --not-buildable python
+      elif [[ "$RUNNER_OS" == "macOS" ]]; then
+        # Jail spack external find to /usr/local to ignore Framework python
+        spack external find --not-buildable --path /usr/local python
+      fi
       spack external find wget
 
       # Make homebrew qt@5 detectable on macOS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_eckit_fckit_atlas
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_eckit_fckit_atlas
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -45,13 +45,13 @@
       version: [5.8.3]
       variants: +ui
     eckit:
-      version: [1.19.0]
+      version: [1.20.2]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.30.0]
+      version: [0.31.1]
       variants: +fckit +trans
     ectrans:
-      version: [develop]
+      version: [1.1.0]
       variants: ~enable_mkl
     eigen:
       version: [3.4.0]
@@ -66,7 +66,7 @@
     fftw:
       version: [3.3.10]
     fiat:
-      version: [main]
+      version: [1.0.0]
     findutils:
       version: [4.8.0]
     flex:
@@ -74,8 +74,8 @@
     # Attention - when updating also check the macos.default site config and
     # the various jcsda-emc-bundles env packages
     fms:
-      version: [2022.01]
-      variants: +64bit +quad_precision +gfs_phys +openmp +pic
+      version: [2022.02]
+      variants: +64bit +quad_precision +gfs_phys +openmp +fpic
     g2:
       version: [3.4.5]
     g2c:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -40,13 +40,13 @@ spack:
     eccodes:
       version: [2.27.0]
     eckit:
-      version: [1.19.0]
+      version: [1.20.2]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.30.0]
+      version: [0.31.1]
       variants: +fckit +trans
     ectrans:
-      version: [develop]
+      version: [1.1.0]
       variants: ~enable_mkl
     eigen:
       version: [3.4.0]
@@ -59,10 +59,10 @@ spack:
     fftw:
       version: [3.3.10]
     fiat:
-      version: [main]
+      version: [1.0.0]
     fms:
-      version: [2022.01]
-      variants: +64bit +quad_precision +gfs_phys +openmp +pic
+      version: [2022.02]
+      variants: +64bit +quad_precision +gfs_phys +openmp +fpic
     g2:
       version: [3.4.5]
     g2c:

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -148,8 +148,6 @@ spack:
       version: [1.3.2]
     py-f90nml:
       version: [1.4.2]
-    py-h5py:
-      version: [3.6.0]
     py-netcdf4:
       version: [1.5.3]
       variants: +mpi

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -39,7 +39,7 @@ spack:
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
       version: [0.24.1]
-      variants: +fckit -trans
+      variants: +fckit ~trans
     ectrans:
       version: [1.0.0]
       variants: ~enable_mkl
@@ -54,7 +54,7 @@ spack:
     fftw:
       version: [3.3.8]
     fiat:
-      version: [main]
+      version: [1.0.0]
     fms:
       version: [2022.01]
       variants: +64bit +quad_precision +gfs_phys +openmp +pic

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -33,10 +33,9 @@ spack:
     - ecbuild@3.6.5
     - eccodes@2.27.0
     - ecflow@5
-    - eckit@1.19.0
-    - ecmwf-atlas@0.30.0
-    # DH* fake version number
-    - ectrans@1.0.0
+    - eckit@1.20.2
+    - ecmwf-atlas@0.31.1
+    - ectrans@1.1.0
     - eigen@3.4.0
     - esmf@8.3.0b09+pio
     # DH* fake version number
@@ -45,7 +44,7 @@ spack:
     # DH* fake version number
     - fiat@1.0.0
     - flex@2.6.4
-    - fms@2022.01
+    - fms@2022.02
     # DH* fake version number
     - fms@release-jcsda
     - g2@3.4.5


### PR DESCRIPTION
## Description

Update versions of ectrans, eckit, fckit, atlas, fms. Requires https://github.com/NOAA-EMC/spack/pull/199 to be merged first - update 11/29/2022 this PR was merged.

Note that https://github.com/NOAA-EMC/spack/pull/199 removes `py-h5py` from `ufs-pyenv`.

Also note that I had to make yet another bug fix to the macOS CI tests, using additional flags for `spack external find` (which are very useful and should be used in the setup instructions for generic platforms in the future) to ignore the macOS Framework Python.

## Issues

Fixes https://github.com/NOAA-EMC/spack-stack/issues/401
Fixes https://github.com/NOAA-EMC/spack-stack/issues/375

## Dependencies

- waiting on https://github.com/NOAA-EMC/spack/pull/199

## Testing

- built locally on Dom's macOS with apple-clang@13.1.6 and openmpi@4.1.4, built jedi-bundle and ran ctests (several test failes, I believe the usual ones we get on macOS - to be confirmed)
- CI tests passed (one skylab build ran out of time at 6hrs, but everything else passed) for https://github.com/NOAA-EMC/spack-stack/pull/408/commits/699160254bc9c12e331a957307ba39c6e24a73dd
- test on one HPC (S4 with Intel): Tested on S4 with Intel. There are a handful of ctest failures, some with floating point mismatches, some with segfaults and some with sigfpe, but these are all in the JEDI code and need to be fixed there.