### PR TITLE
Update NOAA Parallelworks (add ecflow) and clean up documentation

### DIFF
--- a/configs/sites/noaa-aws/mirrors.yaml
+++ b/configs/sites/noaa-aws/mirrors.yaml
@@ -1,0 +1,18 @@
+mirrors:
+  local-source:
+    fetch:
+      url: file:///contrib/EPIC/spack-stack/source-cache/
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null
+    push:
+      url: file:///contrib/EPIC/spack-stack/source-cache/
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null

--- a/configs/sites/noaa-aws/modules.yaml
+++ b/configs/sites/noaa-aws/modules.yaml
@@ -2,3 +2,6 @@ modules:
   default:
     enable::
     - lmod
+    lmod:
+      blacklist:
+      - ecflow

--- a/configs/sites/noaa-aws/packages.yaml
+++ b/configs/sites/noaa-aws/packages.yaml
@@ -45,7 +45,7 @@ packages:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /data/prod/jedi/spack-stack/ecflow-5.8.4
+      prefix: /contrib/spack-stack/apps/ecflow-5.8.4
       modules:
       - ecflow/5.8.4
   file:
@@ -99,7 +99,7 @@ packages:
   mysql:
     externals:
     - spec: mysql@8.0.31
-      prefix: /contrib/spack-stack/mysql-8.0.31
+      prefix: /contrib/spack-stack/apps/mysql-8.0.31
   ncurses:
     externals:
     - spec: ncurses@6.3.20211021+termlib abi=6

--- a/configs/sites/noaa-aws/packages.yaml
+++ b/configs/sites/noaa-aws/packages.yaml
@@ -41,6 +41,13 @@ packages:
     externals:
     - spec: diffutils@3.3
       prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost
+      prefix: /data/prod/jedi/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.11

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -89,7 +89,7 @@ packages:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack/apps/ecflow-5.8.4
+      prefix: /data/prod/jedi/spack-stack/ecflow-5.8.4
       modules:
       - ecflow/5.8.4
   file:

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -88,8 +88,8 @@ packages:
   ecflow:
     buildable: False
     externals:
-    - spec: ecflow@5.8.4
-      prefix: /data/prod/jedi/spack-stack/ecflow-5.8.4
+    - spec: ecflow@5.8.4+ui+static_boost
+      prefix: /contrib/spack-stack/apps/ecflow-5.8.4
       modules:
       - ecflow/5.8.4
   file:

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -422,7 +422,11 @@ NOAA NCO WCOSS2
 NOAA Parallel Works (AWS, Azure, Gcloud)
 ----------------------------------------
 
-On NOAA Parallel Works, ``miniconda``, ``ecflow``, ``mysql`` and a few additional utilities need to be installed as a one-off before spack can be used.
+On NOAA Parallel Works, ``miniconda``, ``ecflow``, ``mysql`` and a few additional utilities need to be installed as a one-off before spack can be used. An additional command needs to be run once to fix a problem with a missing library:
+
+.. code-block:: console
+
+   sudo ln -s /apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin/libintlc.so /apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin/libintl.so
 
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation in ``/contrib/spack-stack/apps/miniconda/miniconda3``.

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -259,7 +259,7 @@ mysql
 NASA Discover
 ------------------------------
 
-On Discover, ``miniconda``, ``qt``, and ``ecflow`` need to be installed as a one-off before spack can be used. When using the GNU compiler, it is also necessary to build your own ``openmpi`` or other MPI library, which requires adapting the installation to the network hardware and ``slurm`` scheduler.
+On Discover, ``miniconda``, ``qt``, ``ecflow``, and ``mysql`` need to be installed as a one-off before spack can be used. When using the GNU compiler, it is also necessary to build your own ``openmpi`` or other MPI library, which requires adapting the installation to the network hardware and ``slurm`` scheduler.
 
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.
@@ -309,7 +309,7 @@ mysql
 NAVY HPCMP Narwhal
 ------------------------------
 
-On Narwhal, ``git-lfs``, ``qt``, and ``ecflow`` need to be installed as a one-off before spack can be used.
+On Narwhal, ``git-lfs``, ``qt``, ``ecflow``, and ``mysql`` need to be installed as a one-off before spack can be used.
 
 git-lfs
    The following instructions install ``git-lfs`` in ``/p/app/projects/NEPTUNE/spack-stack/git-lfs-2.10.0``. Version 2.10.0 is the default version for Narwhal. First, download the ``git-lfs`` RPM on a system with full internet access (e.g., Cheyenne) using ``wget https://download.opensuse.org/repositories/openSUSE:/Leap:/15.2/standard/x86_64/git-lfs-2.10.0-lp152.1.2.x86_64.rpm`` and copy this file to ``/p/app/projects/NEPTUNE/spack-stack/git-lfs-2.10.0/src``. Then switch to Narwhal and run the following commands. 
@@ -374,8 +374,7 @@ Casper is co-located with Cheyenne and shares the parallel filesystem ``/glade``
 NCAR-Wyoming Cheyenne
 ------------------------------
 
-On Cheyenne, a workaround is needed to avoid the modules provided by CISL take precedence over the spack modules. The default module path for compilers is removed, the module path is set to a different location and that location is then loaded into the module environment. If new compilers or MPI libraries are
-added to ``/glade/u/apps/ch/modulefiles/default/compilers`` by CISL, the spack-stack maintainers need to make the corresponding changes in ``/glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers``. See :numref:`Section %s <Preconfigured_Sites_Cheyenne>` for details. Note also that there are problems with newer versions of the Intel compiler/MPI library when trying to run MPI jobs with just one task (``mpiexec -np 1``) - for JEDI, job hangs forever in a particular MPI communication call in oops. This is why an older version Intel 19 is used here and on Casper.
+On Cheyenne, there are problems with newer versions of the Intel compiler/MPI library when trying to run MPI jobs with just one task (``mpiexec -np 1``) - for JEDI, job hangs forever in a particular MPI communication call in oops. This is why an older version Intel 19 is used here and on Casper.
 
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Because of the workaround for the compilers, the ``miniconda`` module should be placed in ``/glade/work/jedipara/cheyenne/spack-stack/misc``. Don't forget to log off and back on to forget about the conda environment.
@@ -423,10 +422,29 @@ NOAA NCO WCOSS2
 NOAA Parallel Works (AWS, Azure, Gcloud)
 ----------------------------------------
 
-**WORK IN PROGRESS**
+On NOAA Parallel Works, ``miniconda``, ``ecflow``, ``mysql`` and a few additional utilities need to be installed as a one-off before spack can be used.
+
+miniconda
+   Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation in ``/contrib/spack-stack/apps/miniconda/miniconda3``.
+
+ecflow
+   ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `miniconda` and loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow`` in ``/contrib/spack-stack/apps/ecflow-5.8.4``. Because of the dependency on ``miniconda``, that module must be loaded automatically in the ``ecflow`` module. If the ``cmake`` step for ``ecflow`` fails with an error related to Python, add ``-DPython3_EXECUTABLE=`which python3` `` to the ``cmake`` command.
+
+.. code-block:: console
+
+   module unuse /opt/cray/craype/default/modulefiles
+   module unuse /opt/cray/modulefiles
+   export PATH="${PATH}:/contrib/spack-stack/apps/utils/bin"
+   module use /contrib/spack-stack/modulefiles/core
+   module load miniconda/3.9.12
+   module load gnu/9.2.0
+   module load cmake/3.20.1
 
 mysql
-  ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/contrib/spack-stack/mysql-8.0.31``.
+   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/contrib/spack-stack/apps/mysql-8.0.31``.
+
+Other utilities
+   The following utilities need to be installed in ``/contrib/spack-stack/apps/utils/bin``: ``curl``, ``git-lfs``, ``rg``. **The instructions for this step are missing**.
 
 .. _MaintainersSection_Gaea:
 
@@ -434,7 +452,7 @@ mysql
 NOAA RDHPCS Gaea C4
 ------------------------------
 
-On Gaea, ``miniconda``, ``qt``, and ``ecflow`` need to be installed as a one-off before spack can be used.
+On Gaea, ``miniconda``, ``qt``, ``ecflow``, and ``mysql`` need to be installed as a one-off before spack can be used.
 
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment. Use the following workaround to avoid the terminal being spammed by error messages about missing version information (``/bin/bash: /lustre/f2/pdata/esrl/gsd/spack-stack/miniconda-3.9.12/lib/libtinfo.so.6: no version information available (required by /lib64/libreadline.so.7)``):
@@ -475,7 +493,7 @@ mysql
 NOAA RDHPCS Gaea C5
 ------------------------------
 
-On Gaea C5, ``miniconda``, ``qt``, and ``ecflow`` need to be installed as a one-off before spack can be used.
+On Gaea C5, ``miniconda``, ``qt``, ``ecflow``, and ``mysql`` need to be installed as a one-off before spack can be used.
 
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment. Use the following workaround to avoid the terminal being spammed by error messages about missing version information (``/usr/bin/lua5.3: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/miniconda-3.9.12-c5/lib/libtinfo.so.6: no version information available (required by /lib64/libreadline.so.7)``):
@@ -519,7 +537,7 @@ mysql
 NOAA RDHPCS Hera
 ------------------------------
 
-On Hera, ``miniconda``, ``mysql`` must be installed as a one-off before spack can be used. When using the GNU compiler, it is also necessary to build your own ``openmpi`` or other MPI library.
+On Hera, ``miniconda`` and ``mysql`` must be installed as a one-off before spack can be used. When using the GNU compiler, it is also necessary to build your own ``openmpi`` or other MPI library.
 
 miniconda
    Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment.

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -419,7 +419,7 @@ CONFIG_SITE should be set to empty in `compilers.yaml`. Don't use ``module purge
 NOAA Parallel Works (AWS, Azure, Gcloud)
 ----------------------------------------
 
-The following is required for building new spack environments and for using spack to build and run software. The default module path needs to be removed, otherwise spack detect the system as Cray. It is also necessary to add ``git-lfs`` and some other utilities to the search path.
+The following is required for building new spack environments and for using spack to build and run software. The default module path needs to be removed, otherwise spack detect the system as Cray. It is also necessary to add ``git-lfs`` and some other utilities to the search path (see :numref:`Section %s <MaintainersSection_Parallel_Works >`).
 
 .. code-block:: console
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -5,9 +5,7 @@ Pre-configured sites
 
 Directory ``configs/sites`` contains site configurations for several HPC systems, as well as minimal configurations for macOS and Linux. The macOS and Linux configurations are **not** meant to be used as is, as user setups and package versions vary considerably. Instructions for adding this information can be found in :numref:`Section %s <NewSiteConfigs>`.
 
-Pre-configured sites are split into two categories: Tier 1 with officially support spack-stack installations (see :numref:`Section %s <Preconfigured_Sites_Tier1>`), and Tier 2 (sites with configuration files that were tested or contributed by others in the past, but that are not officially supported by the spack-stack team; see :numref:`Section %s <Preconfigured_Sites_Tier2>`).
-
-.. _Preconfigured_Sites_Tier1:
+Pre-configured sites are split into two categories: Tier 1 with officially supported spack-stack installations (see :numref:`Section %s <Preconfigured_Sites_Tier1>`), and Tier 2 (sites with configuration files that were tested or contributed by others in the past, but that are not officially supported by the spack-stack team; see :numref:`Section %s <Preconfigured_Sites_Tier2>`).
 
 =============================================================
 Officially supported spack-stack 1.3.0 installations (tier 1)

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -424,6 +424,8 @@ The following is required for building new spack environments and for using spac
    module use /contrib/spack-stack/modulefiles/core
    module load miniconda/3.9.12
    module load mysql/8.0.31
+   # So far only on NOAA-AWS for spack-stack develop versions newer than 1.3.1
+   module load ecflow/5.8.4
 
 For ``spack-stack-1.3.0`` with Intel, load the following modules after loading miniconda and ecflow:
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -8,6 +8,7 @@ Directory ``configs/sites`` contains site configurations for several HPC systems
 Pre-configured sites are split into two categories: Tier 1 with officially support spack-stack installations (see :numref:`Section %s <Preconfigured_Sites_Tier1>`), and Tier 2 (sites with configuration files that were tested or contributed by others in the past, but that are not officially supported by the spack-stack team; see :numref:`Section %s <Preconfigured_Sites_Tier2>`).
 
 .. _Preconfigured_Sites_Tier1:
+
 =============================================================
 Officially supported spack-stack 1.3.0 installations (tier 1)
 =============================================================
@@ -93,6 +94,12 @@ Ready-to-use spack-stack 1.3.1 installations are available on the following, ful
 ^** spack-stack-1.3.1 is not yet available on NOAA Parallel Works Azure, but on AWS and Gcloud.
 
 For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/noaa-emc/spack-stack/issues>`_ and `discussions <https://github.com/noaa-emc/spack-stack/discussions>`_ first.
+
+.. _Preconfigured_Sites_Tier1:
+
+=============================================================
+Pre-configured sites (tier 1)
+=============================================================
 
 .. _Preconfigured_Sites_Orion:
 


### PR DESCRIPTION
## Description

Add `ecflow` to NOAA Parallel Works and complete the documentation for these platforms. This has been tested in a temporary location for AWS only (using `ca-jcsda`): `/lustre/spack-stack-test/spack-stack-pw-ecflow/envs/unified-env`

- [n/a] Installation on NOAA-AWS: This will be done in a follow-up PR
- [n/a] Installation on NOAA-Gcloud: This will be done in a follow-up PR
- [n/a] Installation on NOAA-Azure: This will be done in a follow-up PR
- [x] Documentation updates

Also:
- [x] General clean up of documentation (add missing headers, complete the maintainer section).
- [x] Update of submodule pointer for spack for recent merges

## Issues

n/a - part of epic https://github.com/JCSDA-internal/AOP23/issues/58

## Testing

- [x] ran jedi-bundle ctest on NOAA ParallelWorks AWS (uses Intel) - 100% tests passed, 0 tests failed out of 1674 
- [x] ran the qg-4dvar Skylab experiment on NOAA Parallelworks AWS successfully

## Dependencies

none