### PR TITLE
Add gaea-c5 config

### DIFF
--- a/configs/sites/gaea-c5/compilers.yaml
+++ b/configs/sites/gaea-c5/compilers.yaml
@@ -1,0 +1,22 @@
+compilers:
+- compiler:
+    spec: intel@2022.0.2
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    target: any
+    modules:
+    - PrgEnv-intel/8.3.3
+    - intel/2022.0.2
+    - craype/2.7.15
+    environment:
+      set:
+        # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 
+        # Automake-based builds are installed in lib64 
+        # which confuses some packages.
+        CONFIG_SITE: ''
+    extra_rpaths: []

--- a/configs/sites/gaea-c5/config.yaml
+++ b/configs/sites/gaea-c5/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 6

--- a/configs/sites/gaea-c5/modules.yaml
+++ b/configs/sites/gaea-c5/modules.yaml
@@ -1,0 +1,4 @@
+modules:
+  default:
+    enable::
+    - lmod

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -62,10 +62,6 @@
       externals:
       - spec: bzip2@1.0.6
         prefix: /usr
-    cmake:
-      externals:
-      - spec: cmake@3.17.0
-        prefix: /usr
     coreutils:
       externals:
       - spec: coreutils@8.32

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -1,0 +1,214 @@
+  packages:
+    all:
+      compiler:: [intel@2022.0.2]
+      providers:
+        mpi:: [cray-mpich@8.1.16]
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@8.1.16~wrappers
+        modules:
+        - libfabric
+        - craype-network-ofi
+        - cray-mpich/8.1.16
+    esmf:
+      version: [8.3.0b09]
+      variants: ~xerces ~pnetcdf +pio esmf_os=Linux esmf_comm=mpich3
+    cmake:
+      buildable: false
+      externals:
+      - spec: cmake@3.23.1
+        modules: [cmake/3.23.1]
+    git:
+      buildable: false
+      externals:
+      - spec: git@2.35.2
+        modules: [git/2.35.2]
+    git-lfs:
+      buildable: false
+      externals:
+      - spec: git-lfs@2.11.0
+        modules: [git-lfs/2.11.0]
+    pkg-config:
+      buildable: false
+      externals:
+      - spec: pkg-config@0.29.2
+        prefix: /usr
+    python:
+      buildable: false
+      externals:
+      - spec: python@3.9.12 +bz2 +ctypes +dbm ~debug +libxml2 +lzma ~nis ~optimizations +pic +pyexpat +pythoncmd +readline +shared +sqlite3 +ssl ~tix ~tkinter +uuid +zlib
+        modules: [python/3.9.12]
+    autoconf:
+      externals:
+      - spec: autoconf@2.69
+        prefix: /usr
+    automake:
+      externals:
+      - spec: automake@1.15.1
+        prefix: /usr
+    bash:
+      externals:
+      - spec: bash@4.4.23
+        prefix: /usr
+    binutils:
+      externals:
+      - spec: binutils@2.37.20211103
+        prefix: /usr
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /usr
+    cmake:
+      externals:
+      - spec: cmake@3.17.0
+        prefix: /usr
+    coreutils:
+      externals:
+      - spec: coreutils@8.32
+        prefix: /usr
+    cpio:
+      externals:
+      - spec: cpio@2.12
+        prefix: /usr
+    curl:
+      externals:
+      - spec: curl@7.66.0+gssapi+ldap+nghttp2
+        prefix: /usr
+    diffutils:
+      externals:
+      - spec: diffutils@3.6
+        prefix: /usr
+    dos2unix:
+      externals:
+      - spec: dos2unix@7.4.0
+        prefix: /usr
+    file:
+      externals:
+      - spec: file@5.32
+        prefix: /usr
+    findutils:
+      externals:
+      - spec: findutils@4.8.0
+        prefix: /usr
+    flex:
+      externals:
+      - spec: flex@2.6.4+lex
+        prefix: /usr
+    gawk:
+      externals:
+      - spec: gawk@4.2.1
+        prefix: /usr
+    gettext:
+      externals:
+      - spec: gettext@0.20.2
+        prefix: /usr
+    ghostscript:
+      externals:
+      - spec: ghostscript@9.52
+        prefix: /usr
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+    groff:
+      externals:
+      - spec: groff@1.22.3
+        prefix: /usr
+    hwloc:
+      externals:
+      - spec: hwloc@2.6.0a1
+        prefix: /usr
+    openjdk:
+      externals:
+      - spec: openjdk@11.0.16_8-suse-150000.3.83.1-x8664
+        prefix: /usr
+    libfuse:
+      externals:
+      - spec: libfuse@2.9.7
+        prefix: /usr
+      - spec: libfuse@3.6.1
+        prefix: /usr
+    libtool:
+      externals:
+      - spec: libtool@2.4.6
+        prefix: /usr
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.7
+        prefix: /usr
+    lustre:
+      externals:
+      - spec: lustre@2.15.0.2_rc2_cray_113_g62287d0
+        prefix: /usr
+    m4:
+      externals:
+      - spec: m4@1.4.18
+        prefix: /usr
+    ncurses:
+      externals:
+      - spec: ncurses@6.1.20180317+termlib abi=6
+        prefix: /usr
+    openssh:
+      externals:
+      - spec: openssh@8.4p1
+        prefix: /usr
+    openssl:
+      externals:
+      - spec: openssl@1.1.1d
+        prefix: /usr
+    perl:
+      externals:
+      - spec: perl@5.26.1~cpanm+shared+threads
+        prefix: /usr
+    rsync:
+      externals:
+      - spec: rsync@3.1.3
+        prefix: /usr
+    ruby:
+      externals:
+      - spec: ruby@2.5.9
+        prefix: /usr
+    sed:
+      externals:
+      - spec: sed@4.4
+        prefix: /usr
+    slurm:
+      externals:
+      - spec: slurm@21.08.8
+        prefix: /usr
+    subversion:
+      externals:
+      - spec: subversion@1.10.6
+        prefix: /usr
+    tar:
+      externals:
+      - spec: tar@1.34
+        prefix: /usr
+    texinfo:
+      externals:
+      - spec: texinfo@6.5
+        prefix: /usr
+    wget:
+      externals:
+      - spec: wget@1.20.3
+        prefix: /usr
+    which:
+      externals:
+      - spec: which@2.21
+        prefix: /usr
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr
+    zip:
+      externals:
+      - spec: zip@3.0
+        prefix: /usr
+    rdma-core:
+      externals:
+      - spec: rdma-core@37.0
+        prefix: /usr


### PR DESCRIPTION
This PR adds "gaea-c5" to site configs. I've only added intel compiler so far. For packages.yaml, I added cmake, python, git, and git-lfs based on modules, then used "spack external find --all" for everything else. I've set "buildable: false" for several packages to make builds faster but these aren't strictly needed. I've added the same esmf scheme as for acorn (esmf_os/esmf_comm).