### PR TITLE
Remove python spec details from external package listing on acorn

### DIFF
--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -71,7 +71,7 @@
     python:
       buildable: false
       externals:
-      - spec: python@3.8.6+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter+uuid+zlib
+      - spec: python@3.8.6
         modules: [python/3.8.6]
     # On Acorn, perl module requires gcc :(
     perl:


### PR DESCRIPTION
Having the detailed spec for python in the external packages has caused issues ("Attempted to use external for 'python' which does not satisfy any configured external spec") on account of changing specs. For now I think the safe bet is to remove the variants.