### PR TITLE
Remove ~ensurepip from python spec in Acorn config

### DIFF
--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -41,7 +41,7 @@
         prefix: /usr
     python:
       externals:
-      - spec: python@3.8.6+bz2+ctypes+dbm~ensurepip+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
+      - spec: python@3.8.6+bz2+ctypes+dbm+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
         prefix: /apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk
     perl:
       externals:


### PR DESCRIPTION
~ensurepip variant is still in acorn, which causes any python-having builds with site=acorn to fail.

Fixes #414. 