### PR TITLE
Update to odc version 1.4.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/srherbener/spack
+  branch = feature/odc-1.4.6
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -155,7 +155,7 @@
     nlohmann-json-schema-validator:
       version: [2.1.0]
     odc:
-      version: [1.4.5]
+      version: [1.4.6]
       variants: ~fortran
     openblas:
       version: [0.3.19]

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -15,7 +15,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     py-gitpython@3.1.27, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
-    yafyaml@0.5.1, zlib@1.2.13, odc@1.4.5, crtm@v2.4-jedi.2, shumlib@macos_clang_linux_intel_port]
+    yafyaml@0.5.1, zlib@1.2.13, odc@1.4.6, crtm@v2.4-jedi.2, shumlib@macos_clang_linux_intel_port]
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
     # https://github.com/NOAA-EMC/spack-stack/issues/326

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -62,7 +62,7 @@ spack:
     - netcdf-fortran@4.6.0
     - nlohmann-json@3.10.5
     - nlohmann-json-schema-validator@2.1.0
-    - odc@1.4.5
+    - odc@1.4.6
     - parallelio@2.5.9
     - parallel-netcdf@1.12.2
     - py-eccodes@1.4.2

--- a/configs/templates/skylab-no-python-dev/spack.yaml
+++ b/configs/templates/skylab-no-python-dev/spack.yaml
@@ -77,7 +77,7 @@ spack:
     - netcdf-fortran@4.6.0
     - nlohmann-json@3.10.5
     - nlohmann-json-schema-validator@2.1.0
-    - odc@1.4.5
+    - odc@1.4.6
     - parallelio@2.5.9
     - parallel-netcdf@1.12.2
     # DH* fake version number


### PR DESCRIPTION
This PR updates configuration to use the new odc 1.4.6 version. I'm not certain that I made all of the correct changes everywhere so please double check this. Thanks!

fixes #542