### PR TITLE
Get rid of ubuntu 22.04 lmod install instructions in `NewSiteConfigs.rst`

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -217,9 +217,11 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 7. Set default compiler and MPI library (make sure to use the correct ``apple-clang`` version for your system and the desired ``openmpi`` version)
 
 .. code-block:: console
-
-   spack config add "packages:all:providers:mpi:[openmpi@4.1.4]"
-   spack config add "packages:all:compiler:[apple-clang@13.1.6]"
+   # Check your clang version then add it to your site compiler config.
+   clang --version
+   spack config add "packages:all:compiler:[apple-clang@YOUR-VERSION]"
+   spack config add "packages:all:providers:mpi:[openmpi@4.1.5]"
+   
 
 8. If applicable (depends on the environment), edit the main config file for the environment and adjust the compiler matrix to match the compilers for macOS, as above:
 
@@ -434,7 +436,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 7. Set default compiler and MPI library (make sure to use the correct ``gcc`` version for your system and the desired ``openmpi`` version)
 
 .. code-block:: console
-   # Check your gcc site's GCC version then add it to your site compiler config.
+   # Check your gcc version then add it to your site compiler config.
    gcc --version
    spack config add "packages:all:compiler:[gcc@YOUR-VERSION]"
    

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -434,14 +434,15 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 7. Set default compiler and MPI library (make sure to use the correct ``gcc`` version for your system and the desired ``openmpi`` version)
 
 .. code-block:: console
-   GCC_VERSION="$(gcc --version | grep -o -m1 -P "\d{1,2}\.\d{1,2}\.\d{1,2}$")"
-   spack config add "packages:all:compiler:[gcc@${GCC_VERSION}]"
+   # Check your gcc site's GCC version then add it to your site compiler config.
+   gcc --version
+   spack config add "packages:all:compiler:[gcc@YOUR-VERSION]"
    
    # Example for Red Hat 8 following the above instructions
-   spack config add "packages:all:providers:mpi:[openmpi@4.1.4]"
+   spack config add "packages:all:providers:mpi:[openmpi@4.1.5]"
    
    # Example for Ubuntu 20.04 or 22.04 following the above instructions
-   spack config add "packages:all:providers:mpi:[mpich@4.0.2]"
+   spack config add "packages:all:providers:mpi:[mpich@4.1.1]"
 
 8. If you have manually installed lmod, you will need to update the site module configuration to use lmod instead of tcl. Skip this step if you followed the Ubuntu or Red Hat instructions above.
 


### PR DESCRIPTION
Update (and simplify) ubuntu setup instructions to use tcl modules. The current 22.04 ubuntu lmod is incompatible with spack-generated modules. This is being tracked in issue #593 

Since the only difference between 22.04 and 20.04 was the use of lmod, I've combined the ubuntu instructions.
