### PR TITLE
Use py-pythran@0.12.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_pythran_0122
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_pythran_0122
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -221,9 +221,10 @@
       version: [3.1.0]
     py-python-dateutil:
       version: [2.8.2]
-    #py-pythran:
-    #  # Earlier versions don't compile on macOS with llvm-clang/13.0.0 and Python/3.9
-    #  version: [0.11.0]
+    py-pythran:
+      # Versions earlier than 0.11.0 don't compile on macOS with llvm-clang/13.0.0 and Python/3.9,
+      # and 0.11.0 leads to downstream errors in py-scipy with the Intel compilers
+      version: [0.12.2]
     py-pyyaml:
       version: [6.0]
     py-scipy:


### PR DESCRIPTION
## Description

Use py-pythran@0.12.2, which fixes problems compiling py-scipy with Intel (therefore we deactivated pythran support for py-scipy).

Also includes submodule pointer updates for other packages in spack that had PRs merged yesterday.

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/262

## Issues

This should fix https://github.com/NOAA-EMC/spack-stack/issues/565 (to be confirmed)

## Testing

Tested successfully on Orion w/ Intel.
**MISSING** - CI tests