### PR TITLE
Bug fixes for Cheyenne with Intel

### DIFF
--- a/configs/sites/cheyenne/compilers.yaml
+++ b/configs/sites/cheyenne/compilers.yaml
@@ -14,9 +14,9 @@ compilers::
   #    - intel/2022.1
   #    environment:
   #      prepend_path:
-  #        PATH: '/glade/u/apps/ch/opt/gnu/10.1.0/bin'
-  #        CPATH: '/glade/u/apps/ch/opt/gnu/10.1.0/include'
-  #        LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2022.1/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/glade/u/apps/ch/opt/gnu/10.1.0/lib64'
+  #        PATH: '/glade/u/apps/ch/opt/gnu/9.1.0/bin'
+  #        CPATH: '/glade/u/apps/ch/opt/gnu/9.1.0/include'
+  #        LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2022.1/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/glade/u/apps/ch/opt/gnu/9.1.0/lib64'
   #      set:
   #        I_MPI_ROOT: '/glade/u/apps/opt/intel/2022.1/mpi/2021.5.1'
   #    extra_rpaths: []
@@ -34,9 +34,9 @@ compilers::
       - intel/19.1.1
       environment:
         prepend_path:
-          PATH: '/glade/u/apps/ch/opt/gnu/10.1.0/bin'
-          CPATH: '/glade/u/apps/ch/opt/gnu/10.1.0/include'
-          LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/ch/opt/gnu/10.1.0/lib64'
+          PATH: '/glade/u/apps/ch/opt/gnu/9.1.0/bin'
+          CPATH: '/glade/u/apps/ch/opt/gnu/9.1.0/include'
+          LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/ch/opt/gnu/9.1.0/lib64'
         set:
           INTEL_LICENSE_FILE: '28518@128.117.177.41'
           LM_LICENSE_FILE: '28518@128.117.177.41'

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -189,6 +189,9 @@ packages:
     externals:
     - spec: openssl@1.0.2p-fips
       prefix: /usr
+  # Pin patchelf to 0.15.0 for Intel compiler (no C++-17 features)
+  patchelf:
+    version:: [0.15.0]
   perl:
     externals:
     - spec: perl@5.18.2~cpanm+shared+threads

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -4,7 +4,7 @@ packages:
     #compiler:: [gcc@9.3.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.0]
-      #mpi:: [mpich@4.0.2%gcc@9.3.0]
+      #mpi:: [mpich@4.0.2]
 
 ### MPI, Python, MKL
   # Comment out next two lines for gnu@9.3.0 with mpich@4.0.2 built by spack


### PR DESCRIPTION
These bug fixes didn't make it into the spack-stack 1.2.0 release. They are identical to what was done for Casper in the release. Need to downgrade the GCC backend for older Intel versions due to a bug (that has since been fixed in newer Intel versions). Also need to pin `patchelf` to 0.15 to work with the older Intel compiler. In addition, one small bug fix in a commented line in the S4 site config.

Tested successfully on Cheyenne and S4. No need to run CI tests, these files are not used.