### PR TITLE
Acorn config update

### DIFF
--- a/configs/sites/acorn/compilers.yaml
+++ b/configs/sites/acorn/compilers.yaml
@@ -10,7 +10,7 @@ compilers:
     operating_system: sles15
     target: any
     modules:
-    - PrgEnv-intel
+    - PrgEnv-intel/8.3.3
     - intel/19.1.3.304
     - craype/2.7.13
     environment:

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -1,49 +1,77 @@
   packages:
+    all:
+      compiler:: [intel@19.1.3.304,cce@14.0.3]
+      providers:
+        mpi:: [cray-mpich@8.1.9]
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@8.1.9~wrappers
+        modules:
+        - libfabric
+        - craype-network-ofi
+        - cray-mpich/8.1.9
     openssl:
+      buildable: false
       externals:
       - spec: openssl@1.1.1d
         prefix: /usr
     tar:
+      buildable: false
       externals:
-      - spec: tar@1.30
+      - spec: tar@1.34
         prefix: /usr
     diffutils:
+      buildable: false
       externals:
       - spec: diffutils@3.6
         prefix: /usr
     pkgconfig:
       buildable: false
     m4:
+      buildable: false
       externals:
       - spec: m4@1.4.18
         prefix: /usr
     openssh:
+      buildable: false
       externals:
       - spec: openssh@8.4p1
         prefix: /usr
     pkg-config:
+      buildable: false
       externals:
       - spec: pkg-config@0.29.2
         prefix: /usr
     wget:
+      buildable: false
       externals:
       - spec: wget@1.20.3
         prefix: /usr
     cmake:
+      buildable: false
       externals:
       - spec: cmake@3.20.2
         prefix: /apps/spack/cmake/3.20.2/intel/19.1.3.304/utnbptm3hrf7gppztidueu4jogfgemut
-      - spec: cmake@3.17.0
-        prefix: /usr
     git:
+      buildable: false
       externals:
-      - spec: git@2.34.1+tcltk
+      - spec: git@2.35.3
         prefix: /usr
+      externals:
+      - spec: git@2.29.0
+        modules: [git/2.29.0]
+    git-lfs:
+      buildable: false
+      externals:
+      - spec: git-lfs@2.11.0
+        modules: [git-lfs/2.11.0]
     python:
+      buildable: false
       externals:
       - spec: python@3.8.6+bz2+ctypes+dbm+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
         prefix: /apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk
     perl:
+      buildable: false
       externals:
       - spec: perl@5.26.1~cpanm+shared+threads
         prefix: /usr

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -1,6 +1,6 @@
   packages:
     all:
-      compiler:: [intel@19.1.3.304,cce@14.0.3]
+      compiler:: [intel@19.1.3.304]
       providers:
         mpi:: [cray-mpich@8.1.9]
     cray-mpich:

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -51,7 +51,7 @@
       buildable: false
       externals:
       - spec: cmake@3.20.2
-        prefix: /apps/spack/cmake/3.20.2/intel/19.1.3.304/utnbptm3hrf7gppztidueu4jogfgemut
+        modules: [cmake/3.20.2]
     git:
       buildable: false
       externals:
@@ -68,10 +68,21 @@
     python:
       buildable: false
       externals:
-      - spec: python@3.8.6+bz2+ctypes+dbm+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-        prefix: /apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk
+      - spec: python@3.8.6+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib
+        modules: [python/3.8.6]
+    # On Acorn, perl module requires gcc :(
     perl:
       buildable: false
       externals:
       - spec: perl@5.26.1~cpanm+shared+threads
         prefix: /usr
+    curl:
+      buildable: false
+      externals:
+      - spec: curl@7.72.0
+        modules: [curl/7.72.0]
+    libxml2:
+      buildable: false
+      externals:
+      - spec: libxml2@2.9.10
+        modules: [libxml2/2.9.10]


### PR DESCRIPTION
This PR makes the following changes to the Acorn site config:

1. Explicitly add PrgEnv-intel version number in compilers.yaml
2. Add intel and cray-mpich as compiler/provider in packages.yaml
3. Add external cray-mpich (with libfabric/ofi modules) to packages.yaml
4. Set `buildable: false` for most packages (to stay as close to possible to operational environment; these can be rolled back if absolutely needed)
5. Add a couple other external packages
6. Update tar version
7. Update python spec

Once the ESMF/MPICH issue is resolved (https://github.com/spack/spack/issues/34720), then knock on wood, we should be able to install UFS deps with spack-stack on Acorn with minimal hassle.