### PR TITLE
Set cdo to ~openmp by default

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -26,6 +26,7 @@
     # work with all compilers that are currently in use in spack-stack
     cdo:
       version: [2.0.5]
+      variants: ~openmp
     cmake:
       version: [3.23.1]
       variants: +ownlibs


### PR DESCRIPTION
This PR sets ~openmp for cdo so that threadsafe hdf5 isn't required in the global workflow or unified stacks.
Goes with https://github.com/NOAA-EMC/spack/pull/243
Fixes https://github.com/NOAA-EMC/spack-stack/issues/496