### PR TITLE
Rename jedi-ewok-env to ewok-env

### DIFF
--- a/.github/actions/setup-spack-stack/action.yaml
+++ b/.github/actions/setup-spack-stack/action.yaml
@@ -197,7 +197,7 @@ runs:
         spack rm jedi-tools-env || true
       fi
       if [[ "$RUNNER_OS" == "macOS" && "${{ inputs.compiler }}" == "gcc"* ]]; then
-        spack rm jedi-ewok-env || true
+        spack rm ewok-env || true
       fi
       set -eo pipefail
 

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -137,7 +137,7 @@ jobs:
           module available
 
           module load jedi-ufs-env/unified-dev
-          module load jedi-ewok-env/unified-dev
+          module load ewok-env/unified-dev
           module load soca-env/unified-dev
           module list
 

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -175,7 +175,7 @@ jobs:
           module available
 
           module load jedi-ufs-env/unified-dev
-          module load jedi-ewok-env/unified-dev
+          module load ewok-env/unified-dev
           module load soca-env/unified-dev
           module list
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/rename_ewok_env
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/rename_ewok_env
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -188,7 +188,7 @@
       variants: ~mpi
     # Comment out for now until build problems are solved
     # https://github.com/NOAA-EMC/spack-stack/issues/522
-    # see also jedi-ewok-env virtual package and container
+    # see also ewok-env virtual package and container
     # README.md
     #py-mysql-connector-python:
     #  version: [8.0.32]

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -4,7 +4,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 
 ### spack-stack-1.3.1 / skylab-4.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
 ```
-  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, jedi-ewok-env@1.0.0, jedi-fv3-env@1.0.0,
+  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
     eckit@1.23.0, ecmwf-atlas@0.33.0 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -7,7 +7,7 @@ spack:
 
   specs:
     # Virtual environment packages
-    - jedi-ewok-env
+    - ewok-env
     - jedi-fv3-env
     - jedi-mpas-env
     - jedi-ufs-env

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -10,7 +10,7 @@ spack:
   - packages:
       - global-workflow-env@unified-dev
       #- gsi-env@unified-dev
-      - jedi-ewok-env@unified-dev
+      - ewok-env@unified-dev
       - jedi-fv3-env@unified-dev
       - jedi-mpas-env@unified-dev
       - jedi-tools-env@unified-dev
@@ -43,7 +43,7 @@ spack:
         - jedi-tools-env%intel
         ## Don't even bother building those with Intel 18,
         ## not needed. Many of the Python packages don't build.
-        #- jedi-ewok-env%intel@18
+        #- ewok-env%intel@18
         #- jedi-fv3-env%intel@18
         #- jedi-tools-env%intel@18
         #- jedi-ufs-env%intel@18

--- a/doc/source/Environments.rst
+++ b/doc/source/Environments.rst
@@ -18,7 +18,7 @@ Environments can be constructed in two ways in spack-stack:
            spack add netcdf-c@4.7.4
            spack add ufs-weather-model-env
            spack add ufs-weather-model-env@1.0.0 +debug
-           spack add jedi-ewok-env +solo +r2d2 +ewok 
+           spack add ewok-env
            spack add mapl@2.12.3 +debug ^esmf@8.3.0 +debug
            spack add mapl@2.12.3 +debug ^esmf@8.3.0 +debug
            ...
@@ -59,7 +59,7 @@ The purpose of virtual packages is to provide a convenient collection of package
 
 **AUTOMATICALLY GENERATE A TABLE WITH NAME AND DESCRIPTION BASED ON THE FILE NAME AND THE DOXSTRING? IF WE DO THAT, ALSO UPDATE THE SECTION ON GENERATING DOCUMENTATION WITH THE NECESSARY DETAILS**
 
-**For now, check the contents of ``spack/var/spack/repos/jcsda-emc-bundles/packages/`` yourself, sorry. Also, run ``spack info jedi-ewok-env``, for example, to obtain further information on the package.**
+**For now, check the contents of ``spack/var/spack/repos/jcsda-emc-bundles/packages/`` yourself, sorry. Also, run ``spack info ewok-env``, for example, to obtain further information on the package.**
 
 .. _EnvironmentsTemplates:
 


### PR DESCRIPTION
## Description

Rename `jedi-ewok-env` to `ewok-env` as described in https://github.com/NOAA-EMC/spack-stack/issues/527.

Also includes spack submodule pointer updates for recent merges.

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/263

## Issues

Fixes https://github.com/NOAA-EMC/spack-stack/issues/527

## Testing

Only requires CI testing:
- [x] documentation
- [x] Ubuntu
- [x] macOS
