### PR TITLE
Update Acorn config and include bufr@12.0.0 for 1.4.1

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -20,7 +20,7 @@
       version: [1.78.0]
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
     bufr:
-      version: [11.7.1]
+      version: [12.0.0]
       variants: +python
     # Newer versions of CDO require the C++-17 standard, which doesn't
     # work with all compilers that are currently in use in spack-stack

--- a/configs/sites/acorn/compilers.yaml
+++ b/configs/sites/acorn/compilers.yaml
@@ -12,6 +12,7 @@ compilers:
     - PrgEnv-intel/8.3.3
     - craype/2.7.13
     - intel/19.1.3.304
+    - libfabric
     environment:
       set:
         # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 
@@ -32,6 +33,7 @@ compilers:
     - PrgEnv-gnu/8.3.3
     - craype/2.7.13
     - gcc/11.2.0
+    - libfabric
     environment:
       set:
         # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so 

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -58,5 +58,7 @@
       version: [1.3.5]
     gdal:
       variants: ~curl
-    py-scipy:
-      version: [1.8.1]
+    flex:
+      externals:
+      - spec: flex@2.6.4+lex
+        prefix: /usr


### PR DESCRIPTION
Might as well include updates made post-1.4.0 installation to facilitate Acorn installation.

Also, update bufr default to 12.0.0.