### PR TITLE
Bug fix in instructions for Ubuntu 20.04 and 22.04 to install complete mysql

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -362,6 +362,7 @@ The following instructions were used to prepare a basic Ubuntu 20.04 system as i
    apt install -y libcurl4-openssl-dev
    apt install -y libssl-dev
    apt install -y mysql-server
+   apt install -y libmysqlclient-dev
 
    # Python
    apt install -y python3-dev python3-pip
@@ -410,6 +411,7 @@ The following instructions were used to prepare a basic Ubuntu 22.04 system as i
    apt install -y libssl-dev
    apt install -y meson
    apt install -y mysql-server
+   apt install -y libmysqlclient-dev
 
    # Python
    apt install -y python3-dev python3-pip


### PR DESCRIPTION
## Description

Add missing `apt install` command on Ubuntu 20.04 and 22.04. Not needed on CentOS where `mysql-server` contains what is needed. Kriti from JCSDA tested this on her laptop and it works.