### PR TITLE
release/1.4.0: bug fix for clang-mpich container recipe

### DIFF
--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -200,6 +200,7 @@ spack:
         #Set environment variables for installing tzdata
         ENV DEBIAN_FRONTEND=noninteractive
         ENV TZ=Etc/UTC
+        ENV MPICH_VERSION=4.1.1
         ENV CC=clang
         ENV CXX=clang++
         ENV FC=gfortran
@@ -215,6 +216,7 @@ spack:
         cd /usr/lib/llvm-10/lib && \
         ln -svf libc++abi.so.1.0 libc++abi.so
         # Copy spack find output from builder
+        ENV MPICH_VERSION=4.1.1
         COPY --from=builder /root/spack_find.out /root/spack_find.out
         # Copy mpich-${MPICH_VERSION} installation from builder
         COPY --from=builder /opt/mpich-${MPICH_VERSION} /opt/mpich-${MPICH_VERSION}


### PR DESCRIPTION
## Description

I mistakenly removed the environment variable `MPICH_VERSION` that needs to be set in each of the step in the extra instructions. This fixes it.

## Definition of Done

Container builds - tested successfully.

### Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a