### PR TITLE
Add +parallelio for esmf in common/packages.yaml

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -56,7 +56,7 @@
     # config and update the projections for lmod/tcl
     esmf:
       version: [8.4.1]
-      variants: ~xerces ~pnetcdf
+      variants: ~xerces ~pnetcdf +parallelio
     fckit:
       version: [0.10.0]
       variants: +eckit


### PR DESCRIPTION
UFS needs `esmf+parallelio`. Sorry for missing this in the ESMF version change.