### PR TITLE
Update spack submodule to include latest ufs-weather-model (package) updates and fiat tags

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/fiat_tags
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/fiat_tags
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for spack for the changes in https://github.com/NOAA-EMC/spack/pull/217 (add `@develop` to ufs-weather-model) and https://github.com/NOAA-EMC/spack/pull/219 (`fiat` tags).

## Issues

Working towards https://github.com/NOAA-EMC/spack/issues/28

## Testing

This PR needs proper testing - not only to build, but also to run jedi-bundle (because the fiat tags that ECMWF created are slightly different hashes than what we used as "fake" 1.0.0 and 1.1.0 versions until now).
