### PR TITLE
release/1.3.0: Once again, update configs/common/modules.yaml for ESMF/MAPL

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -116,12 +116,8 @@ modules:
             'PNG_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.2.0~debug: 'esmf-8.2.0'
-          ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
           ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
           ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
-          ^esmf@8.3.0~debug: 'esmf-8.3.0'
-          ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
           ^esmf@8.4.0~debug: 'esmf-8.4.0'
           ^esmf@8.4.0+debug: 'esmf-8.4.0-debug'
           ^esmf@8.4.1~debug: 'esmf-8.4.1'
@@ -344,12 +340,8 @@ modules:
             'PNG_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.2.0~debug: 'esmf-8.2.0'
-          ^esmf@8.2.0+debug: 'esmf-8.2.0-debug'
           ^esmf@8.3.0b09~debug: 'esmf-8.3.0b09'
           ^esmf@8.3.0b09+debug: 'esmf-8.3.0b09-debug'
-          ^esmf@8.3.0~debug: 'esmf-8.3.0'
-          ^esmf@8.3.0+debug: 'esmf-8.3.0-debug'
           ^esmf@8.4.0~debug: 'esmf-8.4.0'
           ^esmf@8.4.0+debug: 'esmf-8.4.0-debug'
           ^esmf@8.4.1~debug: 'esmf-8.4.1'


### PR DESCRIPTION
## Description
Turns out that https://github.com/NOAA-EMC/spack-stack/pull/515 fixed the wrong module names for `mapl` with `esmf@8.4.1`, but in turn messed up the ones with `esmf@8.3.0b09`. I couldn't find a clean way to do this except for removing versions that are not being built (and will never be built again with spack-stack), so I think that's ok.

With this PR, I get:
```
mapl/2.22.0-debug-esmf-8.3.0b09-debug
mapl/2.22.0-esmf-8.3.0b09            
mapl/2.35.2-debug-esmf-8.4.1-debug   
mapl/2.35.2-esmf-8.4.1               
```