### PR TITLE
Acorn update jun2023

### DIFF
--- a/configs/sites/acorn/compilers.yaml
+++ b/configs/sites/acorn/compilers.yaml
@@ -12,6 +12,7 @@ compilers:
     - PrgEnv-intel/8.3.3
     - craype/2.7.13
     - intel/19.1.3.304
+    - libfabric
     environment:
       set:
         # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 
@@ -32,6 +33,7 @@ compilers:
     - PrgEnv-gnu/8.3.3
     - craype/2.7.13
     - gcc/11.2.0
+    - libfabric
     environment:
       set:
         # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -58,5 +58,7 @@
       version: [1.3.5]
     gdal:
       variants: ~curl
-    py-scipy:
-      version: [1.8.1]
+    flex:
+      externals:
+      - spec: flex@2.6.4+lex
+        prefix: /usr

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -36,7 +36,7 @@ Ready-to-use spack-stack 1.4.0 installations are available on the following, ful
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA Parallel Works (AWS, Azure, Gcloud) Intel             | Mark Potts / Cam Book         | ``/contrib/EPIC/spack-stack/spack-stack-1.3.0/envs/unified-env``                                             |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA Acorn Intel                                           | Hang Lei / Alex Richert       | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.3.0/envs/unified-env``                              |
+| NOAA Acorn Intel                                           | Hang Lei / Alex Richert       | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.0/envs/unified-env``                              |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA RDHPCS Gaea C4 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.0-c4/envs/unified-env``                   |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -381,6 +381,8 @@ When installing an official `spack-stack` on Acorn, be mindful of umask and grou
 Due to a combined quirk of Cray and Spack, the ``PrgEnv-gnu`` and ``gcc`` modules must be loaded when `ESMF` is being installed with `GCC`.
 
 As of spring 2023, there is an inconsistency in `libstdc++` versions on Acorn between the login and compute nodes. It is advisable to compile on the compute nodes, which requires running ``spack fetch`` prior to installing through a batch job.
+
+Note that certain packages, such as recent versions of `py-scipy`, cannot be compiled on compute nodes because their build systems require internet access.
 
 .. note::
    System-wide ``spack`` software installations are maintained by NCO on this platform. The spack-stack official installations use those installations for some dependencies.


### PR DESCRIPTION
This PR updates Acorn configuration following the 1.4.0 installation.
- The Cray compilers are, strangely, using MPI even in instances where it doesn't seem to be needed, leading to compilation failures when libfabric can't be found. For now, adding libfabric to the list of modules in compilers.yaml resolves this.
- Adding the external 'flex' library resolved an issue of duplicate packages.
- The py-scipy version setting wasn't being respected but the more recent version managed to compile anyway, so I removed that setting.