### PR TITLE
Add support for JEDI-NEPTUNE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/NOAA-EMC/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/NOAA-EMC/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_neptune_packages
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/NOAA-EMC/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_neptune_packages
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/NOAA-EMC/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -62,7 +62,6 @@ modules:
       - libxrandr
       - libxrender
       - libxxf86vm
-      - libyaml
       - lz4
       - m4
       - mysql
@@ -114,6 +113,12 @@ modules:
         environment:
           set:
             'PNG_ROOT': '{prefix}'
+      libyaml:
+        environment:
+          set:
+            'YAML_DIR': '{prefix}'
+            'YAML_LIB': '{prefix}/lib'
+            'YAML_INC': '{prefix}/include'
       mapl:
         suffixes:
           ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'
@@ -290,7 +295,6 @@ modules:
       - libxrandr
       - libxrender
       - libxxf86vm
-      - libyaml
       - lz4
       - m4
       - mysql
@@ -342,6 +346,12 @@ modules:
         environment:
           set:
             'PNG_ROOT': '{prefix}'
+      libyaml:
+        environment:
+          set:
+            'YAML_DIR': '{prefix}'
+            'YAML_LIB': '{prefix}/lib'
+            'YAML_INC': '{prefix}/include'
       mapl:
         suffixes:
           ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -109,6 +109,10 @@ modules:
         environment:
           set:
             'ESMFMKFILE': '{prefix}/lib/esmf.mk'
+      hdf5:
+        environment:
+          set:
+            'HDF5_DIR': '{prefix}'
       libpng:
         environment:
           set:
@@ -135,6 +139,12 @@ modules:
         environment:
           set:
             'OMPI_MCA_rmaps_base_oversubscribe': '1'
+      p4est:
+        environment:
+          set:
+            'P4EST_API_DIR': '{prefix}'
+            'P4EST_API_LIB': '{prefix}/lib'
+            'P4EST_API_INC': '{prefix}/include'
       bacio:
         environment:
           set:
@@ -342,6 +352,10 @@ modules:
         environment:
           set:
             'ESMFMKFILE': '{prefix}/lib/esmf.mk'
+      hdf5:
+        environment:
+          set:
+            'HDF5_DIR': '{prefix}'
       libpng:
         environment:
           set:
@@ -368,6 +382,12 @@ modules:
         environment:
           set:
             'OMPI_MCA_rmaps_base_oversubscribe': '1'
+      p4est:
+        environment:
+          set:
+            'P4EST_API_DIR': '{prefix}'
+            'P4EST_API_LIB': '{prefix}/lib'
+            'P4EST_API_INC': '{prefix}/include'
       bacio:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -115,6 +115,8 @@
       version: [2.1.0]
     libpng:
       version: [1.6.37]
+    libyaml:
+      version: [0.2.5]
     mapl:
       # 2.35.2 goes with esmf@8.4.1
       #version: [2.35.2]
@@ -162,6 +164,8 @@
       variants: +noavx512
     openmpi:
       variants: +internal-hwloc +two_level_namespace
+    p4est:
+      version: [2.8]
     parallelio:
       version: [2.5.9]
       variants: +pnetcdf

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -5,84 +5,19 @@ spack:
   view: false
   include: []
 
-  specs:
-    # Virtual environment packages
-    - ewok-env
-    - jedi-fv3-env
-    - jedi-mpas-env
-    - jedi-ufs-env
-    - jedi-um-env
-    - soca-env
+  definitions:
+  - compilers: ['%apple-clang', '%gcc', '%intel']
+  - packages:
+      - ewok-env@unified-dev
+      - jedi-fv3-env@unified-dev
+      - jedi-mpas-env@unified-dev
+      - jedi-neptune-env@unified-dev
+      - jedi-tools-env@unified-dev
+      - jedi-ufs-env@unified-dev
+      - jedi-um-env@unified-dev
+      - soca-env@unified-dev
 
-    # Individual packages
-    - bacio@2.4.1
-    # Do not request specific version of bison - this leads to duplicate packages being built
-    #- bison@3.8.2
-    - bufr@11.7.1
-    - crtm@2.3.0
-    - crtm@2.4.0
-    - crtm@v2.4-jedi.2
-    - crtm@v2.4.1-jedi
-    - crtm@v3.0.0-rc.1
-    - ecbuild@3.7.2
-    - eccodes@2.27.0
-    - ecflow@5
-    - eckit@1.23.0
-    - ecmwf-atlas@0.33.0
-    - ectrans@1.2.0
-    - eigen@3.4.0
-    - esmf@8.3.0b09
-    # DH* fake version number
-    #- ewok@0.0.1
-    - fckit@0.10.1
-    - fiat@1.1.0
-    # Do not request specific version of flex - this leads to duplicate packages being built
-    #- flex@2.6.4
-    - fms@2022.04
-    # DH* fake version number
-    - fms@release-jcsda
-    - g2@3.4.5
-    - g2tmpl@1.10.2
-    #- gdal@3.4.3
-    #- geos@3.9.1
-    - gftl-shared@1.5.0
-    - gsibec@1.1.2
-    - hdf@4.2.15
-    - hdf5@1.12.2
-    - ip@3.3.3
-    - jasper@2.0.32
-    - jedi-cmake@1.4.0
-    - libpng@1.6.37
-    - mapl@2.22.0
-    - nccmp@1.9.0.1
-    - ncview@2.1.8
-    - nemsio@2.5.2
-    - netcdf-c@4.9.2
-    - netcdf-cxx4@4.3.1
-    - netcdf-fortran@4.6.0
-    - nlohmann-json@3.10.5
-    - nlohmann-json-schema-validator@2.1.0
-    - odc@1.4.6
-    - parallelio@2.5.9
-    - parallel-netcdf@1.12.2
-    - py-eccodes@1.4.2
-    - py-f90nml@1.4.3
-    - py-h5py@3.6.0
-    - py-numpy@1.22.3
-    - py-pandas@1.4.0
-    - py-pyyaml@6.0
-    - py-scipy@1.9.3
-    - py-shapely@1.8.0
-    - py-xarray@2022.3.0
-    # DH* fake version number
-    #- r2d2@0.0.1
-    # DH* fake version number
-    - shumlib@macos_clang_linux_intel_port
-    - sigio@2.3.2
-    #- solo@1.0.0
-    - sp@2.3.3
-    - udunits@2.2.28
-    - w3emc@2.9.2
-    - w3nco@2.4.1
-    - yafyaml@0.5.1
-    - zlib@1.2.13
+  specs:
+    - matrix:
+      - [$packages]
+      - [$compilers]

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -13,6 +13,7 @@ spack:
       - ewok-env@unified-dev
       - jedi-fv3-env@unified-dev
       - jedi-mpas-env@unified-dev
+      - jedi-neptune-env@unified-dev
       - jedi-tools-env@unified-dev
       - jedi-ufs-env@unified-dev
       - jedi-um-env@unified-dev
@@ -24,12 +25,14 @@ spack:
       #- upp-env@unified-dev
       #- ww3-env@unified-dev
 
-      # Additional esmf/mapl tag for testing
-      #- esmf@8.4.1~debug+external-parallelio
-      #- mapl@2.35.2~debug ^esmf@8.4.1~debug+external-parallelio
+      # Additional esmf/mapl tags - don't activate by default, this
+      # can lead to duplicate packages (e.g. in Ubuntu CI tests)
+      #- esmf@8.4.2~debug+external-parallelio
+      #- mapl@2.35.2~debug ^esmf@8.4.2~debug+external-parallelio
 
-      # Additional crtm tag for testing - don't activate by default,
-      # this can lead to duplicate packages (e.g. in Ubuntu CI tests)
+      # Additional crtm tags - don't activate by default, this
+      # can lead to duplicate packages (e.g. in Ubuntu CI tests)
+      #- crtm@v2.4-jedi.2
       #- crtm@v3.0.0-rc.1
 
   specs:


### PR DESCRIPTION
## Description

Add support for `jedi-neptune-env`:
- library versions for NEPTUNE dependencies
- module environment variables for NEPTUNE dependencies
- add `jedi-neptune-env` to `unified-dev` and `skylab-dev` template

Also: Make `skylab-dev` template look like `unified-dev` template.

## Dependencies

Waiting on https://github.com/NOAA-EMC/spack/pull/264

## Issues

Fixes #498 

## Testing

Tested on Narwhal with Intel and on macOS with apple-clang.