### PR TITLE
release/1.3.0: repair submodule pointer for spack, update Jet docs

### DIFF
--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -486,6 +486,8 @@ Hera sits behind the NOAA firewall and doesn't have access to all packages on th
 NOAA RDHPCS Jet
 ------------------------------
 
+Note that the ``target`` architecture for Jet must be set to ``core2`` to satisfy differences between the various Jet partitions and ensure that installations run on the front-end nodes (xjet-like) will function on the other partitions.
+
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
 


### PR DESCRIPTION
## Description

Commit https://github.com/NOAA-EMC/spack-stack/commit/8c17a8d7c53d876130bbb1fd0c479e2253a4d6ef inadvertently updated the submodule pointer for spack (resetting it by one commit). This PR fixes it, spack points back to the head of release/1.3.0L:
```
commit 0625840d25d82847cb1d18304d174d2d61d66a82 (HEAD, noaa-emc/release/1.3.0)
Merge: 425f8f2dd8 917e9dcb2b
Author: Dom Heinzeller <dom.heinzeller@icloud.com>
Date:   Thu Mar 23 21:06:41 2023 -0600

    Merge pull request #249 from climbfuji/bugfix/pyh5py_hdf5_versions

    Add py-h5py@3.8.0 and fix hdf5 dependency in package
```