### PR TITLE
Build zstd with the +programs variant

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -259,3 +259,6 @@
       version: [0.5.1]
     zlib:
       version: [1.2.13]
+    zstd:
+      version: [1.5.2]
+      variants: +programs


### PR DESCRIPTION
This PR adds a spec to the `configs/common/packages.yaml` that tells spack to always build zstd with the +programs variant. This was done to avoid duplicate zstd library builds since some client packages of zstd want the zstd application binaries (zstd, unzstd, etc) and others don't. Note that it doesn't hurt the packages that don't want the programs variant to include the programs variant for zstd.