### PR TITLE
release/1.3.0: Bug fix, revert esmf to 8.3.0b09 and mapl to 2.22.0

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -124,6 +124,8 @@ modules:
           ^esmf@8.3.0+debug snapshot=none: 'esmf-8.3.0-debug'
           ^esmf@8.4.0~debug snapshot=none: 'esmf-8.4.0'
           ^esmf@8.4.0+debug snapshot=none: 'esmf-8.4.0-debug'
+          ^esmf@8.4.1~debug snapshot=none: 'esmf-8.4.1'
+          ^esmf@8.4.1+debug snapshot=none: 'esmf-8.4.1-debug'
       openmpi:
         environment:
           set:
@@ -350,6 +352,8 @@ modules:
           ^esmf@8.3.0+debug snapshot=none: 'esmf-8.3.0-debug'
           ^esmf@8.4.0~debug snapshot=none: 'esmf-8.4.0'
           ^esmf@8.4.0+debug snapshot=none: 'esmf-8.4.0-debug'
+          ^esmf@8.4.1~debug snapshot=none: 'esmf-8.4.1'
+          ^esmf@8.4.1+debug snapshot=none: 'esmf-8.4.1-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,9 +54,13 @@
       version: [3.4.0]
     # Attention - when updating the version also check the common modules.yaml
     # config and update the projections for lmod/tcl
+    # Note: Stay away from esmf@8.4.1 ... breaks all sorts of things
+    #esmf:
+    #  version: [8.4.1]
+    #  variants: ~xerces ~pnetcdf +parallelio
     esmf:
-      version: [8.4.1]
-      variants: ~xerces ~pnetcdf +parallelio
+      version: [8.3.0b09]
+      variants: ~xerces ~pnetcdf +pio snapshot=b09
     fckit:
       version: [0.10.0]
       variants: +eckit
@@ -112,7 +116,9 @@
     libpng:
       version: [1.6.37]
     mapl:
-      version: [2.35.2]
+      # 2.35.2 goes with esmf@8.4.1
+      #version: [2.35.2]
+      version: [2.22.0]
     met:
       version: [10.1.1]
       variants: +python +grib2

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -20,7 +20,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
     # https://github.com/NOAA-EMC/spack-stack/issues/326
-    # jedi-ufs-env@1.0.0, esmf@8.4.1, mapl@2.35.2
+    # jedi-ufs-env@1.0.0, esmf@8.3.0b09, mapl@2.22.0
 ```
 
 ### Create an AMI on AWS EC2 to build docker containers

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -31,7 +31,7 @@ spack:
     - ecmwf-atlas@0.32.1
     - ectrans@1.2.0
     - eigen@3.4.0
-    - esmf@8.4.1
+    - esmf@8.3.0b09
     # DH* fake version number
     #- ewok@0.0.1
     - fckit@0.10.0
@@ -53,7 +53,7 @@ spack:
     - jasper@2.0.32
     - jedi-cmake@1.4.0
     - libpng@1.6.37
-    - mapl@2.35.2
+    - mapl@2.22.0
     - nccmp@1.9.0.1
     - ncview@2.1.8
     - nemsio@2.5.2

--- a/configs/templates/skylab-no-python-dev/spack.yaml
+++ b/configs/templates/skylab-no-python-dev/spack.yaml
@@ -46,7 +46,7 @@ spack:
     - ecmwf-atlas@0.32.1
     - ectrans@1.2.0
     - eigen@3.4.0
-    - esmf@8.4.1
+    - esmf@8.3.0b09
     # DH* fake version number
     #- ewok@0.0.1
     - fckit@0.10.0
@@ -68,7 +68,7 @@ spack:
     - jasper@2.0.32
     - jedi-cmake@1.4.0
     - libpng@1.6.37
-    - mapl@2.35.2
+    - mapl@2.22.0
     - nccmp@1.9.0.1
     - ncview@2.1.8
     - nemsio@2.5.2

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -20,16 +20,16 @@ spack:
   - zlib@1.2.11~shared
   - bacio@2.4.1
   - crtm@2.4.0~fix
-  - esmf@8.4.1+debug~shared
-  - esmf@8.4.1~debug~shared
+  - esmf@8.3.0b09+debug~shared
+  - esmf@8.3.0b09~debug~shared
   - fms@2022.04 constants=GFS
   - g2@3.4.5
   - g2tmpl@1.10.0
   - gftl-shared@1.5.0
   - hdf5@1.14.0+hl+mpi~shared~szip
   - ip@3.3.3
-  - mapl@2.35.2~pnetcdf+debug~shared
-  - mapl@2.35.2~pnetcdf~debug~shared
+  - mapl@2.22.0~pnetcdf+debug~shared
+  - mapl@2.22.0~pnetcdf~debug~shared
   - netcdf-c@4.9.2~parallel-netcdf+mpi~shared~dap
   - netcdf-fortran@4.6.0~shared
   - parallel-netcdf@1.12.2~shared

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -20,16 +20,16 @@ spack:
   - zlib@1.2.11~shared
   - bacio@2.4.1
   - crtm@2.4.0~fix
-  - esmf@8.3.0b09+debug~shared
-  - esmf@8.3.0b09~debug~shared
+  - esmf@8.4.1+debug~shared+parallelio
+  - esmf@8.4.1~debug~shared+parallelio
   - fms@2022.04 constants=GFS
   - g2@3.4.5
   - g2tmpl@1.10.0
   - gftl-shared@1.5.0
   - hdf5@1.14.0+hl+mpi~shared~szip
   - ip@3.3.3
-  - mapl@2.22.0~pnetcdf+debug~shared
-  - mapl@2.22.0~pnetcdf~debug~shared
+  - mapl@2.35.2~pnetcdf+debug~shared
+  - mapl@2.35.2~pnetcdf~debug~shared
   - netcdf-c@4.9.2~parallel-netcdf+mpi~shared~dap
   - netcdf-fortran@4.6.0~shared
   - parallel-netcdf@1.12.2~shared

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -24,6 +24,12 @@ spack:
       #- upp-env@unified-dev
       #- ww3-env@unified-dev
 
+      # Additional esmf/mapl tag for testing
+      #- esmf@8.4.1+debug+parallelio
+      #- esmf@8.4.1~debug+parallelio
+      #- mapl@2.35.2+debug ^esmf@8.4.1+debug+parallelio
+      #- mapl@2.35.2~debug ^esmf@8.4.1~debug+parallelio
+
       # Additional crtm tag for testing - don't activate by default,
       # this can lead to duplicate packages (e.g. in Ubuntu CI tests)
       #- crtm@v3.0.0-rc.1


### PR DESCRIPTION
## Description

Numerous problems reported with esmf@8.4.1, including not being able to build the current ufs-weather-model develop or JEDI-UFS. Revert to what is currently the default in the ufs-weather-model, ufs-srweather-app, (JEDI) ufs-bundle.

esmf@8.4.1 also doesn't build on Narwhal (a Cray).

## Testing

- CI test for Ubuntu passed, verified that it built `esmf@8.3.0b09` and `mapl@2.22.0`: https://github.com/NOAA-EMC/spack-stack/actions/runs/4502043011/jobs/7923309130?pr=510
- CI test for macOS passed, verified that it built `esmf@8.3.0b09` and `mapl@2.22.0`: https://github.com/NOAA-EMC/spack-stack/actions/runs/4502043055/jobs/7923309081?pr=510
- Reverting to `esmf@8.3.0b09` and `mapl@2.22.0` solves the linker problems for the JEDI-UFS ufs-bundle on my macOS