### PR TITLE
Update Acorn site config for 1.3.0 release

### DIFF
--- a/configs/sites/acorn/compilers.yaml
+++ b/configs/sites/acorn/compilers.yaml
@@ -21,7 +21,7 @@ compilers:
         CONFIG_SITE: ''
     extra_rpaths: []
 - compiler:
-    spec: gcc@12.1.0
+    spec: gcc@11.2.0
     paths:
       cc: cc
       cxx: CC
@@ -33,7 +33,7 @@ compilers:
     modules:
     - PrgEnv-gnu/8.3.3
     - craype/2.7.13
-    - gcc/12.1.0
+    - gcc/11.2.0
     environment:
       set:
         # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 

--- a/configs/sites/acorn/config.yaml
+++ b/configs/sites/acorn/config.yaml
@@ -1,2 +1,3 @@
 config:
   build_jobs: 6
+  build_stage: $tempdir/$user/spack-stage

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -1,6 +1,6 @@
   packages:
     all:
-      compiler:: [intel@19.1.3.304,gcc@12.1.0]
+      compiler:: [intel@19.1.3.304,gcc@11.2.0]
       providers:
         mpi:: [cray-mpich@8.1.9]
     cray-mpich:
@@ -12,57 +12,12 @@
         - cray-mpich/8.1.9
     esmf:
       version: [8.3.0b09]
-      variants: ~xerces ~pnetcdf +pio snapshot=b09 esmf_os=Linux esmf_comm=mpich3
-    openssl:
-      buildable: false
-      externals:
-      - spec: openssl@1.1.1d
-        prefix: /usr
-    tar:
-      buildable: false
-      externals:
-      - spec: tar@1.34
-        prefix: /usr
-    diffutils:
-      buildable: false
-      externals:
-      - spec: diffutils@3.6
-        prefix: /usr
-    pkgconfig:
-      buildable: false
-    m4:
-      buildable: false
-      externals:
-      - spec: m4@1.4.18
-        prefix: /usr
-    openssh:
-      buildable: false
-      externals:
-      - spec: openssh@8.4p1
-        prefix: /usr
-    pkg-config:
-      buildable: false
-      externals:
-      - spec: pkg-config@0.29.2
-        prefix: /usr
-    wget:
-      buildable: false
-      externals:
-      - spec: wget@1.20.3
-        prefix: /usr
-    cmake:
-      buildable: false
-      externals:
-      - spec: cmake@3.20.2
-        modules: [cmake/3.20.2]
+      variants: ~xerces ~pnetcdf +pio ~shared snapshot=b09 esmf_os=Linux esmf_comm=mpich3
     git:
       buildable: false
       externals:
       - spec: git@2.35.3
         prefix: /usr
-      externals:
-      - spec: git@2.29.0
-        modules: [git/2.29.0]
     git-lfs:
       buildable: false
       externals:
@@ -71,21 +26,32 @@
     python:
       buildable: false
       externals:
-      - spec: python@3.8.6
-        modules: [python/3.8.6]
-    # On Acorn, perl module requires gcc :(
+      - spec: python@3.8.6%intel
+        prefix: /apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk
+      - spec: python@3.8.6%gcc
+        prefix: /apps/spack/python/3.8.6/gcc/11.2.0/gr4zqejk5oxwsrmxvkenmye4nni4zt6e
     perl:
       buildable: false
       externals:
       - spec: perl@5.26.1~cpanm+shared+threads
         prefix: /usr
-    curl:
+    mysql:
       buildable: false
       externals:
-      - spec: curl@7.72.0
-        modules: [curl/7.72.0]
-    libxml2:
+      - spec: mysql@8.0.31
+        prefix: /lfs/h1/emc/nceplibs/noscrub/spack-stack/externals/mysql/mysql-8.0.31-linux-glibc2.17-x86_64-minimal
+    ecflow:
       buildable: false
       externals:
-      - spec: libxml2@2.9.10
-        modules: [libxml2/2.9.10]
+      - spec: ecflow@5.6.0
+        modules: [ecflow/5.6.0.13]
+    patchelf:
+      version: [0.13.1]
+    gettext:
+      version: [0.19.7]
+    rhash:
+      version: [1.3.5]
+    gdal:
+      variants: ~curl
+    py-scipy:
+      version: [1.8.1]


### PR DESCRIPTION
No changes needed to common files.

Main changes:
- Switching to gcc@11.2.0 and corresponding Python to avoid some Python-related build issues.
- Eliminating some external packages which create more problems than they solve.
- Using external ecFlow and MySQL.
- Moving build stage directory off of Lustre space.