### PR TITLE
Add python to default modules for linux and macos

### DIFF
--- a/configs/sites/linux.default/modules.yaml
+++ b/configs/sites/linux.default/modules.yaml
@@ -7,3 +7,4 @@ modules:
       # List of packages for which we need modules that are blacklisted by default
       - openmpi
       - mpich
+      - python

--- a/configs/sites/macos.default/modules.yaml
+++ b/configs/sites/macos.default/modules.yaml
@@ -7,3 +7,4 @@ modules:
       # List of packages for which we need modules that are blacklisted by default
       - openmpi
       - mpich
+      - python


### PR DESCRIPTION
This PR places the python package on the module whitelist for generic linux and macos sites. It leaves python on the module blacklist for the HPC sites since the HPC platforms are currently providing an external python module. This change is being done to support the methodology of always building python in the stack for non HPC linux and macos platforms.

Fixes #432