### PR TITLE
Dup check update

### DIFF
--- a/util/show_duplicate_packages.py
+++ b/util/show_duplicate_packages.py
@@ -45,9 +45,9 @@ def show_duplicate_packages(txt_to_check, ignore_list=[], only_show_dups=False):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check output of `spack concretize` for duplicate packages")
-    parser.add_argument("filename", nargs="?")
-    parser.add_argument("-d", action="store_true")
-    parser.add_argument("-i", nargs="*", action="append")
+    parser.add_argument("filename", nargs="?", help="'log.concretize' or other concretization output; if not set, stdin will be used")
+    parser.add_argument("-d", action="store_true", help="Only show duplicates (default output is colorized list of all packages)")
+    parser.add_argument("-i", nargs="*", action="append", help="Ignore package name (e.g., 'hdf5', 'netcdf-c')")
     args = parser.parse_args()
     if args.filename:
         with open(args.filename, "r") as f:

--- a/util/show_duplicate_packages.py
+++ b/util/show_duplicate_packages.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check output of `spack concretize` for duplicate packages")
     parser.add_argument("filename", nargs="?", help="'log.concretize' or other concretization output; if not set, stdin will be used")
     parser.add_argument("-d", action="store_true", help="Only show duplicates (default output is colorized list of all packages)")
-    parser.add_argument("-i", nargs="*", action="append", help="Ignore package name (e.g., 'hdf5', 'netcdf-c')")
+    parser.add_argument("-i", default=[], nargs="*", action="append", help="Ignore package name (e.g., 'hdf5', 'netcdf-c')")
     args = parser.parse_args()
     if args.filename:
         with open(args.filename, "r") as f:


### PR DESCRIPTION
### Summary

This PR fixes a bug in show_duplicate_packages.py that causes it to fail when `-i` is not used. It also adds help descriptions for the command line arguments.

### Testing

Tested on personal computer.

### Applications affected

n/a

### Systems affected

none

### Dependencies

none

### Issue(s) addressed

Fixes #654

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications. (mark complete once show_duplicate_packages.py completes successfully in the CIs)
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
