### PR TITLE
Bump py-h5py from 3.6.0 to 3.8.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = release/1.3.0
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = release/1.3.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/pyh5py_hdf5_versions
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = release/1.3.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/pyh5py_hdf5_versions
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = release/1.3.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -183,7 +183,7 @@
     py-eccodes:
       version: [1.4.2]
     py-h5py:
-      version: [3.6.0]
+      version: [3.8.0]
       variants: ~mpi
     py-mysql-connector-python:
       version: [8.0.13]


### PR DESCRIPTION
## Description

Fixes https://github.com/NOAA-EMC/spack-stack/issues/513

Waiting on https://github.com/NOAA-EMC/spack/pull/249 - make sure to update the submodule pointer after this gets merged.
