### PR TITLE
EMSF beta variant/MAPL modulefile names

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -115,12 +115,14 @@ modules:
             'PNG_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.2.0~debug: 'esmf-8.2.0'
-          ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
-          ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
-          ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
-          ^esmf@8.3.0~debug: 'esmf-8.3.0'
-          ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
+          ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'
+          ^esmf@8.2.0+debug snapshot=none: 'esmf-8.2.0-debug'
+          ^esmf@8.3.0b09~debug snapshot=b09: 'esmf-8.3.0b09'
+          ^esmf@8.3.0b09+debug snapshot=b09: 'esmf-8.3.0b09-debug'
+          ^esmf@8.3.0~debug snapshot=none: 'esmf-8.3.0'
+          ^esmf@8.3.0+debug snapshot=none: 'esmf-8.3.0-debug'
+          ^esmf@8.4.0~debug snapshot=none: 'esmf-8.4.0'
+          ^esmf@8.4.0+debug snapshot=none: 'esmf-8.4.0-debug'
       openmpi:
         environment:
           set:
@@ -338,12 +340,14 @@ modules:
             'PNG_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.2.0~debug: 'esmf-8.2.0'
-          ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
-          ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
-          ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
-          ^esmf@8.3.0~debug: 'esmf-8.3.0'
-          ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
+          ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'
+          ^esmf@8.2.0+debug snapshot=none: 'esmf-8.2.0-debug'
+          ^esmf@8.3.0b09~debug snapshot=b09: 'esmf-8.3.0b09'
+          ^esmf@8.3.0b09+debug snapshot=b09: 'esmf-8.3.0b09-debug'
+          ^esmf@8.3.0~debug snapshot=none: 'esmf-8.3.0'
+          ^esmf@8.3.0+debug snapshot=none: 'esmf-8.3.0-debug'
+          ^esmf@8.4.0~debug snapshot=none: 'esmf-8.4.0'
+          ^esmf@8.4.0+debug snapshot=none: 'esmf-8.4.0-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -59,7 +59,7 @@
     # config and update the projections for lmod/tcl
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf +pio
+      variants: ~xerces ~pnetcdf +pio snapshot=b09
     fckit:
       version: [0.9.5]
       variants: +eckit

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -12,7 +12,7 @@
         - cray-mpich/8.1.9
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf +pio esmf_os=Linux esmf_comm=mpich3
+      variants: ~xerces ~pnetcdf +pio snapshot=b09 esmf_os=Linux esmf_comm=mpich3
     openssl:
       buildable: false
       externals:

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -12,7 +12,7 @@
         - cray-mpich/8.1.16
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf +pio esmf_os=Linux esmf_comm=mpich3
+      variants: ~xerces ~pnetcdf +pio snapshot=b09 esmf_os=Linux esmf_comm=mpich3
     python:
       buildable: false
       externals:

--- a/configs/templates/hpc-dev-v1/spack.yaml
+++ b/configs/templates/hpc-dev-v1/spack.yaml
@@ -52,7 +52,7 @@ spack:
       version: [3.4.0]
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf +pio
+      variants: ~xerces ~pnetcdf +pio snapshot=b09
     fckit:
       version: [0.9.5]
       variants: +eckit

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -47,7 +47,7 @@ spack:
       version: [3.3.7]
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf
+      variants: ~xerces ~pnetcdf snapshot=b09
     fckit:
       version: [0.9.2]
       variants: +eckit

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -20,8 +20,8 @@ spack:
   - zlib@1.2.11~shared
   - bacio@2.4.1
   - crtm@2.4.0
-  - esmf@8.3.0b09+debug~shared
-  - esmf@8.3.0b09~debug~shared
+  - esmf@8.3.0b09+debug~shared snapshot=b09
+  - esmf@8.3.0b09~debug~shared snapshot=b09
   - fms@2022.01
   - fms@2022.04 constants=GFS
   - g2@3.4.5


### PR DESCRIPTION
This PR makes use of the `snapshot` variant now in NOAA-EMC spack's ESMF package, and also adds ESMF 8.4.0 to the modules config.