### PR TITLE
Update ectrans, fiat, fms; add `constants=GFS` variant for fms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/ectrans120_fiat110
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/ectrans120_fiat110
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -51,7 +51,7 @@
       version: [0.31.1]
       variants: +fckit +trans
     ectrans:
-      version: [1.1.0]
+      version: [1.2.0]
       variants: ~enable_mkl
     eigen:
       version: [3.4.0]
@@ -66,16 +66,15 @@
     fftw:
       version: [3.3.10]
     fiat:
-      version: [1.0.0]
+      version: [1.1.0]
     findutils:
       version: [4.8.0]
     flex:
       version: [2.6.4]
-    # Attention - when updating also check the macos.default site config and
-    # the various jcsda-emc-bundles env packages
+    # Attention - when updating also check the various jcsda-emc-bundles env packages
     fms:
-      version: [2022.02]
-      variants: +64bit +quad_precision +gfs_phys +openmp +fpic
+      version: [2022.04]
+      variants: +64bit +quad_precision +gfs_phys +openmp +fpic constants=GFS
     g2:
       version: [3.4.5]
     g2c:

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.6.5, eccodes@2.27.0, ecflow@5,
-    eckit@1.20.2, ecmwf-atlas@0.31.1 +trans ~fftw, ectrans@1.1.0 ~fftw, eigen@3.4.0,
+    eckit@1.20.2, ecmwf-atlas@0.31.1 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.9.5, flex@2.6.4, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.0.6, hdf5@1.12.1, hdf@4.2.15, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.8.1, netcdf-cxx4@4.3.1,

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -46,7 +46,7 @@ spack:
       version: [0.31.1]
       variants: +fckit +trans
     ectrans:
-      version: [1.1.0]
+      version: [1.2.0]
       variants: ~enable_mkl
     eigen:
       version: [3.4.0]
@@ -59,10 +59,10 @@ spack:
     fftw:
       version: [3.3.10]
     fiat:
-      version: [1.0.0]
+      version: [1.1.0]
     fms:
-      version: [2022.02]
-      variants: +64bit +quad_precision +gfs_phys +openmp +fpic
+      version: [2022.04]
+      variants: +64bit +quad_precision +gfs_phys +openmp +fpic constants=GFS
     g2:
       version: [3.4.5]
     g2c:

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -41,7 +41,7 @@ spack:
       version: [0.24.1]
       variants: +fckit ~trans
     ectrans:
-      version: [1.0.0]
+      version: [1.2.0]
       variants: ~enable_mkl
     eigen:
       version: [3.3.7]
@@ -54,10 +54,10 @@ spack:
     fftw:
       version: [3.3.8]
     fiat:
-      version: [1.0.0]
+      version: [1.1.0]
     fms:
-      version: [2022.01]
-      variants: +64bit +quad_precision +gfs_phys +openmp +pic
+      version: [2022.04]
+      variants: +64bit +quad_precision +gfs_phys +openmp +fpic constants=GFS
     g2:
       version: [3.4.5]
     g2c:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -3,14 +3,6 @@ spack:
     unify: when_possible
 
   view: false
-
-  packages:
-    fiat:
-      version: [1.0.0]
-    ectrans:
-      version: [1.1.0]
-
-  view: false
   include: []
 
   specs:
@@ -36,17 +28,17 @@ spack:
     - ecflow@5
     - eckit@1.20.2
     - ecmwf-atlas@0.31.1
-    - ectrans@1.1.0
+    - ectrans@1.2.0
     - eigen@3.4.0
     - esmf@8.3.0b09+pio
     # DH* fake version number
     #- ewok@0.0.1
     - fckit@0.9.5
     # DH* fake version number
-    - fiat@1.0.0
+    - fiat@1.1.0
     # Do not request specific version of flex - this leads to duplicate packages being built
     #- flex@2.6.4
-    - fms@2022.02
+    - fms@2022.04
     # DH* fake version number
     - fms@release-jcsda
     - g2@3.4.5

--- a/configs/templates/skylab-no-python-dev/spack.yaml
+++ b/configs/templates/skylab-no-python-dev/spack.yaml
@@ -3,14 +3,6 @@ spack:
     unify: when_possible
 
   view: false
-
-  packages:
-    fiat:
-      version: [1.0.0]
-    ectrans:
-      version: [1.1.0]
-
-  view: false
   include: []
 
   specs:
@@ -51,17 +43,17 @@ spack:
     #- ecflow@5
     - eckit@1.20.2
     - ecmwf-atlas@0.31.1
-    - ectrans@1.1.0
+    - ectrans@1.2.0
     - eigen@3.4.0
     - esmf@8.3.0b09+pio
     # DH* fake version number
     #- ewok@0.0.1
     - fckit@0.9.5
     # DH* fake version number
-    - fiat@1.0.0
+    - fiat@1.1.0
     # Do not request specific version of flex - this leads to duplicate packages being built
     #- flex@2.6.4
-    - fms@2022.02
+    - fms@2022.04
     # DH* fake version number
     - fms@release-jcsda
     - g2@3.4.5

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -22,7 +22,7 @@ spack:
   - crtm@2.4.0
   - esmf@8.3.0b09+debug~shared
   - esmf@8.3.0b09~debug~shared
-  - fms@2022.01
+  - fms@2022.04
   - g2@3.4.5
   - g2tmpl@1.10.0
   - gftl-shared@1.5.0

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -22,7 +22,7 @@ spack:
   - crtm@2.4.0
   - esmf@8.3.0b09+debug~shared
   - esmf@8.3.0b09~debug~shared
-  - fms@2022.04
+  - fms@2022.04 constants=GFS
   - g2@3.4.5
   - g2tmpl@1.10.0
   - gftl-shared@1.5.0


### PR DESCRIPTION
## Description

- Update ectrans to 1.2.0
- Update fiat to 1.1.0
- Update fms to 2022.04, add variant `constants=GFS`

## Issues

Fixes #444 
Fixes #443 
Fixes #379 

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/215

## Testing

CI tests passed for all but one of the Ubuntu runs (Ubuntu mvapich2 skylab-dev), which timed out at 6hrs being almost finished. I am rerunning the macOS ones, which was killed by a hiccup of the CI system itself last night.