### PR TITLE
Update eckit and ecmf-atlas for spack-stack-1.4.0 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_eckit_atlas_20230519
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_eckit_atlas_20230519
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -45,7 +45,7 @@
       version: [1.23.1-pre]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.33.1-pre-jcsda]
+      version: [0.33.1-pre-jcsda-cxx14]
       variants: +fckit +trans
     ectrans:
       version: [1.2.0]

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -42,7 +42,7 @@
       version: [5.8.4]
       variants: +ui
     eckit:
-      version: [1.23.1-pre]
+      version: [1.23.2-pre]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
       version: [0.33.1-pre-jcsda-cxx14]

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -42,10 +42,10 @@
       version: [5.8.4]
       variants: +ui
     eckit:
-      version: [1.23.0]
+      version: [1.23.1-pre]
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.33.0]
+      version: [0.33.1-pre-jcsda]
       variants: +fckit +trans
     ectrans:
       version: [1.2.0]

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.0, ecmwf-atlas@0.33.0 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.12.2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
@@ -32,7 +32,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0,
     bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.0, ecmwf-atlas@0.33.0 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@2022.04, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.12.2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda-cxx14 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.12.2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
@@ -32,7 +32,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0,
     bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda-cxx14 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@2022.04, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.12.2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda-cxx14 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.23.2-pre, ecmwf-atlas@0.33.1-pre-jcsda-cxx14 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
@@ -32,7 +32,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0,
     bacio@2.4.1, bison@3.8.2, bufr@11.7.1, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.1-pre, ecmwf-atlas@0.33.1-pre-jcsda-cxx14 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.23.2-pre, ecmwf-atlas@0.33.1-pre-jcsda-cxx14 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.10.1, fms@2023.01, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,


### PR DESCRIPTION
## Description

Add new versions of eckit and ecmwf-atlas. Both of them are temporary versions ("fake releases"?). For `eckit`, we  point to a commit in the authoritative repo (we are awaiting the creation of the tag). For `ecmwf-atlas`, we need to add specific commits to a slightly earlier version, because since May 3rd the authoritative repository requires C++-17 standard and we haven't had the time to update the entire software stack and the JEDI components to match that requirement.

## Definition of Done

- [x] Build spack-stack, jedi-bundle and run ctests on macOS with apple-cland - see https://github.com/JCSDA-internal/jedi-bundle/issues/40
- [ ] Build spack-stack, jedi-bundle and run ctests on Cheyenne with Intel 19
- [ ] Build spack-stack, jedi-bundle and run ctests on Hercules with Intel 2023.x.y

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/567

## Dependencies

- waiting on https://github.com/JCSDA/spack/pull/270

## Impact

None