### PR TITLE
release/1.3.0: fix mapl module filenames

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -116,16 +116,16 @@ modules:
             'PNG_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'
-          ^esmf@8.2.0+debug snapshot=none: 'esmf-8.2.0-debug'
-          ^esmf@8.3.0b09~debug snapshot=b09: 'esmf-8.3.0b09'
-          ^esmf@8.3.0b09+debug snapshot=b09: 'esmf-8.3.0b09-debug'
-          ^esmf@8.3.0~debug snapshot=none: 'esmf-8.3.0'
-          ^esmf@8.3.0+debug snapshot=none: 'esmf-8.3.0-debug'
-          ^esmf@8.4.0~debug snapshot=none: 'esmf-8.4.0'
-          ^esmf@8.4.0+debug snapshot=none: 'esmf-8.4.0-debug'
-          ^esmf@8.4.1~debug snapshot=none: 'esmf-8.4.1'
-          ^esmf@8.4.1+debug snapshot=none: 'esmf-8.4.1-debug'
+          ^esmf@8.2.0~debug: 'esmf-8.2.0'
+          ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
+          ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
+          ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
+          ^esmf@8.3.0~debug: 'esmf-8.3.0'
+          ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
+          ^esmf@8.4.0~debug: 'esmf-8.4.0'
+          ^esmf@8.4.0+debug: 'esmf-8.4.0-debug'
+          ^esmf@8.4.1~debug: 'esmf-8.4.1'
+          ^esmf@8.4.1+debug: 'esmf-8.4.1-debug'
       openmpi:
         environment:
           set:
@@ -344,16 +344,16 @@ modules:
             'PNG_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'
-          ^esmf@8.2.0+debug snapshot=none: 'esmf-8.2.0-debug'
-          ^esmf@8.3.0b09~debug snapshot=b09: 'esmf-8.3.0b09'
-          ^esmf@8.3.0b09+debug snapshot=b09: 'esmf-8.3.0b09-debug'
-          ^esmf@8.3.0~debug snapshot=none: 'esmf-8.3.0'
-          ^esmf@8.3.0+debug snapshot=none: 'esmf-8.3.0-debug'
-          ^esmf@8.4.0~debug snapshot=none: 'esmf-8.4.0'
-          ^esmf@8.4.0+debug snapshot=none: 'esmf-8.4.0-debug'
-          ^esmf@8.4.1~debug snapshot=none: 'esmf-8.4.1'
-          ^esmf@8.4.1+debug snapshot=none: 'esmf-8.4.1-debug'
+          ^esmf@8.2.0~debug: 'esmf-8.2.0'
+          ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
+          ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
+          ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
+          ^esmf@8.3.0~debug: 'esmf-8.3.0'
+          ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
+          ^esmf@8.4.0~debug: 'esmf-8.4.0'
+          ^esmf@8.4.0+debug: 'esmf-8.4.0-debug'
+          ^esmf@8.4.1~debug: 'esmf-8.4.1'
+          ^esmf@8.4.1+debug: 'esmf-8.4.1-debug'
       openmpi:
         environment:
           set:


### PR DESCRIPTION
## Description

Fix mapl module filenames. Tested for lmod on Dom's macOS, and for tcl on Gaea.