### PR TITLE
release/1.3.0: final PR that replaces spack branch with tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
   url = https://github.com/NOAA-EMC/spack
-  branch = release/1.3.0
+  branch = spack-stack-1.3.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -101,7 +101,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        ref: release/1.3.0
+        ref: spack-stack-1.3.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -88,7 +88,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        ref: release/1.3.0
+        ref: spack-stack-1.3.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -106,7 +106,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/noaa-emc/spack
-        ref: release/1.3.0
+        ref: spack-stack-1.3.0
         resolve_sha: false
 
     # Whether or not to strip binaries


### PR DESCRIPTION
## Description

Final PR for release/1.3.0 branch: update references to spack branch release/1.3.0 with newly created tag spack-stack-1.3.0