### PR TITLE
Update FMS & SCOTCH defaults

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = ufs_jun2023
+  url = https://github.com/jcsda/spack
+  branch = release/1.4.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,5 @@
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules
   branch = develop
+[submodule "spack/"]
+	branch = release/1.4.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-1.4.0
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = ufs_jun2023
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,3 @@
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules
   branch = develop
-[submodule "spack/"]
-	branch = release/1.4.1

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -246,6 +246,7 @@
       version: [5.15.3]
     scotch:
       version: [7.0.3]
+      variants: +mpi+metis~shared~threads~mpi_thread+noarch
     sfcio:
       version: [1.4.1]
     shumlib:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@
       version: [1.1.0]
     fms:
       version: [2023.01]
-      variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS
+      variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
     g2:
       version: [3.4.5]
     g2c:


### PR DESCRIPTION
This PR updates default specs for fms and scotch in order to support UFS WM.