### PR TITLE
Updates required for creating binary (build) caches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/buildcaches
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/buildcaches_skip_on_error_fix_double_rpath
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/buildcaches
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/config.yaml
+++ b/configs/common/config.yaml
@@ -5,6 +5,8 @@ config:
     root: $env/install
     projections:
       all: "${COMPILERNAME}/${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+    # Needed for relocation of binary packages (build caches)
+    padded_length: true
 
   # The build stage can be purged with `spack clean --stage` and
   # `spack clean -a`, so it is important that the specified directory uniquely


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for spack with changes required for creating binary (build) caches for multiple packages, for example all packages in an environment, at once. See https://github.com/NOAA-EMC/spack/pull/231 for a description of the changes.

I also added a config option in `configs/common/config.yaml` that must be enabled when creating build caches. It is not enabled by default, because the option should only be used when creating build caches. It basically pads the library path in shared libraries with "garbage" so that a package can later be relocated to a path that is longer than the one it was built for. In future PRs, we will provide the necessary documentation and automation to enable this option when creating build caches.

This PR is also needed to fix the CI tests in following PRs (see #476 for macOS, Linux will be contributed by EPIC using Jenkins, plus possible other solutions).

## Issues

Working towards https://github.com/NOAA-EMC/spack-stack/issues/365

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/231