### PR TITLE
Add Nautilus site config, last-minute bug fixes for Gaea C4 and Hercules, remove jedi-tools from skylab-dev template

### DIFF
--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -83,7 +83,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[openmpi]"
           spack config add "packages:all:compiler:[apple-clang@14.0.0]"
-          sed -i '' "s/\['\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
+          sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
 

--- a/.github/workflows/macos-dom.yaml
+++ b/.github/workflows/macos-dom.yaml
@@ -61,7 +61,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[openmpi@4.1.4]"
           spack config add "packages:all:compiler:[apple-clang@13.1.6]"
-          sed -i '' "s/\['\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
+          sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
           # Concretize, add source cache (read-only!), install
           spack concretize 2>&1 | tee log.concretize.apple-clang-13.1.6

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -121,7 +121,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[intel-oneapi-mpi@2021.4.0]"
           spack config add "packages:all:compiler:[intel@2021.4.0]"
-          sed -i "s/\['\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel'\]/g" $ENVDIR/spack.yaml
+          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel'\]/g" $ENVDIR/spack.yaml
 
           spack concretize 2>&1 | tee log.concretize.intel-2021.4.0
 

--- a/configs/sites/gaea/compilers.yaml
+++ b/configs/sites/gaea/compilers.yaml
@@ -10,7 +10,7 @@ compilers::
       operating_system: cnl7
       modules:
       - PrgEnv-intel
-      - intel/intel-classic.2022.0.2
+      - intel-classic/2022.0.2
       environment:
         prepend_path:
           PATH: '/opt/gcc/10.3.0/snos/bin'

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -126,15 +126,17 @@ packages:
     externals:
     - spec: openssh@8.7p1
       prefix: /usr
-  openssl:
-    buildable: False
-    externals:
-    - spec: openssl@3.0.1
-      prefix: /usr
-  perl:
-    externals:
-    - spec: perl@5.32.1~cpanm+shared+threads
-      prefix: /usr
+  # Do not use, can lead to duplicate packages being built
+  #openssl:
+  #  buildable: False
+  #  externals:
+  #  - spec: openssl@3.0.1
+  #    prefix: /usr
+  # Do not use, incomplete package (missing FindBin for example)
+  #perl:
+  #  externals:
+  #  - spec: perl@5.32.1~cpanm+shared+threads
+  #    prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.7.3
@@ -149,10 +151,11 @@ packages:
     externals:
     - spec: subversion@1.14.1
       prefix: /usr
-  tar:
-    externals:
-    - spec: tar@1.34
-      prefix: /usr
+  # Do not use, problems on compute nodes with Intel
+  #tar:
+  #  externals:
+  #  - spec: tar@1.34
+  #    prefix: /usr
   texinfo:
     externals:
     - spec: texinfo@6.7

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -1,0 +1,39 @@
+compilers:
+- compiler:
+    spec: aocc@4.0.0
+    paths:
+      cc: /p/app/compilers/amd/aocc/4.0.0/bin/clang
+      cxx: /p/app/compilers/amd/aocc/4.0.0/bin/clang++
+      f77: /p/app/compilers/amd/aocc/4.0.0/bin/flang
+      fc: /p/app/compilers/amd/aocc/4.0.0/bin/flang
+    flags:
+      cflags: null
+      cxxflags: null
+      fflags: null
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - amd/aocc/4.0.0
+    - amd/aocl/aocc/4.0
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.5.0
+    paths:
+      cc: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/icc
+      cxx: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/icpc
+      f77: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+      fc: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - intel/compiler/2022.0.2
+    environment:
+      prepend_path:
+        PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
+        CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
+        LD_LIBRARY_PATH: '/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
+      #set:
+      #  I_MPI_ROOT: '/glade/u/apps/opt/intel/2020u1/impi/2019.7.217/intel64'
+    extra_rpaths: []

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -33,7 +33,7 @@ compilers:
       prepend_path:
         PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
         CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
-        LD_LIBRARY_PATH: '/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
-      #set:
-      #  I_MPI_ROOT: '/glade/u/apps/opt/intel/2020u1/impi/2019.7.217/intel64'
+        LD_LIBRARY_PATH: '/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
+      set:
+        I_MPI_ROOT: '/p/app/compilers/intel/oneapi/mpi/2021.5.1'
     extra_rpaths: []

--- a/configs/sites/nautilus/config.yaml
+++ b/configs/sites/nautilus/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 8

--- a/configs/sites/nautilus/mirrors.yaml
+++ b/configs/sites/nautilus/mirrors.yaml
@@ -1,0 +1,18 @@
+mirrors:
+  local-source:
+    fetch:
+      url: file:///p/app/projects/NEPTUNE/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null
+    push:
+      url: file:///p/app/projects/NEPTUNE/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null

--- a/configs/sites/nautilus/modules.yaml
+++ b/configs/sites/nautilus/modules.yaml
@@ -1,0 +1,8 @@
+modules:
+  default:
+    enable::
+    - lmod
+    lmod:
+      whitelist:
+      # List of packages for which we need modules that are blacklisted by default
+      - python

--- a/configs/sites/nautilus/modules.yaml
+++ b/configs/sites/nautilus/modules.yaml
@@ -1,8 +1,10 @@
 modules:
   default:
     enable::
-    - lmod
-    lmod:
+    - tcl
+    tcl:
       whitelist:
       # List of packages for which we need modules that are blacklisted by default
       - python
+      blacklist:
+      - ecflow

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -47,6 +47,13 @@ packages:
     externals:
     - spec: diffutils@3.6
       prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost
+      prefix: /p/app/projects/NEPTUNE/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
   findutils:
     externals:
     - spec: findutils@4.6.0
@@ -87,6 +94,8 @@ packages:
     externals:
     - spec: mysql@8.0.31
       prefix: /p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31
+      modules:
+      - mysql/8.0.31
   openssh:
     externals:
     - spec: openssh@8.0p1

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -1,0 +1,117 @@
+packages:
+  all:
+    compiler:: [intel@2021.5.0, aocc@4.0.0]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.4]
+
+### MPI, Python, MKL
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
+      modules:
+      - intel/mpi/2021.5.1
+      prefix: /p/app/compilers/intel/oneapi
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+      prefix: /p/app/penguin/openmpi/4.1.4/aoc
+
+### All other external packages listed alphabetically
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.16.1
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.30.117
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.30
+      prefix: /usr
+  #curl:
+  #  externals:
+  #  - spec: curl@7.61.1+gssapi+ldap+nghttp2
+  #    prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.31.1~tcltk
+      prefix: /usr
+  git-lfs:
+    externals:
+    - spec: git-lfs@2.13.3
+      prefix: /usr
+  gmake:
+    externals:
+    - spec: gmake@4.2.1
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.3
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  mysql:
+    externals:
+    - spec: mysql@8.0.31
+      prefix: /p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31
+  openssh:
+    externals:
+    - spec: openssh@8.0p1
+      prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@1.1.1k
+      prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.26.3~cpanm+open+shared+threads
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.4.2
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.30
+      prefix: /usr
+  texinfo:
+    externals:
+    - spec: texinfo@6.5
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.19.5
+      prefix: /usr

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -6,13 +6,12 @@ spack:
   include: []
 
   definitions:
-  - compilers: ['%apple-clang', '%gcc', '%intel']
+  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
       - ewok-env@unified-dev
       - jedi-fv3-env@unified-dev
       - jedi-mpas-env@unified-dev
       - jedi-neptune-env@unified-dev
-      - jedi-tools-env@unified-dev
       - jedi-ufs-env@unified-dev
       - jedi-um-env@unified-dev
       - soca-env@unified-dev

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -6,7 +6,7 @@ spack:
   include: []
 
   definitions:
-  - compilers: ['%apple-clang', '%gcc', '%intel']
+  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
       - global-workflow-env@unified-dev
       #- gsi-env@unified-dev

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -360,6 +360,28 @@ ecflow
 mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31``.
 
+.. _MaintainersSection_Narwhal:
+
+------------------------------
+NAVY HPCMP Nautilus
+------------------------------
+
+On Nautilus, ``mysql`` and ``ecflow`` need to be installed as a one-off before spack can be used.
+
+ecflow
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow`` in ``/p/app/projects/NEPTUNE/spack-stack/ecflow-5.8.4``.
+
+.. code-block:: console
+
+   module purge
+
+   module load slurm
+   module load amd/aocc/4.0.0
+   module load amd/aocl/aocc/4.0
+
+mysql
+  ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31``.
+
 .. _MaintainersSection_Casper:
 
 ------------------------------

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -25,6 +25,10 @@ Ready-to-use spack-stack 1.3.0 installations are available on the following, ful
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NAVY HPCMP Narwhal GNU                                     | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.3.0/envs/unified-env-gcc-10.3.0``                        |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
+| NAVY HPCMP Nautilus Intel                                  | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-add-nautilus/envs/jedi-fv3-intel-2021.5.0/``(temporary)    |
++------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
+| NAVY HPCMP Nautilus AMD clang/flang                        | Dom Heinzeller / ???          | ``WORK IN PROGRESS``                                                                                         |
++------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NCAR-Wyoming Casper Intel                                  | Dom Heinzeller / ???          | ``/glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.3.0-casper/envs/unified-env``                      |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NCAR-Wyoming Cheyenne Intel/GNU                            | Cam Book / Dom Heinzeller     | ``/glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.3.0/envs/unified-env``                             |
@@ -300,6 +304,49 @@ For ``spack-stack-1.3.0`` with GNU, load the following modules after loading the
    module load stack-gcc/10.3.0
    module load stack-cray-mpich/8.1.14
    module load stack-python/3.9.7
+
+.. _Preconfigured_Sites_Nautilus:
+
+------------------------------
+NAVY HPCMP Nautilus
+------------------------------
+
+With Intel, the following is required for building new spack environments and for using spack to build and run software.
+
+.. code-block:: console
+
+   module purge
+
+   module load slurm
+   module load intel/compiler/2022.0.2
+   module load intel/mpi/2021.5.1
+
+   module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
+   module load ecflow/5.8.4
+   module load mysql/8.0.31
+
+With AMD clang/flang (aocc), the following is required for building new spack environments and for using spack to build and run software.
+
+.. code-block:: console
+
+   module purge
+
+   module load slurm
+   module load amd/aocc/4.0.0
+   module load amd/aocl/aocc/4.0
+   module load penguin/openmpi/4.1.4/aocc
+
+   module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
+   module load ecflow/5.8.4
+   module load mysql/8.0.31
+
+.. note::
+
+   There are still problems launching the ecflow GUI, although the package is installed.
+
+.. note::
+
+   spack-stack is not yet officially supported on Nautilus. Test installations for a limited set of packages are in ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-add-nautilus/envs/jedi-fv3-intel-2021.5.0/`` and ``WORK IN PROGRESS``, respectively.
 
 .. _Preconfigured_Sites_Casper:
 


### PR DESCRIPTION
## Description

Add configuration for Navy's Nautilus HPC. This PR adds a first config for Nautilus that was only tested with the Intel compiler. The configuration with AMD's compilers (`aocc = clang/flang`) is there, but it hasn't been tested yet.

Similar to Narwhal / Gaea, building spack environments depends on the modules that are loaded in the user shell. This should not be the case, because Nautilus is a Penguin linux system. I am working with the spack developers to figure out why that is, but until then it is fine to simply build separate environments for different compilers.

The PR also contains two tiny last-minute bug fixes for Gaea C4 and Hercules, and remove jedi-tools from skylab-dev template (not needed to build skylab).

## Definition of Done

- [x] spack-stack build for limited set of packages with Intel (`jedi-fv3-env`, `soca-env`, `ewok-env`)

### Issue(s) addressed

Closes #562 
Closes https://github.com/JCSDA/spack-stack/issues/584 (tested on Hercules)

## Dependencies

None

## Impact

This PR only updates the Nautilus site config and contains two last-minute bug fixes for the Gaea and Neptune site configs. This does not affect any other site or spack-stack in any other way. This PR can be merged anytime without waiting for other PRs or CI tests.
