### PR TITLE
release/1.3.0: Add missing variant `+parallelio` to esmf@8.4.1

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -56,7 +56,7 @@
     # config and update the projections for lmod/tcl
     esmf:
       version: [8.4.1]
-      variants: ~xerces ~pnetcdf
+      variants: ~xerces ~pnetcdf +parallelio
     fckit:
       version: [0.10.0]
       variants: +eckit


### PR DESCRIPTION
All in the title
- CI tests running
- Verified that the variant concretizes correctly on my macOS