### PR TITLE
Add py-pip to containers (`README.md`)

### DIFF
--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -13,9 +13,12 @@ runs:
         # Needed for the following apt-get install calls to work
         sudo apt-get update
 
-        # Install Curl/ssl headers. Executables exist by default in spack external find.
-        sudo apt-get install libcurl4-openssl-dev
-        sudo apt-get install libssl-dev
+        set +eo pipefail
+        # TEST # Install Curl/ssl headers. Executables exist by default in spack external find.
+        # TEST #sudo apt-get install libcurl4-openssl-dev
+        # TEST #sudo apt-get install libssl-dev
+        sudo apt-get remove curl libcurl4-openssl-dev
+        set -eo pipefail
 
         # Install git-lfs to avoid compilation errors of "go" with Intel
         sudo apt-get install git-lfs

--- a/.github/actions/setup-os/action.yaml
+++ b/.github/actions/setup-os/action.yaml
@@ -14,9 +14,7 @@ runs:
         sudo apt-get update
 
         set +eo pipefail
-        # TEST # Install Curl/ssl headers. Executables exist by default in spack external find.
-        # TEST #sudo apt-get install libcurl4-openssl-dev
-        # TEST #sudo apt-get install libssl-dev
+        # Remove curl to avoid build errors on Ubuntu
         sudo apt-get remove curl libcurl4-openssl-dev
         set -eo pipefail
 

--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -147,9 +147,10 @@ runs:
       # Find homebrew qt@5 on macOS
       spack external find --path /usr/local/opt/qt@5 qt
 
-      if [[ "$RUNNER_OS" == "Linux" ]]; then
-        spack external find curl
-      elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      # if [[ "$RUNNER_OS" == "Linux" ]]; then
+      #   spack external find curl
+      # elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      if [[ "$RUNNER_OS" == "macOS" ]]; then
         spack external find --path /usr/local/opt/curl curl
       fi
 

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -12,7 +12,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.5.4, nlohmann-json-schema-validator@2.1.0, nlohmann-json@3.10.5,
     parallel-netcdf@1.12.2, parallelio@2.5.7, py-eccodes@1.4.2, py-f90nml@1.4.3, py-numpy@1.22.3,
-    py-pandas@1.4.0, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
+    py-pandas@1.4.0, py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4-jedi.2, shumlib@macos_clang_linux_intel_port]
     # Don't build ESMF and MAPL for now:


### PR DESCRIPTION
## Description.

As the title says. Tested, fixes https://github.com/NOAA-EMC/spack-stack/issues/435.

Also included is a submodule pointer update for spack for recent changes to ESMF (in case this PR gets merged before #437).

## Testing

CI tests passed except for weird errors when rerunning tests that hit the 6hr walltime (gnu 9 with mvapich2) where it can't find the cached externals, even though they are there.