### PR TITLE
Add GCC to Acorn config

### DIFF
--- a/configs/sites/acorn/compilers.yaml
+++ b/configs/sites/acorn/compilers.yaml
@@ -20,3 +20,24 @@ compilers:
         # which confuses some packages.
         CONFIG_SITE: ''
     extra_rpaths: []
+- compiler:
+    spec: gcc@12.1.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    target: any
+    modules:
+    - PrgEnv-gnu/8.3.3
+    - gcc/12.1.0
+    - craype/2.7.13
+    environment:
+      set:
+        # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 
+        # Automake-based builds are installed in lib64 
+        # which confuses some packages.
+        CONFIG_SITE: ''
+    extra_rpaths: []

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -1,6 +1,6 @@
   packages:
     all:
-      compiler:: [intel@19.1.3.304]
+      compiler:: [intel@19.1.3.304,gcc@12.1.0]
       providers:
         mpi:: [cray-mpich@8.1.9]
     cray-mpich:


### PR DESCRIPTION
Adding GCC to Acorn config. Builds ufs-weather-model-static successfully. No special configuration compared with Intel (both are using Cray wrappers).