### PR TITLE
Update python load command for AWS Red Hat 8

### DIFF
--- a/doc/source/Platforms.rst
+++ b/doc/source/Platforms.rst
@@ -430,7 +430,7 @@ For ``spack-stack-1.2.0``/``skylab-3.0.0``, use a c6i.2xlarge instance or simila
    module use /home/ec2-user/spack-stack-v1/envs/skylab-3.0.0-gcc-11.2.1/install/modulefiles/Core
    module load stack-gcc/11.2.1
    module load stack-openmpi/4.1.4
-   module load stack-python/3.9.7
+   module load stack-python/3.9.13
    module available
 
 ..  _Platform_New_Site_Configs:


### PR DESCRIPTION
See https://github.com/JCSDA-internal/jedi-docs/pull/542#pullrequestreview-1244246609 (if you can).
> One command is that iin the list of modules to load for AWS Red Hat 8, it is now module load stack-python/3.9.13 instead of module load stack-python/3.9.7

No testing needed, can be merged anytime.