### PR TITLE
Change dummy versions in skylab-dev template

### DIFF
--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -8,13 +8,13 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
-      - ewok-env@unified-dev
-      - jedi-fv3-env@unified-dev
-      - jedi-mpas-env@unified-dev
-      - jedi-neptune-env@unified-dev
-      - jedi-ufs-env@unified-dev
-      - jedi-um-env@unified-dev
-      - soca-env@unified-dev
+      - ewok-env@skylab-dev
+      - jedi-fv3-env@skylab-dev
+      - jedi-mpas-env@skylab-dev
+      - jedi-neptune-env@skylab-dev
+      - jedi-ufs-env@skylab-dev
+      - jedi-um-env@skylab-dev
+      - soca-env@skylab-dev
 
   specs:
     - matrix:


### PR DESCRIPTION
## Description

Change dummy versions in skylab-dev template from unified-dev to skylab-dev to avoid confusion. This is for develop.

It was mentioned that it is confusing to build the skylab-dev template and then load `jedi-fv3-env/unified-dev` for example.

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

n/a