### PR TITLE
Run full CI tests only on PRs that are ready for review

### DIFF
--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -44,7 +44,6 @@ jobs:
 
           spack external find
           spack external find perl
-          spack external find python
           spack external find wget
           PATH="/usr/local/opt/qt@5/bin:${PATH}" spack external find qt
           PATH="/usr/local/opt/curl/bin:${PATH}" spack external find curl

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -57,6 +57,7 @@ jobs:
           mpi: ${{ matrix.compiler-mpi.mpi }}
 
   build-spack-stack:
+    if: '! github.event.pull_request.draft'
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -57,6 +57,7 @@ jobs:
           mpi: ${{ matrix.compiler-mpi.mpi }}
 
   build-spack-stack:
+    if: '! github.event.pull_request.draft'
     needs: [cache-externals, cache-spack-mirror]
     strategy:
       matrix:


### PR DESCRIPTION
## Description
1. Run full CI tests only on PRs that are ready for review, not on draft PRs
    - but for now, still create the caches (mirror and external dependencies) for draft PRs, since they get reused
3. Update self-hosted CI runs on Dom's macOS
    - reflect changes from earlier PRs that build Python in spack

## Testing
- Tested successfully on Dom's macOS
- CI tests mostly successful, one test timed out close to the finish line and doesn't want to restart because of the missing cache issue that we don't understand