### PR TITLE
Add ncdiag/1.1.1 to the stack

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -91,6 +91,8 @@
       version: [1.2.3]
     gsibec:
       version: [1.1.2]
+    gsi-ncdiag:
+      version: [1.1.1]
     gsl-lite:
       version: [0.37.0]
     hdf:

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -53,6 +53,6 @@ spack:
   - wgrib2@2.0.8
   - wrf-io@1.2.0
   - ncio@1.1.2
-  - gsi-ncdiag@1.0.0
+  - gsi-ncdiag@1.1.1
   - met@10.1.0
   - metplus@4.1.0


### PR DESCRIPTION
### Summary

Update the spack hash to include the recently added ncdiag (version 1.1.1) library and include the library in the development UFS SRW template.

### Testing

Built a test environment on S4.

### Applications affected

GSI

### Systems affected

All

### Dependencies

Already merged: noaa-emc/gsi-ncdiag#4 and jcsda/spack#285.
### Issue(s) addressed

#651

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
