### PR TITLE
Ops update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = ops_update_batch
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = ops_update_batch
+  url = https://github.com/JCSDA/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/JCSDA/spack
+  url = https://github.com/jcsda/spack
   branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@
       version: [1.1.0]
     fms:
       version: [2022.04]
-      variants: precision=32,64 +quad_precision +gfs_phys +openmp +fpic constants=GFS
+      variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS
     g2:
       version: [3.4.5]
     g2c:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -162,6 +162,8 @@
       variants: +noavx512
     openmpi:
       variants: +internal-hwloc +two_level_namespace
+    openssl:
+      variants: +shared
     parallelio:
       version: [2.5.9]
       variants: +pnetcdf


### PR DESCRIPTION
This PR points to the spack update for WCOSS ops, and updates packages.yaml to change fms's 'fpic' variant to 'pic'.