### PR TITLE
Use wgrib2@3.1.1 on Nautilus

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -272,7 +272,7 @@
       version: [2.4.1]
     wget:
       version: [1.21.2]
-    # When changing wgrib2, also check Hercules site config
+    # When changing wgrib2, also check Hercules and Nautilus site configs
     wgrib2:
       version: [2.0.8]
     wrf-io:

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -18,6 +18,11 @@ packages:
     - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
       prefix: /p/app/penguin/openmpi/4.1.4/aoc
 
+### Modifications of common packages
+  # Version 2.0.8 doesn't compile on Nautilus
+  wgrib2:
+    version:: [3.1.1]
+
 ### All other external packages listed alphabetically
   autoconf:
     externals:


### PR DESCRIPTION
## Description

Same as for Hercules, wgrib2@2.0.8 doesn't build on Nautilus (seems to be a common pattern on the newest systems with the newest Intel compilers).

## Definition of Done

Already tested/installed on Nautilus

### Issue(s) addressed

n/a

## Dependencies

n/a