### PR TITLE
Disable threadsafe for hdf5 in common/packages.yaml

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -94,7 +94,7 @@
       variants: ~fortran ~netcdf
     hdf5:
       version: [1.14.0]
-      variants: +hl +fortran +mpi +threadsafe +szip
+      variants: +hl +fortran +mpi ~threadsafe +szip
     ip:
       version: [3.3.3]
     ip2:


### PR DESCRIPTION
When making the changes for cdo/openmp/hdf5+threadsafe, I forgot to switch hdf5 to ~threadsafe...