### PR TITLE
Bug fix for S4 GNU compiler config

### DIFF
--- a/configs/sites/s4/compilers.yaml
+++ b/configs/sites/s4/compilers.yaml
@@ -30,6 +30,5 @@ compilers:
     target: x86_64
     modules:
     - gnu/9.3.0
-    modules: []
     environment: {}
     extra_rpaths: []


### PR DESCRIPTION
Remove additional, empty `modules:` option from S4 GNU compiler config. Stumbled over this while testing on S4. No CI tests required for this PR.