### PR TITLE
Update of AWS parallelcluster site config and instructions

### DIFF
--- a/configs/sites/aws-pcluster/README.md
+++ b/configs/sites/aws-pcluster/README.md
@@ -158,6 +158,7 @@ cmake .. -DPython3_EXECUTABLE=/usr/bin/python3 -DENABLE_STATIC_BOOST_LIBS=OFF -D
 make -j4 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 ```
+
 3b. Install msql community server
 ```
 cd /home/ubuntu/jedi
@@ -172,15 +173,20 @@ apt --fix-broken install
 dpkg -i *.deb
 # Set root password, choose strong password encryption option
 exit
+rm *.deb
 ```
-4. Option 1: Use pre-defined site config in spack-stack (skip steps 5-7 afterwards)
+
+4. Option 1: Testing existing site config in spack-stack (skip steps 5-7 afterwards)
 ```
-cd /home/ubuntu/jedi
+mkdir -p /home/ubuntu/sandpit
+cd /home/ubuntu/sandpit
 git clone -b develop --recursive https://github.com/noaa-emc/spack-stack spack-stack
 cd spack-stack/
 . setup.sh
-spack stack create env --site aws-pcluster --template=skylab-dev --name=skylab-2.0.0-intel-2021.4.0
-spack env activate -p envs/skylab-2.0.0-intel-2021.4.0
+spack stack create env --site aws-pcluster --template=unified-dev --name=unified-dev
+spack env activate -p envs/unified-dev
+sed -i "s/\['\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel', '\%gcc'\]/g" envs/unified-dev/spack.yaml
+
 ```
 5. Option 2: For spack site configuration, to find Intel compiler
 ```

--- a/configs/sites/aws-pcluster/compilers.yaml
+++ b/configs/sites/aws-pcluster/compilers.yaml
@@ -1,18 +1,35 @@
 compilers:
 - compiler:
-    spec: intel@2021.4.0
+    spec: intel@2022.1.0
     paths:
-      cc: /opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/icc
-      cxx: /opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/icpc
-      f77: /opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/ifort
-      fc: /opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/ifort
+      cc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64/icc
+      cxx: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64/icpc
+      f77: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64/ifort
+      fc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64/ifort
     flags: {}
     operating_system: ubuntu20.04
     target: x86_64
     modules: []
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin'
+        LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin'
+      set:
+        I_MPI_PMI_LIBRARY: '/opt/slurm/lib/libpmi.so'
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2022.1.0
+    paths:
+      cc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/icx
+      cxx: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/icpx
+      f77: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/ifx
+      fc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/ifx
+    flags: {}
+    operating_system: ubuntu20.04
+    target: x86_64
+    modules: []
+    environment:
+      #prepend_path:
+      #  LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin'
       set:
         I_MPI_PMI_LIBRARY: '/opt/slurm/lib/libpmi.so'
     extra_rpaths: []

--- a/configs/sites/aws-pcluster/compilers.yaml
+++ b/configs/sites/aws-pcluster/compilers.yaml
@@ -16,23 +16,24 @@ compilers:
       set:
         I_MPI_PMI_LIBRARY: '/opt/slurm/lib/libpmi.so'
     extra_rpaths: []
-- compiler:
-    spec: oneapi@2022.1.0
-    paths:
-      cc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/icx
-      cxx: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/icpx
-      f77: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/ifx
-      fc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/ifx
-    flags: {}
-    operating_system: ubuntu20.04
-    target: x86_64
-    modules: []
-    environment:
-      #prepend_path:
-      #  LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin'
-      set:
-        I_MPI_PMI_LIBRARY: '/opt/slurm/lib/libpmi.so'
-    extra_rpaths: []
+# Spack gets confused if there is an Intel and a OneAPI compiler ...
+#- compiler:
+#    spec: oneapi@2022.1.0
+#    paths:
+#      cc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/icx
+#      cxx: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/icpx
+#      f77: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/ifx
+#      fc: /opt/intel/oneapi/compiler/2022.1.0/linux/bin/ifx
+#    flags: {}
+#    operating_system: ubuntu20.04
+#    target: x86_64
+#    modules: []
+#    environment:
+#      #prepend_path:
+#      #  LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin'
+#      set:
+#        I_MPI_PMI_LIBRARY: '/opt/slurm/lib/libpmi.so'
+#    extra_rpaths: []
 - compiler:
     spec: gcc@9.4.0
     paths:

--- a/configs/sites/aws-pcluster/modules.yaml
+++ b/configs/sites/aws-pcluster/modules.yaml
@@ -1,9 +1,10 @@
 modules:
   default:
     enable::
-    - tcl
-    tcl:
+    - lmod
+    lmod:
       whitelist:
       # List of packages for which we need modules that are blacklisted by default
+      - intel-oneapi-mpi
       - openmpi
       - mpich

--- a/configs/sites/aws-pcluster/modules.yaml
+++ b/configs/sites/aws-pcluster/modules.yaml
@@ -5,6 +5,4 @@ modules:
     lmod:
       whitelist:
       # List of packages for which we need modules that are blacklisted by default
-      - intel-oneapi-mpi
-      - openmpi
-      - mpich
+      - python

--- a/configs/sites/aws-pcluster/packages.yaml
+++ b/configs/sites/aws-pcluster/packages.yaml
@@ -13,13 +13,13 @@ packages:
     - spec: intel-oneapi-mpi@2021.6.0%intel@2022.1.0
       prefix: /opt/intel
       modules:
-      - libfabric-aws/1.16.0~amzn3.0
+      - libfabric-aws/1.16.0~amzn4.0
       - intelmpi
     #externals:
     #- spec: intel-oneapi-mpi@2021.6.0%oneapi@2022.1.0
     #  prefix: /opt/intel
     #  modules:
-    #  - libfabric-aws/1.16.0~amzn3.0
+    #  - libfabric-aws/1.16.0~amzn4.0
     #  - intelmpi
   openmpi:
     externals:
@@ -27,7 +27,7 @@ packages:
         fabrics=ofi schedulers=slurm
       prefix: /opt/amazon/openmpi
       modules:
-      - libfabric-aws/1.16.0~amzn3.0
+      - libfabric-aws/1.16.0~amzn4.0
       - openmpi/4.1.4
 
 ### All other external packages listed alphabetically

--- a/configs/sites/aws-pcluster/packages.yaml
+++ b/configs/sites/aws-pcluster/packages.yaml
@@ -1,8 +1,9 @@
 packages:
   all:
-    compiler: [intel@2021.4.0, oneapi@2022.1.0, gcc@9.4.0]
+    compiler: [intel@2022.1.0, gcc@9.4.0]
+    #compiler: [oneapi@2022.1.0]
     providers:
-      mpi: [intel-oneapi-mpi@2021.4.0, openmpi@4.1.4]
+      mpi: [intel-oneapi-mpi@2021.6.0, openmpi@4.1.4]
 
 ### MPI, Python, MKL
   mpi:
@@ -14,12 +15,12 @@ packages:
       modules:
       - libfabric-aws/1.16.0~amzn3.0
       - intelmpi
-    externals:
-    - spec: intel-oneapi-mpi@2021.6.0%oneapi@2022.1.0
-      prefix: /opt/intel
-      modules:
-      - libfabric-aws/1.16.0~amzn3.0
-      - intelmpi
+    #externals:
+    #- spec: intel-oneapi-mpi@2021.6.0%oneapi@2022.1.0
+    #  prefix: /opt/intel
+    #  modules:
+    #  - libfabric-aws/1.16.0~amzn3.0
+    #  - intelmpi
   openmpi:
     externals:
     - spec: openmpi@4.1.4%gcc@9.4.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath

--- a/configs/sites/aws-pcluster/packages.yaml
+++ b/configs/sites/aws-pcluster/packages.yaml
@@ -1,18 +1,33 @@
 packages:
   all:
-    compiler: [intel@2021.4.0]
+    compiler: [intel@2021.4.0, oneapi@2022.1.0, gcc@9.4.0]
     providers:
-      mpi: [intel-oneapi-mpi@2021.4.0]
+      mpi: [intel-oneapi-mpi@2021.4.0, openmpi@4.1.4]
 
 ### MPI, Python, MKL
-  intel-oneapi-mpi:
+  mpi:
     buildable: false
+  intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.4.0%intel@2021.4.0
+    - spec: intel-oneapi-mpi@2021.6.0%intel@2022.1.0
       prefix: /opt/intel
       modules:
       - libfabric-aws/1.16.0~amzn3.0
       - intelmpi
+    externals:
+    - spec: intel-oneapi-mpi@2021.6.0%oneapi@2022.1.0
+      prefix: /opt/intel
+      modules:
+      - libfabric-aws/1.16.0~amzn3.0
+      - intelmpi
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.4%gcc@9.4.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
+        fabrics=ofi schedulers=slurm
+      prefix: /opt/amazon/openmpi
+      modules:
+      - libfabric-aws/1.16.0~amzn3.0
+      - openmpi/4.1.4
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -42,6 +57,10 @@ packages:
   #  externals:
   #  - spec: cmake@3.16.3
   #    prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.30
+      prefix: /usr
   curl:
     externals:
     - spec: curl@7.68.0+gssapi+ldap+nghttp2
@@ -94,7 +113,7 @@ packages:
   mysql:
     buildable: False
     externals:
-    - spec: mysql@8.0.30
+    - spec: mysql@8.0.32
       prefix: /usr
   openssh:
     externals:
@@ -104,7 +123,6 @@ packages:
   # leading to duplicate packages (libarchive with different compression
   # settings, somehow triggered by different cmake versions) being installed.
   #openssl:
-  #  buildable: false
   #  externals:
   #  - spec: openssl@1.1.1f
   #    prefix: /usr


### PR DESCRIPTION
## Description

Update AWS site config to use a newer version of the Ubuntu 20.04 AWS Parallelcluster base image (with newer compilers etc), make it support both Intel and GNU, and use lua/lmod instead of tcl environment modules. Update the `README.md` in `configs/sites/aws-pcluster` accordingly.

## Testing

I tested these steps with our current spack-stack develop branch and successfully built the `unified-dev` environment with `intel@2022.1.0/intel-oneapi-mpi@2021.6.0` and `gcc@9.4.0/openmpi@4.1.4`.

## Issues

Working towards https://github.com/NOAA-EMC/spack-stack/issues/455
