### PR TITLE
Update spack fork from spack develop 2022/12/22

### DIFF
--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -61,7 +61,11 @@ runs:
 
         # Print version of xcode
         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
+
+        # Install Python poetry to avoid install errors in spack
+        python3 -m pip install poetry
+
       fi
 
-      # Install Python poetry to avoid install errors in spack
-      python3 -m pip install poetry
+      ## Install Python poetry to avoid install errors in spack
+      #python3 -m pip install poetry

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -132,9 +132,10 @@ runs:
       spack external find mpich
       spack external find openmpi
       spack external find perl
-      if [[ "$RUNNER_OS" == "Linux" ]]; then
-        spack external find --not-buildable python
-      elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      #if [[ "$RUNNER_OS" == "Linux" ]]; then
+      #  spack external find --not-buildable python
+      #elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      if [[ "$RUNNER_OS" == "macOS" ]]; then
         # Jail spack external find to /usr/local to ignore Framework python
         spack external find --not-buildable --path /usr/local python
       fi
@@ -164,8 +165,8 @@ runs:
       # Use external MPI to save compilation time
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
-
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
+      spack config add "packages:all:require:'%${{ inputs.compiler }}'"
 
       if [[ "$RUNNER_OS" == "macOS" ]]; then
         # Turn of SSL for ecflow CI builds for now

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -166,7 +166,8 @@ runs:
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
-      spack config add "packages:all:require:'%${{ inputs.compiler }}'"
+      # This is not working as expected
+      #spack config add "packages:all:require:'%${{ inputs.compiler }}'"
 
       if [[ "$RUNNER_OS" == "macOS" ]]; then
         # Turn of SSL for ecflow CI builds for now

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_spack_from_authoritative_20221222
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_spack_from_authoritative_20221222
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -216,13 +216,13 @@
       version: [3.1.0]
     py-python-dateutil:
       version: [2.8.2]
-    py-pythran:
-      # Earlier versions don't compile on macOS with llvm-clang/13.0.0 and Python/3.9
-      version: [0.11.0]
+    #py-pythran:
+    #  # Earlier versions don't compile on macOS with llvm-clang/13.0.0 and Python/3.9
+    #  version: [0.11.0]
     py-pyyaml:
       version: [6.0]
-    py-scipy:
-      version: [1.8.0]
+    #py-scipy:
+    #  version: [1.8.0]
     # Pin the py-setuptools version to avoid duplicate Python packages
     py-setuptools:
       version: [59.4.0]

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -221,8 +221,8 @@
     #  version: [0.11.0]
     py-pyyaml:
       version: [6.0]
-    #py-scipy:
-    #  version: [1.8.0]
+    py-scipy:
+      version: [1.9.3]
     # Pin the py-setuptools version to avoid duplicate Python packages
     py-setuptools:
       version: [59.4.0]

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -12,7 +12,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.3, py-numpy@1.22.3,
-    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.8.0, py-shapely@1.8.0, py-xarray@2022.3.0,
+    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4-jedi.2, shumlib@macos_clang_linux_intel_port]
     # Don't build ESMF and MAPL for now:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -182,12 +182,12 @@ spack:
       version: [3.1.0]
     py-python-dateutil:
       version: [2.8.2]
-    py-pythran:
-      version: [0.11.0]
+    #py-pythran:
+    #  version: [0.11.0]
     py-pyyaml:
       version: [6.0]
     py-scipy:
-      version: [1.8.0]
+      version: [1.9.3]
     py-shapely:
       version: [1.8.0]
     sfcio:

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -172,12 +172,12 @@ spack:
       version: [3.1.0]
     py-python-dateutil:
       version: [2.8.2]
-    py-pythran:
-      version: [0.11.0]
+    #py-pythran:
+    #  version: [0.11.0]
     py-pyyaml:
       version: [6.0]
     py-scipy:
-      version: [1.8.0]
+      version: [1.9.3]
     py-shapely:
       version: [1.8.0]
     sfcio:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -78,7 +78,7 @@ spack:
     - py-numpy@1.22.3
     - py-pandas@1.4.0
     - py-pyyaml@6.0
-    - py-scipy@1.8.0
+    - py-scipy@1.9.3
     - py-shapely@1.8.0
     - py-xarray@2022.3.0
     # DH* fake version number

--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -551,7 +551,6 @@ This instructions are meant to be a reference that users can follow to set up th
 
    brew install coreutils
    brew install gcc
-   brew install python
    brew install git
    brew install git-lfs
    brew install lmod
@@ -581,15 +580,7 @@ This instructions are meant to be a reference that users can follow to set up th
 
 6. Install xquartz using the provided binary at https://www.xquartz.org. This is required for forwarding of remote X displays, and for displaying the ``ecflow`` GUI, amongst others.
 
-7. Temporary workaround for pip installs in spack (see https://github.com/spack/spack/issues/29308). Make sure that ``python3`` points to the Homebrew version.
-
-.. code-block:: console
-
-   python3 -m pip install poetry
-   # test - successful if no output
-   python3 -c "import poetry"
-
-8. Optional: Install MacTeX if planning to build the ``jedi-tools`` environment with LaTeX/PDF support
+7. Optional: Install MacTeX if planning to build the ``jedi-tools`` environment with LaTeX/PDF support
 
    If the ``jedi-tools`` application is built with variant ``+latex`` to enable building LaTeX/PDF documentation, install MacTeX 
    `MacTeX  <https://www.tug.org/mactex>`_ and configure your shell to have it in the search path, for example:
@@ -624,7 +615,8 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
    spack external find --scope system
    spack external find --scope system perl
-   spack external find --scope system python
+   # Don't use any external Python, let spack build it
+   #spack external find --scope system python
    spack external find --scope system wget
 
    PATH="$HOMEBREW_ROOT/opt/curl/bin:$PATH" \
@@ -653,7 +645,6 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. code-block:: console
 
-   spack config add "packages:python:buildable:False"
    spack config add "packages:all:providers:mpi:[openmpi@4.1.4]"
    spack config add "packages:all:compiler:[apple-clang@13.1.6]"
 


### PR DESCRIPTION
#WIP

## Description

Updates to documentation, CI builds and package configurations (in `config/common/packages.yaml` and in container configs) to work with the updated spack code from https://github.com/NOAA-EMC/spack/pull/210. Important updates are:
- Update `py-scipy` from `1.8.0` to `1.9.3` to fix build errors and duplicate packages
- Let spack build Python for Ubuntu Linux CI builds
- Let spack build Python in macOS instructions for local systems.

**Note:** For now, keep the Homebrew Python for macOS CI runs. We should change this (and the Linux instructions for local systems) to spack-built python in the near future. And consider doing the same on HPCs.

Update .gitmodules and submodule pointer for spack for code review and testing

## Issues

Working towards https://github.com/NOAA-EMC/spack-stack/issues/394 and https://github.com/NOAA-EMC/spack-stack/issues/376.

## Dependencies

- waiting on https://github.com/NOAA-EMC/spack/pull/210

## Testing

- CI tests passed for https://github.com/NOAA-EMC/spack-stack/pull/424/commits/8ae66fbb0719c1a6054af397bf9bdab501121fb4
- Successfully installed on @climbfuji's macOS (`skylab-dev` template + `jedi-tools-env`)