### PR TITLE
Bugfix/conflict intel hdf5 fortran

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,12 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  # to be replaced by final tag
-  branch = release/1.4.0
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  ## to be replaced by final tag
+  #branch = release/1.4.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/conflict_intel_hdf5_fortran
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,10 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  ## to be replaced by final tag
-  #branch = release/1.4.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/conflict_intel_hdf5_fortran
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  # to be replaced by final tag
+  branch = release/1.4.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -97,7 +97,7 @@
       version: [4.2.15]
       variants: ~fortran ~netcdf
     hdf5:
-      version: [1.14.1-2]
+      version: [1.14.0]
       variants: +hl +fortran +mpi ~threadsafe +szip
     ip:
       version: [3.3.3]


### PR DESCRIPTION
## Description

Use hdf5@1.14.0 instead of 1.14.1-2 because of https://github.com/spack/spack/issues/37955.

## Issue(s) addressed

Related to https://github.com/spack/spack/issues/37955

## Dependencies

Waiting on https://github.com/JCSDA/spack/pull/276

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- *no* I have run the unit tests before creating the PR - this will be part of the next PR that updates site config documentation for release/1.4.0
