### PR TITLE
Clean up CRTM for JEDI environments (load manually)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/cleanup_crtm
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/cleanup_crtm
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -15,7 +15,9 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     py-gitpython@3.1.27, py-h5py@3.7.0, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
-    yafyaml@0.5.1, zlib@1.2.13, odc@1.4.6, crtm@v2.4.1-jedi, shumlib@macos_clang_linux_intel_port]
+    yafyaml@0.5.1, zlib@1.2.13, odc@1.4.6, shumlib@macos_clang_linux_intel_port]
+    # Don't build CRTM by default so that it gets built in the JEDI bundles:
+    # crtm@v2.4.1-jedi
     # Don't build ESMF and MAPL for now:
     # https://github.com/JCSDA-internal/MPAS-Model/issues/38
     # https://github.com/jcsda/spack-stack/issues/326

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -16,6 +16,10 @@ spack:
       - jedi-um-env@skylab-dev
       - soca-env@skylab-dev
 
+      # Additional crtm tags
+      - crtm@v2.4-jedi.2
+      - crtm@v2.4.1-jedi
+
   specs:
     - matrix:
       - [$packages]

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -25,15 +25,13 @@ spack:
       #- upp-env@unified-dev
       #- ww3-env@unified-dev
 
-      # Additional esmf/mapl tags - don't activate by default, this
-      # can lead to duplicate packages (e.g. in Ubuntu CI tests)
+      # Additional esmf/mapl tags
       #- esmf@8.4.2~debug+external-parallelio
       #- mapl@2.35.2~debug ^esmf@8.4.2~debug+external-parallelio
 
-      # Additional crtm tags - don't activate by default, this
-      # can lead to duplicate packages (e.g. in Ubuntu CI tests)
-      #- crtm@v2.4-jedi.2
-      #- crtm@v3.0.0-rc.1
+      # Additional crtm tags
+      - crtm@v2.4-jedi.2
+      - crtm@v2.4.1-jedi
 
   specs:
     - matrix:


### PR DESCRIPTION
### Summary

Explicitly include CRTM JEDI branches in skylab-dev and unified-dev templates, because PR https://github.com/JCSDA/spack/pull/286 removes it from `jedi-base-env`. The effect of these changes is that users have to manually load the CRTM module provided by spack-stack if they want to use that version. This is needed to avoid confusion with the current strategy of JEDI to build CRTM in the JEDI bundles.

### Testing

- CI: All tests passed, verified that correct CRTM versions get built as part of the stack.

### Applications affected

JEDI

### Systems affected

All systems using JEDI when the next spack-stack version is rolled out.

### Dependencies

- waiting on https://github.com/JCSDA/spack/pull/286

### Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/642

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
