### PR TITLE
Switch Nautilus to use Intel + OpenMPI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/jedi_neptune_env_update_20230628
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/jedi_neptune_env_update_20230628
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -33,7 +33,8 @@ compilers:
       prepend_path:
         PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
         CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
-        LD_LIBRARY_PATH: '/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
-      set:
-        I_MPI_ROOT: '/p/app/compilers/intel/oneapi/mpi/2021.5.1'
+        LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
+      # For intel-oneapi-mpi only
+      #set:
+      #  I_MPI_ROOT: '/p/app/compilers/intel/oneapi/mpi/2021.5.1'
     extra_rpaths: []

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -3,6 +3,8 @@ packages:
     compiler:: [intel@2021.5.0, aocc@4.0.0]
     providers:
       mpi:: [openmpi@4.1.5, openmpi@4.1.4]
+      blas:: [intel-oneapi-mkl]
+      lapack:: [intel-oneapi-mkl]
 
 ### MPI, Python, MKL
   mpi:
@@ -21,6 +23,12 @@ packages:
       - penguin/openmpi/4.1.5rc2/intel
     - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
       prefix: /p/app/penguin/openmpi/4.1.4/aoc
+  intel-oneapi-mkl:
+    externals:
+    - spec: intel-oneapi-mkl@2022.0.2
+      prefix: /p/app/compilers/intel/oneapi/mkl/2022.0.2
+      modules:
+      - intel-oneapi-mkl@2022.0.2
 
 ### Modifications of common packages
   # Version 2.0.8 doesn't compile on Nautilus

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -7,6 +7,7 @@ packages:
       mpi:: [openmpi@4.1.5rc2]
       #mpi:: [openmpi@4.1.4]
       blas:: [intel-oneapi-mkl]
+      fftw-api:: [intel-oneapi-mkl]
       lapack:: [intel-oneapi-mkl]
   ectrans:
     variants:: +mkl

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -2,19 +2,23 @@ packages:
   all:
     compiler:: [intel@2021.5.0, aocc@4.0.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.4]
+      mpi:: [openmpi@4.1.5, openmpi@4.1.4]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
-  intel-oneapi-mpi:
-    externals:
-    - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
-      modules:
-      - intel/mpi/2021.5.1
-      prefix: /p/app/compilers/intel/oneapi
+  #intel-oneapi-mpi:
+  #  externals:
+  #  - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
+  #    modules:
+  #    - intel/mpi/2021.5.1
+  #    prefix: /p/app/compilers/intel/oneapi
   openmpi:
     externals:
+    - spec: openmpi@4.1.5rc2%intel@2021.5.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+      prefix: /p/app/penguin/openmpi/4.1.5rc2/intel
+      modules:
+      - penguin/openmpi/4.1.5rc2/intel
     - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
       prefix: /p/app/penguin/openmpi/4.1.4/aoc
 

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -2,9 +2,16 @@ packages:
   all:
     compiler:: [intel@2021.5.0, aocc@4.0.0]
     providers:
-      mpi:: [openmpi@4.1.5, openmpi@4.1.4]
+      # For now need to enable one or the other;
+      # see https://github.com/JCSDA/spack-stack/issues/659
+      mpi:: [openmpi@4.1.5rc2]
+      #mpi:: [openmpi@4.1.4]
       blas:: [intel-oneapi-mkl]
       lapack:: [intel-oneapi-mkl]
+  ectrans:
+    variants:: +mkl
+  gsibec:
+    variants:: +mkl
 
 ### MPI, Python, MKL
   mpi:
@@ -21,12 +28,16 @@ packages:
       prefix: /p/app/penguin/openmpi/4.1.5rc2/intel
       modules:
       - penguin/openmpi/4.1.5rc2/intel
+      - slurm
     - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
       prefix: /p/app/penguin/openmpi/4.1.4/aoc
+      modules:
+      - penguin/openmpi/4.1.4/aocc
+      - slurm
   intel-oneapi-mkl:
     externals:
     - spec: intel-oneapi-mkl@2022.0.2
-      prefix: /p/app/compilers/intel/oneapi/mkl/2022.0.2
+      prefix: /p/app/compilers/intel/oneapi
       modules:
       - intel-oneapi-mkl@2022.0.2
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -30,7 +30,7 @@ Ready-to-use spack-stack 1.4.0 installations are available on the following, ful
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NAVY HPCMP Narwhal GNU^**                                  | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-gcc-10.3.0``                        |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NAVY HPCMP Nautilus Intel^*                                | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.5.0-hdf5-1.14.0``        |
+| NAVY HPCMP Nautilus Intel^*                                | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.5.0-openmpi-4.1.5``      |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NAVY HPCMP Nautilus AMD clang/flang                        | Dom Heinzeller / ???          | **currently not supported**                                                                                  |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -255,10 +255,9 @@ With Intel, the following is required for building new spack environments and fo
 .. code-block:: console
 
    module purge
-
    module load slurm
    module load intel/compiler/2022.0.2
-   module load intel/mpi/2021.5.1
+   module load penguin/openmpi/4.1.5rc2/intel
 
    module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
    module load ecflow/5.8.4
@@ -268,9 +267,9 @@ For ``spack-stack-1.4.0`` with Intel, load the following modules after loading t
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.5.0-hdf5-1.14.0/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.5.0-openmpi-4.1.5/install/modulefiles/Core
    module load stack-intel/2021.5.0
-   module load stack-intel-oneapi-mpi/2021.5.1
+   module load stack-openmpi/4.1.5rc2
    module load stack-python/3.10.8
 
 With AMD clang/flang (aocc), the following is required for building new spack environments and for using spack to build and run software.

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -188,6 +188,7 @@ With Intel, the following is required for building new spack environments and fo
 
 .. code-block:: console
 
+   umask 0022
    module unload PrgEnv-cray
    module load PrgEnv-intel/8.3.2
    module unload intel
@@ -216,6 +217,7 @@ With GNU, the following is required for building new spack environments and for 
 
 .. code-block:: console
 
+   umask 0022
    module unload PrgEnv-cray
    module load PrgEnv-gnu/8.3.2
    module unload gcc
@@ -254,7 +256,9 @@ With Intel, the following is required for building new spack environments and fo
 
 .. code-block:: console
 
+   umask 0022
    module purge
+
    module load slurm
    module load intel/compiler/2022.0.2
    module load penguin/openmpi/4.1.5rc2/intel
@@ -276,6 +280,7 @@ With AMD clang/flang (aocc), the following is required for building new spack en
 
 .. code-block:: console
 
+   umask 0022
    module purge
 
    module load slurm

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -271,7 +271,7 @@ For ``spack-stack-1.4.0`` with Intel, load the following modules after loading t
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.5.0-openmpi-4.1.5/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-dev-20230628/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-openmpi/4.1.5rc2
    module load stack-python/3.10.8


### PR DESCRIPTION
### Summary

This PR switches the Navy Nautilus computer to use OpenMPI instead of Intel-MPI with the Intel compiler. This is to address hanging MPI all-to-all communication as reported briefly in #633.

The PR also switches the providers for `blas` and `lapack` to `intel-oneapi-mkl` instead of `openblas`. This is done in the site config for now, leaving the default as-is (i.e. `openblas`, which means spack-stack does not require any special packages from Intel etc to be downloaded and installed by default). This addresses the issue https://github.com/JCSDA/spack-stack/issues/45.

### Testing

- Compiled and loaded the modules
- Built jedi-bundle and ran ctests, all tests that were expected to pass did pass.
- Will rely on @areinecke and @sking112 for testing with JEDI-Neptune.

### Applications affected

Any environment using spack-stack on Nautilus

### Systems affected

Navy's Nautilus

### Dependencies

Waiting on https://github.com/JCSDA/spack/pull/288

### Issue(s) addressed

Resolves #633
Resolves https://github.com/JCSDA/spack-stack/issues/45

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
