### PR TITLE
Update default nemsio to 2.5.4

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -196,7 +196,7 @@ modules:
         environment:
           set:
             'NEMSIO_INC': '{prefix}/include'
-            'NEMSIO_LIB': '{prefix}/lib'
+            'NEMSIO_LIB': '{prefix}/lib64'
             'MKGFSNEMSIOCTL': '{prefix}/mkgfsnemsioctl'
             'NEMSIO_CHGDATE': '{prefix}/bin/nemsio_chgdate'
             'NEMSIO_GET': '{prefix}/bin/nemsio_get'
@@ -441,7 +441,7 @@ modules:
         environment:
           set:
             'NEMSIO_INC': '{prefix}/include'
-            'NEMSIO_LIB': '{prefix}/lib'
+            'NEMSIO_LIB': '{prefix}/lib64'
             'MKGFSNEMSIOCTL': '{prefix}/mkgfsnemsioctl'
             'NEMSIO_CHGDATE': '{prefix}/bin/nemsio_chgdate'
             'NEMSIO_GET': '{prefix}/bin/nemsio_get'

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -196,7 +196,7 @@ modules:
         environment:
           set:
             'NEMSIO_INC': '{prefix}/include'
-            'NEMSIO_LIB': '{prefix}/lib64'
+            'NEMSIO_LIB': '{prefix}/lib64/libnemsio.a'
             'MKGFSNEMSIOCTL': '{prefix}/mkgfsnemsioctl'
             'NEMSIO_CHGDATE': '{prefix}/bin/nemsio_chgdate'
             'NEMSIO_GET': '{prefix}/bin/nemsio_get'
@@ -441,7 +441,7 @@ modules:
         environment:
           set:
             'NEMSIO_INC': '{prefix}/include'
-            'NEMSIO_LIB': '{prefix}/lib64'
+            'NEMSIO_LIB': '{prefix}/lib64/libnemsio.a'
             'MKGFSNEMSIOCTL': '{prefix}/mkgfsnemsioctl'
             'NEMSIO_CHGDATE': '{prefix}/bin/nemsio_chgdate'
             'NEMSIO_GET': '{prefix}/bin/nemsio_get'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -136,7 +136,7 @@
     # ncview - when adding information here, also check Orion
     # and Discover site configs
     nemsio:
-      version: [2.5.2]
+      version: [2.5.4]
     nemsiogfs:
       version: [2.5.3]
     nccmp:


### PR DESCRIPTION
### Summary

Update nemsio to 2.5.4, which eliminates w3nco dependency, and is already used by most applications that use nemsio.

### Testing

GLDAS compiles successfully.

### Applications affected

GLDAS (other applications that use nemsio already use 2.5.4).

### Systems affected

n/a

### Dependencies
none

### Issue(s) addressed
Fixes #664

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
