### PR TITLE
 Updates for MAPL, GFE packages in spack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/GMAO-SI-Team/spack
+  branch = feature/mathomp4/update-mapl
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/GMAO-SI-Team/spack
-  branch = feature/mathomp4/update-mapl
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
## Description

Currently, this PR only updates the submodule pointer for spack to include and test the updates from https://github.com/JCSDA/spack/pull/241. No version changes as part of this PR.

## Issue(s) addressed

@mathomp4 Do you know if this update resolves any of the open issues in spack-stack?

## Dependencies

List the other PRs that this PR is dependent on:
- [x] waiting on https://github.com/JCSDA/spack/pull/241

## Impact

Expected impact on downstream repositories: possibly JEDI and UFS - need to test

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
