### PR TITLE
Add instructions for building openmpi@4.1.5 on Cheyenne, bug fix for pythran 0.12+ with  scipy and older Intel compilers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/pythran_012_intel19
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/pythran_012_intel19
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -3,8 +3,8 @@ packages:
     #compiler:: [intel@2022.0.2, gcc@10.1.0]
     compiler:: [intel@19.1.1.217, gcc@10.1.0]
     providers:
-      #mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.1]
-      mpi:: [intel-mpi@2019.7.217, openmpi@4.1.1]
+      #mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.5]
+      mpi:: [intel-mpi@2019.7.217, openmpi@4.1.5]
 
 ### MPI, Python, MKL
   mpi:
@@ -35,11 +35,12 @@ packages:
       modules:
       - impi/2019.7.217
   openmpi:
-    externals: 
-    - spec: openmpi@4.1.1%gcc@10.1.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm,tm
-      prefix: /glade/u/apps/ch/opt/openmpi/4.1.1/gnu/10.1.0
+    externals:
+    - spec: openmpi@4.1.5%gcc@10.1.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
+        fabrics=ucx schedulers=slurm,tm
+      prefix: /glade/work/epicufsrt/contrib/spack-stack/openmpi-4.1.5
       modules:
-      - openmpi/4.1.1
+      - openmpi/4.1.5
   python:
     buildable: False
     externals:

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -3,8 +3,8 @@ packages:
     #compiler:: [intel@2022.0.2, gcc@10.1.0]
     compiler:: [intel@19.1.1.217, gcc@10.1.0]
     providers:
-      #mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.5]
-      mpi:: [intel-mpi@2019.7.217, openmpi@4.1.5]
+      #mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.1]
+      mpi:: [intel-mpi@2019.7.217, openmpi@4.1.1]
 
 ### MPI, Python, MKL
   mpi:
@@ -36,11 +36,10 @@ packages:
       - impi/2019.7.217
   openmpi:
     externals:
-    - spec: openmpi@4.1.5%gcc@10.1.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
-        fabrics=ucx schedulers=slurm,tm
-      prefix: /glade/work/epicufsrt/contrib/spack-stack/openmpi-4.1.5
+    - spec: openmpi@4.1.1%gcc@10.1.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm,tm
+      prefix: /glade/u/apps/ch/opt/openmpi/4.1.1/gnu/10.1.0
       modules:
-      - openmpi/4.1.5
+      - openmpi/4.1.1
   python:
     buildable: False
     externals:

--- a/doc/modulefile_templates/openmpi
+++ b/doc/modulefile_templates/openmpi
@@ -30,3 +30,8 @@ setenv MPI_HOME ${OPENMPI_PATH}
 unsetenv SLURM_EXPORT_ENV
 setenv PSM2_PATH_SELECTION "static_base"
 setenv SLURM_CPU_BIND "none"
+
+# Settings specific for Cheyenne
+setenv MPI_ROOT ${OPENMPI_PATH}
+setenv UCX_MAX_RNDV_RAILS "1"
+setenv OMPI_MCA_btl "^openib"

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -30,6 +30,18 @@ NASA Discover
    Discover's connection to the outside world can be very slow and spack sometimes aborts with fetch timeouts. Try again until it works, sometimes have to wait for a bit.
 
 ==============================
+NCAR-Wyoming Casper
+==============================
+
+1. ``py-scipy`` is missing the Pythran backend, because older versions of ``py-pythran`` (up to ``0.11.x``) cause compilation errors in ``py-scipy`` for all Intel compilers, and newer ``py-pythran`` versions (``0.12.x`` and later) do not build with the old Intel compiler used on Casper.
+
+==============================
+NCAR-Wyoming Cheyenne
+==============================
+
+1. ``py-scipy`` is missing the Pythran backend, because older versions of ``py-pythran`` (up to ``0.11.x``) cause compilation errors in ``py-scipy`` for all Intel compilers, and newer ``py-pythran`` versions (``0.12.x`` and later) do not build with the old Intel compiler used on Cheyenne.
+
+==============================
 NOAA Parallel Works
 ==============================
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -386,9 +386,7 @@ qt (qt@5)
 .. code-block:: console
 
    module purge
-   module unuse /glade/u/apps/ch/modulefiles/default/compilers
-   export MODULEPATH_ROOT=/glade/work/jedipara/cheyenne/spack-stack/modulefiles
-   module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
+   export LMOD_TMOD_FIND_FIRST=yes
    module load gnu/10.1.0
 
 ecflow
@@ -397,9 +395,7 @@ ecflow
 .. code-block:: console
 
    module purge
-   module unuse /glade/u/apps/ch/modulefiles/default/compilers
-   export MODULEPATH_ROOT=/glade/work/jedipara/cheyenne/spack-stack/modulefiles
-   module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
+   export LMOD_TMOD_FIND_FIRST=yes
    module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
    module load gnu/10.1.0
    module load miniconda/3.9.12
@@ -408,6 +404,27 @@ ecflow
 
 mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/glade/work/jedipara/cheyenne/spack-stack/mysql-8.0.31``.
+
+openmpi
+
+    module purge
+    export LMOD_TMOD_FIND_FIRST=yes
+    module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
+    module load gnu/10.1.0
+
+   ./configure \
+       --prefix=/glade/work/epicufsrt/contrib/spack-stack/openmpi-4.1.5 \
+       --without-verbs \
+       --with-ucx=/glade/u/apps/ch/opt//ucx/1.12.1 \
+       --disable-wrapper-runpath \
+       --with-tm=/opt/pbs \
+       --enable-mca-no-build=btl-uct \
+       2>&1 | tee log.config
+   make VERBOSE=1 -j2
+   make check
+   make install
+
+
 
 .. _MaintainersSection_WCOSS2:
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -303,9 +303,9 @@ For ``spack-stack-1.3.0`` with GNU, load the following modules after loading the
 
 .. _Preconfigured_Sites_Casper:
 
--------------------
+------------------------------
 NCAR-Wyoming Casper
--------------------
+------------------------------
 
 The following is required for building new spack environments and for using spack to build and run software.
 


### PR DESCRIPTION
## Description

This PR adds instructions for building `openmpi@4.1.5` on Cheyenne with `gcc@10.1.0`. @ulmononian and I were able to run several tests with it, and it seems to be working ok. But it does not fix the problem that we built it for (a GOCART-enabled version of the UFS Weather Model that fails with openmpi@4.1.1 and openmpi@4.1.4). I suggest to keep the instructions just in case we need them again before the machine goes out of service.

The PR also does some cleanup of the documentation for Cheyenne and Casper, and updates the submodule pointer to fix a bug when trying to build `py-scipy` with the Pythran extension enabled using the older Intel compiler (19.x.y) on Cheyenne or Casper. The short answer is: it doesn't work. `py-pythran@0.12.2` itself builds fine with for older and newer Intel compilers, and the Pythran extension in `py-scipy` builds fine with newer Intel compilers - but not with older versions.

## Definition of Done

I tested this on Cheyenne.

### Issue(s) addressed

n/a

## Dependencies

- waiting on https://github.com/JCSDA/spack/pull/271

## Impact

none