### PR TITLE
Sync .gitmodules with jcsda/jcsda_emc_spack_stack hash commit.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-1.4.0
-  url = https://github.com/climbfuji/spack
-  branch = feature/merge_rel140_to_jcsda_emc_spack_stack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
## Description

This PR syncs up .gitmodule file as a result of merging https://github.com/JCSDA/spack/pull/277 and https://github.com/JCSDA/spack-stack/pull/613.

## Issue(s) addressed

## Dependencies

None

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
