### PR TITLE
Update URLs with noaa-emc in it to jcsda where appropriate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/NOAA-EMC/spack
+  url = https://github.com/jcsda/spack
   branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -167,7 +167,7 @@
       variants: +pnetcdf
     parallel-netcdf:
       version: [1.12.2]
-    # Do not build pkgconf - https://github.com/NOAA-EMC/spack-stack/issues/123
+    # Do not build pkgconf - https://github.com/jcsda/spack-stack/issues/123
     pkgconf:
       buildable: False
     prod-util:
@@ -187,7 +187,7 @@
       version: [3.6.0]
       variants: ~mpi
     # Comment out for now until build problems are solved
-    # https://github.com/NOAA-EMC/spack-stack/issues/522
+    # https://github.com/jcsda/spack-stack/issues/522
     # see also ewok-env virtual package and container
     # README.md
     #py-mysql-connector-python:

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -18,10 +18,10 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.6, crtm@v2.4.1-jedi, shumlib@macos_clang_linux_intel_port]
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
-    # https://github.com/NOAA-EMC/spack-stack/issues/326
+    # https://github.com/jcsda/spack-stack/issues/326
     # jedi-ufs-env@1.0.0, esmf@8.3.0b09, mapl@2.22.0
     # Comment out for now until build problems are solved
-    # https://github.com/NOAA-EMC/spack-stack/issues/522
+    # https://github.com/jcsda/spack-stack/issues/522
     # py-mysql-connector-python@8.0.32, 
 ```
 

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -100,7 +100,7 @@ spack:
     images:
       os: ubuntu:20.04
       spack:
-        url: https://github.com/noaa-emc/spack
+        url: https://github.com/jcsda/spack
         ref: jcsda_emc_spack_stack
         resolve_sha: false
 

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -87,7 +87,7 @@ spack:
     images:
       os: ubuntu:20.04
       spack:
-        url: https://github.com/noaa-emc/spack
+        url: https://github.com/jcsda/spack
         ref: jcsda_emc_spack_stack
         resolve_sha: false
 

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -105,7 +105,7 @@ spack:
     images:
       os: ubuntu:20.04
       spack:
-        url: https://github.com/noaa-emc/spack
+        url: https://github.com/jcsda/spack
         ref: jcsda_emc_spack_stack
         resolve_sha: false
 

--- a/configs/sites/aws-pcluster/README.md
+++ b/configs/sites/aws-pcluster/README.md
@@ -240,7 +240,7 @@ rm *.deb
 ```
 mkdir -p /home/ubuntu/sandpit
 cd /home/ubuntu/sandpit
-git clone -b develop --recursive https://github.com/noaa-emc/spack-stack spack-stack
+git clone -b develop --recursive https://github.com/jcsda/spack-stack spack-stack
 cd spack-stack/
 . setup.sh
 spack stack create env --site aws-pcluster --template=unified-dev --name=unified-dev
@@ -251,7 +251,7 @@ sed -i "s/\['\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel', '\%gcc'\]/g" envs
 6. Option 2: Test configuring site from scratch
 ```
 mkdir /home/ubuntu/jedi && cd /home/ubuntu/jedi
-git clone -b develop --recursive https://github.com/noaa-emc/spack-stack spack-stack
+git clone -b develop --recursive https://github.com/jcsda/spack-stack spack-stack
 cd spack-stack/
 . setup.sh
 spack stack create env --site linux.default --template=unified-dev --name=unified-dev

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -88,6 +88,3 @@ macOS
 5. Errors such as ``Symbol not found: __cg_png_create_info_struct``
 
    Can happen when trying to use the raster plotting scripts in ``fv3-jedi-tools``. In that case, exporting ``DYLD_LIBRARY_PATH=/usr/lib/:$DYLD_LIBRARY_PATH`` can help. If ``git`` commands fail after this, you might need to verify where ``which git`` points to (Homebrew vs module) and unload the ``git`` module.
-
-6. Error building MET 10.1.1.20220419 build error on macOS Monterey 12.1
-   See https://github.com/NOAA-EMC/spack-stack/issues/316. Note that this error does not occur in the macOS CI tests.

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -162,7 +162,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. code-block:: console
 
-   git clone --recursive https://github.com/NOAA-EMC/spack-stack.git
+   git clone --recursive https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -434,7 +434,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   git clone --recursive https://github.com/NOAA-EMC/spack-stack.git
+   git clone --recursive https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -48,7 +48,7 @@ Ready-to-use spack-stack 1.3.0 installations are available on the following, ful
 | Amazon Web Services AMI Red Hat 8 GNU                      | Dom Heinzeller / ???          | ``/home/ec2-user/spack-stack/spack-stack-1.3.0/envs/unified-env``                                            |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 
-For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/noaa-emc/spack-stack/issues>`_ and `discussions <https://github.com/noaa-emc/spack-stack/discussions>`_ first.
+For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/jcsda/spack-stack/issues>`_ and `discussions <https://github.com/jcsda/spack-stack/discussions>`_ first.
 
 =======================================================================
 Officially supported spack-stack 1.3.1 installations (subset of tier 1)
@@ -92,7 +92,7 @@ Ready-to-use spack-stack 1.3.1 installations are available on the following, ful
 
 ^** spack-stack-1.3.1 is not yet available on NOAA Parallel Works Azure, but on AWS and Gcloud.
 
-For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/noaa-emc/spack-stack/issues>`_ and `discussions <https://github.com/noaa-emc/spack-stack/discussions>`_ first.
+For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/jcsda/spack-stack/issues>`_ and `discussions <https://github.com/jcsda/spack-stack/discussions>`_ first.
 
 .. _Preconfigured_Sites_Orion:
 
@@ -809,7 +809,7 @@ The following instructions install a new spack environment on a pre-configured s
 
 .. code-block:: console
 
-   git clone --recursive https://github.com/NOAA-EMC/spack-stack.git
+   git clone --recursive https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Ensure Python 3.8+ is available and the default before sourcing spack


### PR DESCRIPTION
## Description

All in the title. Let's wait for the CI tests to finish. The submodule pointer update is for the changes in the spack branch for the same reason (PR https://github.com/JCSDA/spack/pull/266).

## Definition of Done

CI tests

### Issue(s) addressed

Part of #298 

## Dependencies

https://github.com/JCSDA/spack/pull/266

## Impact

none

