### PR TITLE
Always build Python with spack in CI tests / update submodule pointer for spack (moving packages to builtin)

### DIFF
--- a/.github/actions/setup-externals/action.yaml
+++ b/.github/actions/setup-externals/action.yaml
@@ -133,18 +133,15 @@ runs:
         tar -xzf mvapich2-${MPI_VERSION}-1.tar.gz
         cd mvapich2-${MPI_VERSION}-1
         if [[ "$RUNNER_OS" == "macOS" ]]; then
-          #./configure --prefix=$HOME/mpi \
-          #    --enable-fortran=yes --enable-cxx \
-          #    --enable-two-level-namespace \
-          #    --with-device=ch4:ofi \
-          #    LIBS="-Wl,-commons,use_dylibs"
-          echo "mvapich2 not configured/tested for macOS!"
-          exit 1
+          ./configure --prefix=$HOME/mpi \
+              --enable-fortran=yes --enable-cxx \
+              --enable-two-level-namespace \
+              --with-device=ch3:sock \
+              LIBS="-Wl,-commons,use_dylibs"
         else
           ./configure --prefix=$HOME/mpi \
-              --enable-fortran=yes --enable-cxx
-              #--enable-fortran=yes --enable-cxx \
-              #--with-device=ch4:ofi
+              --enable-fortran=yes --enable-cxx \
+              --with-device=ch3:sock
         fi
         make -j4
         make install

--- a/.github/actions/setup-externals/action.yaml
+++ b/.github/actions/setup-externals/action.yaml
@@ -93,11 +93,6 @@ runs:
 
       MPI_NAME=`echo "${{ inputs.mpi }}" | cut -d "@" -f 1`
       MPI_VERSION=`echo "${{ inputs.mpi }}" | cut -d "@" -f 2`
-      echo "MPI NAME IS ${MPI_NAME}, VERSION IS ${MPI_VERSION}"
-      exit 1
-
-      export MPICH_VERSION="4.0.2"
-      export OPENMPI_VERSION="4.1.4"
 
       if [[ "${MPI_NAME}" == "openmpi" ]]; then
         wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${MPI_VERSION}.tar.gz
@@ -135,12 +130,28 @@ runs:
         make -j4
         make install
       elif [[ "${MPI_NAME}" == "mvapich2" ]]; then
-        echo "${MPI_NAME} NOT CONFIGURED!"
-        sleep 60
-        exit 1
+        # Note that 2.3.7 apparently had a bug fix release, adding a "-1" to the tarball name
+        wget https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-${MPI_VERSION}-1.tar.gz
+        tar -xzf mvapich2-${MPI_VERSION}-1.tar.gz
+        cd mvapich2-${MPI_VERSION}-1
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          #./configure --prefix=$HOME/mpi \
+          #    --enable-fortran=yes --enable-cxx \
+          #    --enable-two-level-namespace \
+          #    --with-device=ch4:ofi \
+          #    LIBS="-Wl,-commons,use_dylibs"
+          echo "mvapich2 not configured/tested for macOS!"
+          exit 1
+        else
+          ./configure --prefix=$HOME/mpi \
+              --enable-fortran=yes --enable-cxx \
+              --with-device=ch4:ofi
+        fi
+        make -j4
+        make install
       elif [[ "${MPI_NAME}" == "intel-oneapi-mpi" ]]; then
         mkdir -p $HOME/mpi
       else
-        echo "${MPI_NAME} NOT CONFIGURED!"
+        echo "${MPI_NAME} not configured!"
         exit 1
       fi

--- a/.github/actions/setup-externals/action.yaml
+++ b/.github/actions/setup-externals/action.yaml
@@ -99,10 +99,10 @@ runs:
       export MPICH_VERSION="4.0.2"
       export OPENMPI_VERSION="4.1.4"
 
-      if [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz
-        tar -xzf openmpi-${OPENMPI_VERSION}.tar.gz
-        cd openmpi-${OPENMPI_VERSION}
+      if [[ "${MPI_NAME}" == "openmpi" ]]; then
+        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${MPI_VERSION}.tar.gz
+        tar -xzf openmpi-${MPI_VERSION}.tar.gz
+        cd openmpi-${MPI_VERSION}
         # --with-hwloc=internal --with-libevent=internal : https://www.open-mpi.org/faq/?category=building#libevent-or-hwloc-errors-when-linking-fortran
         if [[ "$RUNNER_OS" == "macOS" ]]; then
           ./configure --prefix=$HOME/mpi \
@@ -117,10 +117,10 @@ runs:
         fi
         make -j4
         make install
-      elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
+      elif [[ "${MPI_NAME}" == "mpich" ]]; then
         wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
-        tar -xzf mpich-${MPICH_VERSION}.tar.gz
-        cd mpich-${MPICH_VERSION}
+        tar -xzf mpich-${MPI_VERSION}.tar.gz
+        cd mpich-${MPI_VERSION}
         if [[ "$RUNNER_OS" == "macOS" ]]; then
           ./configure --prefix=$HOME/mpi \
               --enable-fortran --enable-cxx \
@@ -134,6 +134,13 @@ runs:
         fi
         make -j4
         make install
-      else
+      elif [[ "${MPI_NAME}" == "mvapich2" ]]; then
+        echo "${MPI_NAME} NOT CONFIGURED!"
+        sleep 60
+        exit 1
+      elif [[ "${MPI_NAME}" == "intel-oneapi-mpi" ]]; then
         mkdir -p $HOME/mpi
+      else
+        echo "${MPI_NAME} NOT CONFIGURED!"
+        exit 1
       fi

--- a/.github/actions/setup-externals/action.yaml
+++ b/.github/actions/setup-externals/action.yaml
@@ -2,13 +2,11 @@ name: 'setup-externals'
 description: 'Setup externals such as the Intel compiler, MPI libraries.'
 inputs:
   compiler:
-    description: 'Compiler (available options gcc@9, gcc@10, apple-clang, intel)'
+    description: 'Compiler (available options gcc, apple-clang, intel)'
     required: true
-    default: 'gcc@9'
   mpi:
-    description: 'Which MPI flavor (openmpi, mpich, intel-oneapi-mpi)'
-    required: false
-    default: 'mpich@4'
+    description: 'Which MPI flavor (openmpi, mpich, mvapich2, intel-oneapi-mpi)'
+    required: true
 
 runs:
   using: "composite"
@@ -113,7 +111,7 @@ runs:
         make -j4
         make install
       elif [[ "${MPI_NAME}" == "mpich" ]]; then
-        wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+        wget http://www.mpich.org/static/downloads/${MPI_VERSION}/mpich-${MPI_VERSION}.tar.gz
         tar -xzf mpich-${MPI_VERSION}.tar.gz
         cd mpich-${MPI_VERSION}
         if [[ "$RUNNER_OS" == "macOS" ]]; then

--- a/.github/actions/setup-externals/action.yaml
+++ b/.github/actions/setup-externals/action.yaml
@@ -142,8 +142,9 @@ runs:
           exit 1
         else
           ./configure --prefix=$HOME/mpi \
-              --enable-fortran=yes --enable-cxx \
-              --with-device=ch4:ofi
+              --enable-fortran=yes --enable-cxx
+              #--enable-fortran=yes --enable-cxx \
+              #--with-device=ch4:ofi
         fi
         make -j4
         make install

--- a/.github/actions/setup-externals/action.yaml
+++ b/.github/actions/setup-externals/action.yaml
@@ -91,6 +91,11 @@ runs:
         export CXX=icpc
       fi
 
+      MPI_NAME=`echo "${{ inputs.mpi }}" | cut -d "@" -f 1`
+      MPI_VERSION=`echo "${{ inputs.mpi }}" | cut -d "@" -f 2`
+      echo "MPI NAME IS ${MPI_NAME}, VERSION IS ${MPI_VERSION}"
+      exit 1
+
       export MPICH_VERSION="4.0.2"
       export OPENMPI_VERSION="4.1.4"
 

--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -34,7 +34,7 @@ runs:
         brew install git-lfs
         # For now we need gcc-10/gfortran-10
         brew install gcc@10
-        # Also install the llvm clang compilers, use 12
+        # Also install the llvm clang-12 compilers for later use
         brew install llvm@12
         brew install lmod
         brew install qt@5

--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -40,10 +40,6 @@ runs:
         brew install qt@5
         brew install readline
         brew install wget
-        ls -l /usr/local/Cellar
-
-        ls -l /usr/local/Cellar/llvm
-        exit 1
 
         ### # Remove macOS native Python 3.11 from /usr/local/bin
         ### cd /usr/local/bin

--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -41,28 +41,7 @@ runs:
         brew install readline
         brew install wget
 
-        ### # Remove macOS native Python 3.11 from /usr/local/bin
-        ### cd /usr/local/bin
-        ### rm 2to3-3.11
-        ### rm idle3.11
-        ### rm pip3.11
-        ### rm pydoc3.11
-        ### rm python3.11
-        ### rm python3.11-config
-        ### rm python3.11-intel64
-        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/2to3-3.10 2to3 
-        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/idle3.10 idle3
-        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/pip3.10 pip3
-        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/pydoc3.10 pydoc3
-        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/python3.10 python3
-        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/python3.10-config python3-config
-        ### #ln -sf ... python3-intel64 # doesn't exist
-        ### ls -l /usr/local/bin
-
         # Print version of xcode
         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
-
-        ### # Install Python poetry to avoid install errors in spack
-        ### python3 -m pip install poetry
 
       fi

--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -34,11 +34,16 @@ runs:
         brew install git-lfs
         # For now we need gcc-10/gfortran-10
         brew install gcc@10
+        # Also install the llvm clang compilers, use 12
+        brew install llvm@12
         brew install lmod
         brew install qt@5
         brew install readline
         brew install wget
         ls -l /usr/local/Cellar
+
+        ls -l /usr/local/Cellar/llvm
+        exit 1
 
         ### # Remove macOS native Python 3.11 from /usr/local/bin
         ### cd /usr/local/bin

--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -29,10 +29,9 @@ runs:
         sudo apt-get install qt5-default qttools5-dev-tools libqt5svg5-dev
 
       elif [[ "$RUNNER_OS" == "macOS" ]]; then
-        # These are already installed
-        #brew install curl
-        #brew install git
-        #brew install git-lfs
+        brew install curl
+        brew install git
+        brew install git-lfs
         # For now we need gcc-10/gfortran-10
         brew install gcc@10
         brew install lmod
@@ -41,31 +40,28 @@ runs:
         brew install wget
         ls -l /usr/local/Cellar
 
-        # Remove macOS native Python 3.11 from /usr/local/bin
-        cd /usr/local/bin
-        rm 2to3-3.11
-        rm idle3.11
-        rm pip3.11
-        rm pydoc3.11
-        rm python3.11
-        rm python3.11-config
-        rm python3.11-intel64
-        ln -sf ../Cellar/python@3.10/3.10.8/bin/2to3-3.10 2to3 
-        ln -sf ../Cellar/python@3.10/3.10.8/bin/idle3.10 idle3
-        ln -sf ../Cellar/python@3.10/3.10.8/bin/pip3.10 pip3
-        ln -sf ../Cellar/python@3.10/3.10.8/bin/pydoc3.10 pydoc3
-        ln -sf ../Cellar/python@3.10/3.10.8/bin/python3.10 python3
-        ln -sf ../Cellar/python@3.10/3.10.8/bin/python3.10-config python3-config
-        #ln -sf ... python3-intel64 # doesn't exist
-        ls -l /usr/local/bin
+        ### # Remove macOS native Python 3.11 from /usr/local/bin
+        ### cd /usr/local/bin
+        ### rm 2to3-3.11
+        ### rm idle3.11
+        ### rm pip3.11
+        ### rm pydoc3.11
+        ### rm python3.11
+        ### rm python3.11-config
+        ### rm python3.11-intel64
+        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/2to3-3.10 2to3 
+        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/idle3.10 idle3
+        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/pip3.10 pip3
+        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/pydoc3.10 pydoc3
+        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/python3.10 python3
+        ### ln -sf ../Cellar/python@3.10/3.10.8/bin/python3.10-config python3-config
+        ### #ln -sf ... python3-intel64 # doesn't exist
+        ### ls -l /usr/local/bin
 
         # Print version of xcode
         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
 
-        # Install Python poetry to avoid install errors in spack
-        python3 -m pip install poetry
+        ### # Install Python poetry to avoid install errors in spack
+        ### python3 -m pip install poetry
 
       fi
-
-      ## Install Python poetry to avoid install errors in spack
-      #python3 -m pip install poetry

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -187,8 +187,8 @@ runs:
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
-      # Set compiler as hard requirement for all packages
-      spack config add "packages:all:require:one_of:['%${{ inputs.compiler }}']"
+      ## Set compiler as hard requirement for all packages
+      #spack config add "packages:all:require:one_of:['%${{ inputs.compiler }}']"
 
       if [[ "$RUNNER_OS" == "macOS" ]]; then
         # Turn of SSL for ecflow CI builds for now

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -87,6 +87,13 @@ runs:
       echo "Cached ~/spack-mirror not found!"
       exit 1
 
+  - name: bootstrap-spack
+    shell: bash
+    run: |
+      cd ${{ inputs.path }}
+      source setup.sh
+      spack bootstrap now
+
   - name: setup-spack-env
     shell: bash
     run: |
@@ -188,7 +195,7 @@ runs:
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
       ## Set compiler as hard requirement for all packages
-      #spack config add "packages:all:require:one_of:['%${{ inputs.compiler }}']"
+      spack config add "packages:all:require:one_of:['%${{ inputs.compiler }}']"
 
       if [[ "$RUNNER_OS" == "macOS" ]]; then
         # Turn of SSL for ecflow CI builds for now

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -249,17 +249,17 @@ runs:
     run: |
       if [[ ! "${{ inputs.templates }}" == "empty" ]]; then
         cd ${{ inputs.path }}
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
-          # Not yet: need lmod installed, loaded and module use command
-          echo ""
-        elif [[ "$RUNNER_OS" == "macOS" ]]; then
-          # This needs more work
-          #source /usr/local/opt/lmod/init/profile
-          #module use $PWD/envs/${{ inputs.name }}/install/modulefiles/Core
-          #module load stack-${{ inputs.compiler }}
-          #module load stack-python
-          #module load stack-${{ inputs.mpi }}
-        fi
+        #if [[ "$RUNNER_OS" == "Linux" ]]; then
+        #  # Not yet: need lmod installed, loaded and module use command
+        #  echo ""
+        #elif [[ "$RUNNER_OS" == "macOS" ]]; then
+        #  # This needs more work
+        #  #source /usr/local/opt/lmod/init/profile
+        #  #module use $PWD/envs/${{ inputs.name }}/install/modulefiles/Core
+        #  #module load stack-${{ inputs.compiler }}
+        #  #module load stack-python
+        #  #module load stack-${{ inputs.mpi }}
+        #fi
       fi
 
   - name: Upload logs

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -114,8 +114,8 @@ runs:
         spack compiler find
       fi
 
-      # Need to find external packages with the correct compiler,
-      # no way to do that with spack commands.
+      # Need to find external packages and annotate with the
+      # correct compiler, no way to do that with spack commands.
       MPI_NAME=`echo "${{ inputs.mpi }}" | cut -d "@" -f 1`
       MPI_VERSION=`echo "${{ inputs.mpi }}" | cut -d "@" -f 2`
       if [[ "${MPI_NAME}" == "intel-oneapi-mpi" ]]; then
@@ -168,7 +168,7 @@ runs:
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
-      ## Set compiler as hard requirement for all packages
+      # Set compiler as hard requirement for all packages
       spack config add "packages:all:require:one_of:['%${{ inputs.compiler }}']"
 
       if [[ "$RUNNER_OS" == "macOS" ]]; then

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -138,36 +138,10 @@ runs:
       echo "      - spec: ${MPI_NAME}@${MPI_VERSION}%${{ inputs.compiler }}" >> ${SPACK_ENV}/spack.yaml
       echo "        prefix: ${MPI_PREFIX}" >> ${SPACK_ENV}/spack.yaml
 
-      ### # No external find for intel-oneapi-mpi, 
-      ### # And no way to add object entry to list using "spack config add"
-      ### # Add this first so "spack config add packages:" will append to this entry
-      ### if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-      ###   impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
-      ###   echo "" >> ${SPACK_ENV}/spack.yaml
-      ###   echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-      ###   echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
-      ###   echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-      ###   echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-      ###   echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
-      ###   echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
-      ### else
-      ###   # So Spack can find external MPI
-      ###   export "PATH=$HOME/mpi/bin:${PATH}"
-      ### fi
-
       # Spack external find is by default only looking for build-tools, Either
       # need to search for additional packages explicitly.
       spack external find
-      ### spack external find mpich
-      ### spack external find openmpi
       spack external find perl
-      ### #if [[ "$RUNNER_OS" == "Linux" ]]; then
-      ### #  spack external find --not-buildable python
-      ### #elif [[ "$RUNNER_OS" == "macOS" ]]; then
-      ### if [[ "$RUNNER_OS" == "macOS" ]]; then
-      ###   # Jail spack external find to /usr/local to ignore Framework python
-      ###   spack external find --not-buildable --path /usr/local python
-      ### fi
       spack external find wget
 
       # Find homebrew qt@5 on macOS
@@ -279,11 +253,12 @@ runs:
           # Not yet: need lmod installed, loaded and module use command
           echo ""
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
-          source /usr/local/opt/lmod/init/profile
-          module use $PWD/envs/${{ inputs.name }}/install/modulefiles/Core
-          module load stack-${{ inputs.compiler }}
-          module load stack-python
-          module load stack-${{ inputs.mpi }}
+          # This needs more work
+          #source /usr/local/opt/lmod/init/profile
+          #module use $PWD/envs/${{ inputs.name }}/install/modulefiles/Core
+          #module load stack-${{ inputs.compiler }}
+          #module load stack-python
+          #module load stack-${{ inputs.mpi }}
         fi
       fi
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -165,8 +165,8 @@ runs:
       spack config add "packages:mpi:buildable:False"
       spack config add "packages:all:providers:mpi:[${{ inputs.mpi }}]"
       spack config add "packages:all:compiler:[${{ inputs.compiler }}]"
-      # This is not working as expected
-      #spack config add "packages:all:require:'%${{ inputs.compiler }}'"
+      # Set compiler as hard requirement for all packages
+      spack config add "packages:all:require:one_of:['%${{ inputs.compiler }}']"
 
       if [[ "$RUNNER_OS" == "macOS" ]]; then
         # Turn of SSL for ecflow CI builds for now

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -109,28 +109,53 @@ runs:
         spack compiler find
       fi
 
-      # No external find for intel-oneapi-mpi, 
-      # And no way to add object entry to list using "spack config add"
-      # Add this first so "spack config add packages:" will append to this entry
+      # Need to find external packages with the correct compiler,
+      # no way to do that with spack commands.
       if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-        impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
-        echo "" >> ${SPACK_ENV}/spack.yaml
-        echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-        echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
-        echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
-        echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-        echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
-        echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
+        MPI_VERSION=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+        MPI_PREFIX="/opt/intel/oneapi"
+      elif [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
+        # DH* How to detect from package?
+        MPI_VERSION="4.1.4"
+        MPI_PREFIX="$HOME/mpi"
+      elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
+        # DH* How to detect from package?
+        MPI_VERSION="4.0.2"
+        MPI_PREFIX="$HOME/mpi"
       else
-        # So Spack can find external MPI
-        export "PATH=$HOME/mpi/bin:${PATH}"
+        echo "Malformed MPI provider, can only use 'intel-oneapi-mpi', 'openmpi', 'mpich'."
+        exit 1
       fi
+      echo "" >> ${SPACK_ENV}/spack.yaml
+      echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+      echo "    ${{ inputs.mpi }}:" >> ${SPACK_ENV}/spack.yaml
+      echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+      echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+      echo "      - spec: ${{ inputs.mpi }}@${MPI_VERSION}%${{ inputs.compiler }}" >> ${SPACK_ENV}/spack.yaml
+      echo "        prefix: ${MPI_PREFIX}" >> ${SPACK_ENV}/spack.yaml
+
+      ### # No external find for intel-oneapi-mpi, 
+      ### # And no way to add object entry to list using "spack config add"
+      ### # Add this first so "spack config add packages:" will append to this entry
+      ### if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
+      ###   impi_ver=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+      ###   echo "" >> ${SPACK_ENV}/spack.yaml
+      ###   echo "  packages:" >> ${SPACK_ENV}/spack.yaml
+      ###   echo "    intel-oneapi-mpi:" >> ${SPACK_ENV}/spack.yaml
+      ###   echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
+      ###   echo "      externals:" >> ${SPACK_ENV}/spack.yaml
+      ###   echo "      - spec: intel-oneapi-mpi@${impi_ver}" >> ${SPACK_ENV}/spack.yaml
+      ###   echo "        prefix: /opt/intel/oneapi" >> ${SPACK_ENV}/spack.yaml
+      ### else
+      ###   # So Spack can find external MPI
+      ###   export "PATH=$HOME/mpi/bin:${PATH}"
+      ### fi
 
       # Spack external find is by default only looking for build-tools, Either
       # need to search for additional packages explicitly.
       spack external find
-      spack external find mpich
-      spack external find openmpi
+      ### spack external find mpich
+      ### spack external find openmpi
       spack external find perl
       ### #if [[ "$RUNNER_OS" == "Linux" ]]; then
       ### #  spack external find --not-buildable python

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -10,13 +10,11 @@ inputs:
     required: false
     default: 'empty'
   compiler:
-    description: 'Compiler (available options gcc@9, gcc@10, apple-clang, intel)'
+    description: 'Compiler (available options gcc, apple-clang, intel)'
     required: true
-    default: 'gcc@9'
   mpi:
     description: 'Which MPI flavor (openmpi, mpich, intel-oneapi-mpi)'
-    required: false
-    default: 'mpich@4'
+    required: true
   path:
     description: 'Use custom checkout of Spack Stack. Useful in the Spack repo CI.'
     required: false
@@ -111,27 +109,26 @@ runs:
 
       # Need to find external packages with the correct compiler,
       # no way to do that with spack commands.
-      if [[ "${{ inputs.mpi }}" == "intel-oneapi-mpi" ]]; then
-        MPI_VERSION=$(find /opt/intel/oneapi/mpi -maxdepth 1 -mindepth 1 -type d | xargs basename)
+      MPI_NAME=`echo "${{ inputs.mpi }}" | cut -d "@" -f 1`
+      MPI_VERSION=`echo "${{ inputs.mpi }}" | cut -d "@" -f 2`
+      if [[ "${MPI_NAME}" == "intel-oneapi-mpi" ]]; then
         MPI_PREFIX="/opt/intel/oneapi"
-      elif [[ "${{ inputs.mpi }}" == "openmpi"* ]]; then
-        # DH* How to detect from package?
-        MPI_VERSION="4.1.4"
+      elif [[ "${MPI_NAME}" == "openmpi" ]]; then
         MPI_PREFIX="$HOME/mpi"
-      elif [[ "${{ inputs.mpi }}" == "mpich"* ]]; then
-        # DH* How to detect from package?
-        MPI_VERSION="4.0.2"
+      elif [[ "${MPI_NAME}" == "mpich" ]]; then
+        MPI_PREFIX="$HOME/mpi"
+      elif [[ "${MPI_NAME}" == "mvapich2" ]]; then
         MPI_PREFIX="$HOME/mpi"
       else
-        echo "Malformed MPI provider, can only use 'intel-oneapi-mpi', 'openmpi', 'mpich'."
+        echo "Malformed MPI provider, can only use 'intel-oneapi-mpi', 'openmpi', 'mpich', 'mvapich2'."
         exit 1
       fi
       echo "" >> ${SPACK_ENV}/spack.yaml
       echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-      echo "    ${{ inputs.mpi }}:" >> ${SPACK_ENV}/spack.yaml
+      echo "    ${${MPI_NAME}}:" >> ${SPACK_ENV}/spack.yaml
       echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
       echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-      echo "      - spec: ${{ inputs.mpi }}@${MPI_VERSION}%${{ inputs.compiler }}" >> ${SPACK_ENV}/spack.yaml
+      echo "      - spec: ${${MPI_NAME}}@${MPI_VERSION}%${{ inputs.compiler }}" >> ${SPACK_ENV}/spack.yaml
       echo "        prefix: ${MPI_PREFIX}" >> ${SPACK_ENV}/spack.yaml
 
       ### # No external find for intel-oneapi-mpi, 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -125,10 +125,10 @@ runs:
       fi
       echo "" >> ${SPACK_ENV}/spack.yaml
       echo "  packages:" >> ${SPACK_ENV}/spack.yaml
-      echo "    ${${MPI_NAME}}:" >> ${SPACK_ENV}/spack.yaml
+      echo "    ${MPI_NAME}:" >> ${SPACK_ENV}/spack.yaml
       echo "      buildable: False" >> ${SPACK_ENV}/spack.yaml
       echo "      externals:" >> ${SPACK_ENV}/spack.yaml
-      echo "      - spec: ${${MPI_NAME}}@${MPI_VERSION}%${{ inputs.compiler }}" >> ${SPACK_ENV}/spack.yaml
+      echo "      - spec: ${MPI_NAME}@${MPI_VERSION}%${{ inputs.compiler }}" >> ${SPACK_ENV}/spack.yaml
       echo "        prefix: ${MPI_PREFIX}" >> ${SPACK_ENV}/spack.yaml
 
       ### # No external find for intel-oneapi-mpi, 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -132,23 +132,22 @@ runs:
       spack external find mpich
       spack external find openmpi
       spack external find perl
-      #if [[ "$RUNNER_OS" == "Linux" ]]; then
-      #  spack external find --not-buildable python
-      #elif [[ "$RUNNER_OS" == "macOS" ]]; then
-      if [[ "$RUNNER_OS" == "macOS" ]]; then
-        # Jail spack external find to /usr/local to ignore Framework python
-        spack external find --not-buildable --path /usr/local python
-      fi
+      ### #if [[ "$RUNNER_OS" == "Linux" ]]; then
+      ### #  spack external find --not-buildable python
+      ### #elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      ### if [[ "$RUNNER_OS" == "macOS" ]]; then
+      ###   # Jail spack external find to /usr/local to ignore Framework python
+      ###   spack external find --not-buildable --path /usr/local python
+      ### fi
       spack external find wget
 
-      # Make homebrew qt@5 detectable on macOS
-      PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt
+      # Find homebrew qt@5 on macOS
+      spack external find --path /usr/local/opt/qt@5 qt
 
       if [[ "$RUNNER_OS" == "Linux" ]]; then
         spack external find curl
       elif [[ "$RUNNER_OS" == "macOS" ]]; then
-        # Make homebrew curl detectable on macOS
-        PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl
+        spack external find --path /usr/local/opt/curl curl
       fi
 
   - name: configure-options
@@ -253,14 +252,9 @@ runs:
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           source /usr/local/opt/lmod/init/profile
           module use $PWD/envs/${{ inputs.name }}/install/modulefiles/Core
-          # This needs more work: need to replace "${{ inputs.compiler }}" = "gcc@9"
-          # with "gcc/9", otherwise the module load command will fail.
-          # module load stack-${{ inputs.compiler }}
-          # module load stack-python
-          # # jedi-tools doesn't have any mpi dependencies
-          # if [[ ! "${{ inputs.specs }}" == "jedi-tools" ]]; then
-          #   module load stack-${{ inputs.mpi }}
-          # fi
+          module load stack-${{ inputs.compiler }}
+          module load stack-python
+          module load stack-${{ inputs.mpi }}
         fi
       fi
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
+        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: clang@14.0.0, mpi: mpich@4.0.2}  ]
     runs-on: macos-11
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
+        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: clang@14.0.0, mpi: mpich@4.0.2} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: macos-11
     steps:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: apple-clang, mpi: openmpi@4}, {compiler: gcc@10, mpi: mpich@4} ]
+        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
     runs-on: macos-11
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: apple-clang, mpi: openmpi@4}, {compiler: gcc@10, mpi: mpich@4} ]
+        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: macos-11
     steps:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: clang@14.0.0, mpi: mpich@4.0.2}  ]
+        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4} ]
     runs-on: macos-11
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4}, {compiler: clang@14.0.0, mpi: mpich@4.0.2} ]
+        compiler-mpi: [ {compiler: apple-clang@13.0.0, mpi: openmpi@4.1.4} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: macos-11
     steps:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
+        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7}, {compiler: gcc@10.3.0, mpi: mpich@4.0.2} ]
     runs-on: ubuntu-20.04
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
+        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7}, {compiler: gcc@10.3.0, mpi: mpich@4.0.2} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel@2023.0.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
+        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
     runs-on: ubuntu-20.04
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel@2023.0.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
+        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel, mpi: intel-oneapi-mpi}, {compiler: gcc@9, mpi: mpich@4} ]
+        compiler-mpi: [ {compiler: intel@2023.0.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
     runs-on: ubuntu-20.04
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel, mpi: intel-oneapi-mpi}, {compiler: gcc@9, mpi: mpich@4} ]
+        compiler-mpi: [ {compiler: intel@2023.0.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -41,7 +41,7 @@ jobs:
   cache-externals:
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
+        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
     runs-on: ubuntu-20.04
     steps:
 
@@ -60,7 +60,7 @@ jobs:
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:
-        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7} ]
+        compiler-mpi: [ {compiler: intel@2021.8.0, mpi: intel-oneapi-mpi@2021.8.0}, {compiler: gcc@9.4.0, mpi: mvapich2@2.3.7}, {compiler: gcc@10.4.0, mpi: mpich@4.0.2} ]
         template: [skylab-dev, ufs-weather-model, ufs-srw-dev]
     runs-on: ubuntu-20.04
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/move_packages_to_builtin
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/move_packages_to_builtin
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
## Description

1. Fix problem with CI runs not using the correct compilers by using the new-ish `require` syntax (hard requirements). Because the correct compilers are now enforced,
    (a) We can't use `gcc` on macOS anymore (`cpython` doesn't build with `gcc` on macOS) - move to Linux
    (b) We specify explicitly the compiler dependency for the MPI library (externally supplied)
2. Always build Python with spack in the CI tests (in preparation for doing the same on all user platforms in the future)
3. Add the `mvapich2` MPI library to the CI tests.

The CI changes also clean up how version information is supplied (it is now all in the workflow yaml files, as opposed to buried inside the action files).

The PR also updates the submodule pointer for spack for the changes described in https://github.com/NOAA-EMC/spack/pull/212 (Move packages from jcsda-emc "repository" to builtin)

## Issues

Fixes https://github.com/NOAA-EMC/spack-stack/issues/429

## Testing

- Tested locally on @climbfuji's macOS
- CI tests currently running (need to change the "expected" tests in the repo/branch settings due to the changes described above)
