### PR TITLE
Add util to show duplicate pkgs in a spack env

### DIFF
--- a/util/show_duplicate_packages.py
+++ b/util/show_duplicate_packages.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Check output of `spack concretize` for duplicate packages.
+# Usage:
+#   show_duplicate_packages.py log.concretize
+#    -OR-
+#   spack concretize | tee log.concretize | show_duplicate_packages.py > list_of_duplicates.txt
+#
+# '-d' argument prints only duplicates (and disables highlighting).
+#
+# Alex Richert, June 2023
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+
+def colorize_spec(line, package_name, colorize=False):
+    if not colorize: return line
+    c1 = r'\033[93m' ; c2 = r'\033[0m'
+    return re.sub("(\w{7}\s+)(%s)@"%package_name, f"\\1{c1}\\2{c2}@", line)
+
+def show_duplicate_packages(txt_to_check, only_show_dups=False):
+    dd = defaultdict(set)
+    for line in txt_to_check.split("\n"):
+        line = line.replace("^", "")
+        package_name = re.findall("\s\w{7}\s+(\^?[^\s@]+)@", line)
+        if not package_name: continue
+        line = "  ".join(line.split()[1:])
+        dd[package_name[0]].add(line)
+    duplicates_found = False
+    for key in sorted(dd.keys()):
+        multiple = len(dd[key])>1
+        if only_show_dups and not multiple: continue
+        if only_show_dups: colorize = False
+        else: colorize = multiple
+        if multiple: duplicates_found = True
+        for line in dd[key]:
+            print(colorize_spec(line, key, colorize=colorize))
+    sys.stderr.write("===\n%suplicates found%s\n" % (("D","!") if duplicates_found else ("No d",".")))
+    sys.stderr.flush()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check output of `spack concretize` for duplicate packages")
+    if sys.stdin.isatty():
+        parser.add_argument("filename")
+    parser.add_argument("-d", action="store_true")
+    args = parser.parse_args()
+    if sys.stdin.isatty():
+        with open(args.filename, "r") as f:
+            txt_to_check = f.read()
+    else:
+        txt_to_check = sys.stdin.read()
+    show_duplicate_packages(txt_to_check, only_show_dups=args.d)


### PR DESCRIPTION
## Description

This PR adds a script that checks the output of `spack concretize` for duplicate packages (as well as a 'util/' subdirectory in spack-stack, anticipating we'll want to put other miscellaneous helper scripts, etc. there).

## Issue(s) addressed

Helps with #616

## Checklist

- [x] I have performed a self-review of my own code