### PR TITLE
release/1.3.0: Bug fix for py-h5py; remove py-mysql-connector-python; build esmf/mapl static only; py-pip w/ external Python

### DIFF
--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -105,6 +105,11 @@ jobs:
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
           spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ --skip-on-error || true
 
+          # DH* temp
+          echo "py-mysql-connector-python ..."
+          spack install --fail-fast --source --no-check-signature py-mysql-connector-python 2>&1 | tee log.install.apple-clang-14.0.0.py-mysql-connector-python
+          # *DH temp
+
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -105,11 +105,6 @@ jobs:
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
           spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ --skip-on-error || true
 
-          # DH* temp
-          echo "py-mysql-connector-python ..."
-          spack install --fail-fast --source --no-check-signature py-mysql-connector-python 2>&1 | tee log.install.apple-clang-14.0.0.py-mysql-connector-python
-          # *DH temp
-
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = release/1.3.0
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = release/1.3.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/catchall_130
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = release/1.3.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/catchall_130
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = release/1.3.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -57,10 +57,10 @@
     # Note: Stay away from esmf@8.4.1 ... breaks all sorts of things
     #esmf:
     #  version: [8.4.1]
-    #  variants: ~xerces ~pnetcdf +parallelio
+    #  variants: ~xerces ~pnetcdf +parallelio ~shared
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf +pio snapshot=b09
+      variants: ~xerces ~pnetcdf +pio snapshot=b09 ~shared
     fckit:
       version: [0.10.0]
       variants: +eckit
@@ -119,6 +119,7 @@
       # 2.35.2 goes with esmf@8.4.1
       #version: [2.35.2]
       version: [2.22.0]
+      variants: ~shared
     met:
       version: [10.1.1]
       variants: +python +grib2
@@ -183,10 +184,10 @@
     py-eccodes:
       version: [1.4.2]
     py-h5py:
-      version: [3.8.0]
+      version: [3.7.0]
       variants: ~mpi
     py-mysql-connector-python:
-      version: [8.0.13]
+      version: [8.0.32]
     py-netcdf4:
       version: [1.5.3]
       variants: ~mpi

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -186,8 +186,12 @@
     py-h5py:
       version: [3.7.0]
       variants: ~mpi
-    py-mysql-connector-python:
-      version: [8.0.32]
+    # Comment out for now until build problems are solved
+    # https://github.com/NOAA-EMC/spack-stack/issues/522
+    # see also jedi-ewok-env virtual package and container
+    # README.md
+    #py-mysql-connector-python:
+    #  version: [8.0.32]
     py-netcdf4:
       version: [1.5.3]
       variants: ~mpi

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -12,7 +12,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
     parallelio@2.5.9, parallel-netcdf@1.12.2, py-eccodes@1.4.2, py-f90nml@1.4.3,
-    py-gitpython@3.1.27, py-mysql-connector-python@8.0.13, py-numpy@1.22.3,
+    py-gitpython@3.1.27, py-mysql-connector-python@8.0.32, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4-jedi.2, shumlib@macos_clang_linux_intel_port]

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -12,7 +12,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
     parallelio@2.5.9, parallel-netcdf@1.12.2, py-eccodes@1.4.2, py-f90nml@1.4.3,
-    py-gitpython@3.1.27, py-mysql-connector-python@8.0.32, py-numpy@1.22.3,
+    py-gitpython@3.1.27, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4-jedi.2, shumlib@macos_clang_linux_intel_port]
@@ -20,6 +20,9 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
     # https://github.com/NOAA-EMC/spack-stack/issues/326
     # jedi-ufs-env@1.0.0, esmf@8.3.0b09, mapl@2.22.0
+    # Comment out for now until build problems are solved
+    # https://github.com/NOAA-EMC/spack-stack/issues/522
+    # py-mysql-connector-python@8.0.32, 
 ```
 
 ### Create an AMI on AWS EC2 to build docker containers

--- a/configs/sites/casper/packages.yaml
+++ b/configs/sites/casper/packages.yaml
@@ -20,6 +20,13 @@ packages:
       prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
       modules:
       - miniconda/3.9.12
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
+      modules:
+      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -47,6 +47,13 @@ packages:
       prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
       modules:
       - miniconda/3.9.12
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
+      modules:
+      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -26,6 +26,13 @@ packages:
       prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7/
       modules:
       - miniconda/3.9.7
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /discover/swdev/jcsda/spack-stack/miniconda-3.9.7/
+      modules:
+      - miniconda/3.9.7
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -32,6 +32,15 @@ packages:
       prefix: /scratch1/NCEPDEV/global/spack-stack/apps/miniconda/py39_4.12.0
       modules:
       - miniconda/3.9.12
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /scratch1/NCEPDEV/global/spack-stack/apps/miniconda/py39_4.12.0
+      modules:
+      - miniconda/3.9.12
+
+### All other external packages listed alphabetically
   autoconf:
     externals:
     - spec: autoconf@2.69

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -34,6 +34,15 @@ packages:
       prefix: /lfs4/HFIP/hfv3gfs/spack-stack/apps/miniconda/py39_4.12.0
       modules:
       - miniconda/3.9.12
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /lfs4/HFIP/hfv3gfs/spack-stack/apps/miniconda/py39_4.12.0
+      modules:
+      - miniconda/3.9.12
+
+### All other external packages listed alphabetically
   autoconf:
     externals:
     - spec: autoconf@2.69

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -35,6 +35,13 @@ packages:
       prefix: /work/noaa/da/jedipara/spack-stack/miniconda-3.9.7
       modules:
       - miniconda/3.9.7
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /work/noaa/da/jedipara/spack-stack/miniconda-3.9.7
+      modules:
+      - miniconda/3.9.7
 
 ### Modifications of common packages
   # Versions 1.73+ don't compile on orion (bootstrap.sh fails)

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -26,6 +26,13 @@ packages:
       prefix: /data/prod/jedi/spack-stack/miniconda-3.9.12
       modules:
       - miniconda/3.9.12
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /data/prod/jedi/spack-stack/miniconda-3.9.12
+      modules:
+      - miniconda/3.9.12
   # Versions 1.73+ don't compile on s4 (bootstrap.sh fails)
   boost:
     version:: [1.72.0]


### PR DESCRIPTION
## Description

- Submodule pointer update for spack, includes:
    - Bug fix for `py-h5py@3.7.0` in spack
    - Remove `py-mysql-connector-python` (see https://github.com/NOAA-EMC/spack/pull/253);
    - Build esmf/mapl static only for UFS
    - Fix Python venv issues with `py-pip` when an external Python distribution is used (make `py-pip` an external package as well)

This has been tested successfully with Skylab on macOS, AWS, Orion. Builds have been updated on macOS, AWS, Orion, S4, Cheyenne, Hera, Jet, Casper so far. Missing site config updates (external `py-pip`) will be added in a follow-up PR so that this PR can go in.

## Issues

Fixes #530 
Fixes #529 

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/253 (merged)

## Testing

- Built on Dom's macOS for unified-dev environment
- CI tests passed for https://github.com/NOAA-EMC/spack-stack/pull/532/commits/42df98d2157c430f893ad398ef5cb681f47db07c (after that, only site config updates)
- Built on Orion for both Intel and GNU, as well as on AWS, S4, Cheyenne, Hera, Jet, Casper so far
- Skylab tests on macOS, AWS, Orion