### PR TITLE
Final updates (documentation, site configs, ...) for spack-stack-1.4.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   #url = https://github.com/spack/spack
   #branch = develop
   url = https://github.com/jcsda/spack
-  branch = release/1.4.1
+  branch = spack-stack-1.4.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -25,7 +25,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     # py-mysql-connector-python@8.0.32
 ```
 
-### spack-stack-1.4.1 / ufs-weather-model-x.y.z containers for ufs-weather-model as of May 18, 2023
+### spack-stack-1.4.1 / ufs-weather-model-x.y.z containers for ufs-weather-model as of July 5, 2023
 
 **Note. This is not yet working correctly, some libraries are missing. Please do not use yet! Also, if using the clang-mpich container, need to disable openmp for fms, not clear how to do this cleanly.**
 

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -105,7 +105,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/jcsda/spack
-        ref: spack-stack-1.4.0
+        ref: spack-stack-1.4.1
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -92,7 +92,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/jcsda/spack
-        ref: spack-stack-1.4.0
+        ref: spack-stack-1.4.1
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -110,7 +110,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/jcsda/spack
-        ref: spack-stack-1.4.0
+        ref: spack-stack-1.4.1
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -80,7 +80,7 @@ packages:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/ecflow-5.8.4-c5
+      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/ecflow-5.8.4
       modules: [ecflow/5.8.4]
   file:
     externals:
@@ -174,7 +174,7 @@ packages:
     buildable: False
     externals:
     - spec: mysql@8.0.31
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/mysql-8.0.31-c5
+      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/mysql-8.0.31
       modules: [mysql/8.0.31]
   ncurses:
     externals:
@@ -204,7 +204,7 @@ packages:
   qt:
     externals:
     - spec: qt@5.15.2
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/qt-5.15.2-c5/5.15.2/gcc_64
+      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/qt-5.15.2/5.15.2/gcc_64
   rdma-core:
     externals:
     - spec: rdma-core@37.0

--- a/configs/sites/hercules/compilers.yaml
+++ b/configs/sites/hercules/compilers.yaml
@@ -34,17 +34,15 @@ compilers:
 #    environment: {}
 #    extra_rpaths: []
 - compiler:
-    spec: gcc@12.2.0
+    spec: gcc@11.3.1
     paths:
-      cc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gcc
-      cxx: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/g++
-      f77: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
-      fc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
     flags: {}
     operating_system: rocky9
     target: x86_64
-    modules:
-    - contrib/0.1
-    - noaa-gcc/12.2.0
+    modules: []
     environment: {}
     extra_rpaths: []

--- a/configs/sites/hercules/compilers.yaml
+++ b/configs/sites/hercules/compilers.yaml
@@ -34,15 +34,17 @@ compilers:
 #    environment: {}
 #    extra_rpaths: []
 - compiler:
-    spec: gcc@11.3.1
+    spec: gcc@12.2.0
     paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
+      cc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gcc
+      cxx: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/g++
+      f77: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+      fc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
     flags: {}
     operating_system: rocky9
     target: x86_64
     modules: []
+    - contrib/0.1
+    - noaa-gcc/12.2.0
     environment: {}
     extra_rpaths: []

--- a/configs/sites/hercules/compilers.yaml
+++ b/configs/sites/hercules/compilers.yaml
@@ -43,7 +43,7 @@ compilers:
     flags: {}
     operating_system: rocky9
     target: x86_64
-    modules: []
+    modules:
     - contrib/0.1
     - noaa-gcc/12.2.0
     environment: {}

--- a/configs/sites/hercules/mirrors.yaml
+++ b/configs/sites/hercules/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///work/noaa/da/role-da/spack-stack/source-cache
+      url: file:///work/noaa/epic/role-epic/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///work/noaa/da/role-da/spack-stack/source-cache
+      url: file:///work/noaa/epic/role-epic/spack-stack/source-cache
       access_pair:
       - null
       - null

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -3,7 +3,7 @@ packages:
     compiler:: [intel@2021.7.1, gcc@12.2.0]
     #compiler:: [oneapi@2022.2.1]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.7.1, openmpi@4.1.4]
+      mpi:: [intel-oneapi-mpi@2021.7.1, openmpi@4.1.5]
 
 ### MPI, Python, MKL
   mpi:
@@ -20,15 +20,11 @@ packages:
     #  - intel-oneapi-mpi/2021.7.1
   openmpi:
     externals:
-    - spec: openmpi@4.1.4%gcc@12.2.0 ~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
+    - spec: openmpi@4.1.5%gcc@11.3.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
         fabrics=ucx schedulers=slurm
-      prefix: /apps/spack-managed/gcc-12.2.0/openmpi-4.1.4-vkwtvxdep4xawgt5vt5ldkoadvahvowt
+      prefix: /work/noaa/epic/role-epic/spack-stack/hercules/openmpi-4.1.5/gcc-11.3.1
       modules:
-      - contrib/0.1
-      - noaa-gcc/12.2.0
-      - slurm/22.05.8
-      - ucx/1.13.1
-      - openmpi/4.1.4
+      - openmpi/4.1.5
   python:
     buildable: False
     externals:
@@ -168,3 +164,10 @@ packages:
     externals:
     - spec: wget@1.21.1
       prefix: /usr
+  # Need to use external zlib, because of qt dependence on it (otherwise issues with tar command)
+  zlib:
+    externals:
+    - spec: zlib@1.2.13
+      prefix: /apps/spack-managed/gcc-11.3.1/zlib-1.2.13-ltp4c3zzde3zi3gf7x4b7c7nj5ww4i4g
+      modules:
+      - zlib/1.2.13

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -74,9 +74,9 @@ packages:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /work/noaa/epic-ps/role-epic-ps/spack-stack/ecflow-5.8.4-hercules
+      prefix: /work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4
       modules:
-      - ecflow/5.8.4-hercules
+      - ecflow/5.8.4
   findutils:
     externals:
     - spec: findutils@4.8.0
@@ -119,9 +119,9 @@ packages:
     buildable: False
     externals:
     - spec: mysql@8.0.31
-      prefix: /work/noaa/epic-ps/role-epic-ps/spack-stack/mysql-8.0.31-hercules
+      prefix: /work/noaa/epic/role-epic/spack-stack/hercules/mysql-8.0.31
       modules:
-      - mysql/8.0.31-hercules
+      - mysql/8.0.31
   openssh:
     externals:
     - spec: openssh@8.7p1

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [intel@2021.7.1, gcc@11.3.1]
+    compiler:: [intel@2021.7.1, gcc@12.2.0]
     #compiler:: [oneapi@2022.2.1]
     providers:
       mpi:: [intel-oneapi-mpi@2021.7.1, openmpi@4.1.4]
@@ -20,10 +20,14 @@ packages:
     #  - intel-oneapi-mpi/2021.7.1
   openmpi:
     externals:
-    - spec: openmpi@4.1.4%gcc@11.3.1 ~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
+    - spec: openmpi@4.1.4%gcc@12.2.0 ~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
         fabrics=ucx schedulers=slurm
-      prefix: /apps/spack-managed/gcc-11.3.1/openmpi-4.1.4-ruvlmb6yyvzbzbiqaov4zk75ogthczsp
+      prefix: /apps/spack-managed/gcc-12.2.0/openmpi-4.1.4-vkwtvxdep4xawgt5vt5ldkoadvahvowt
       modules:
+      - contrib/0.1
+      - noaa-gcc/12.2.0
+      - slurm/22.05.8
+      - ucx/1.13.1
       - openmpi/4.1.4
   python:
     buildable: False
@@ -144,7 +148,7 @@ packages:
   qt:
     externals:
     - spec: qt@5.15.8
-      prefix: /apps/spack-managed/gcc-11.3.1/qt-5.15.8-d47tsna6f5dylcpblkfgw4gpn2cucihd
+      prefix: /apps/spack-managed/gcc-12.2.0/qt-5.15.8-gayzhaahclvlybiiykwj2cym4vo33w6x
       modules:
       - qt/5.15.8
   subversion:

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [intel@2021.7.1, gcc@12.2.0]
+    compiler:: [intel@2021.7.1, gcc@11.3.1]
     #compiler:: [oneapi@2022.2.1]
     providers:
       mpi:: [intel-oneapi-mpi@2021.7.1, openmpi@4.1.5]

--- a/configs/sites/orion/mirrors.yaml
+++ b/configs/sites/orion/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///work/noaa/da/role-da/spack-stack/source-cache
+      url: file:///work/noaa/epic/role-epic/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///work/noaa/da/role-da/spack-stack/source-cache
+      url: file:///work/noaa/epic/role-epic/spack-stack/source-cache
       access_pair:
       - null
       - null

--- a/doc/modulefile_templates/openmpi
+++ b/doc/modulefile_templates/openmpi
@@ -31,7 +31,7 @@ unsetenv SLURM_EXPORT_ENV
 setenv PSM2_PATH_SELECTION "static_base"
 setenv SLURM_CPU_BIND "none"
 
-# Settings specific for Cheyenne
+# Settings specific for Cheyenne and Hercules
 setenv MPI_ROOT ${OPENMPI_PATH}
 setenv UCX_MAX_RNDV_RAILS "1"
 setenv OMPI_MCA_btl "^openib"

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -63,6 +63,9 @@ Sign into qt, select customized installation, choose qt@5.15.2 only (uncheck all
 .. note::
    On air-gapped systems, the above method may not work (we have not encountered such a system so far).
 
+.. note::
+   If ``./qt-unified-linux-x64-online.run`` fails to start with the error ``qt.qpa.xcb: could not connect to display`` and a role account is being used, follow the procedure described in https://www.thegeekdiary.com/how-to-set-x11-forwarding-export-remote-display-for-users-who-switch-accounts-using-sudo to export the display. A possible warning ``xauth:  file /ncrc/home1/role.epic/.Xauthority does not exist`` can be ignored, since this file gets created by the ``xauth`` command.
+
 ..  _MaintainersSection_ecFlow:
 
 ------------------------------
@@ -243,7 +246,7 @@ MSU Hercules
 ------------------------------
 
 ecflow
-  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library, using an available ``Qt5`` installation. After loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow`` in ``/work/noaa/epic-ps/role-epic-ps/spack-stack/ecflow-5.8.4-hercules``.
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library, using an available ``Qt5`` installation. After loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow`` in ``/work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4``.
 
 .. code-block:: console
 
@@ -252,6 +255,22 @@ ecflow
 
 mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/work/noaa/epic-ps/role-epic-ps/spack-stack/mysql-8.0.31-hercules``.
+
+openmpi
+  need to load qt so to get consistent zlib (or just load zlib directly, check qt module)
+
+.. code-block:: console
+
+   module purge
+   module load zlib/1.2.13
+   module load ucx/1.13.1
+   ./configure \
+       --prefix=/work/noaa/epic/role-epic/spack-stack/hercules/openmpi-4.1.5/gcc-11.3.1  \
+       --with-ucx=$UCX_ROOT \
+       --with-zlib=$ZLIB_ROOT
+   make VERBOSE=1 -j4
+   make check
+   make install
 
 .. _MaintainersSection_Discover:
 
@@ -538,17 +557,8 @@ NOAA RDHPCS Gaea C5
 
 On Gaea C5, ``miniconda``, ``qt``, ``ecflow``, and ``mysql`` need to be installed as a one-off before spack can be used.
 
-miniconda
-   Follow the instructions in :numref:`Section %s <MaintainersSection_Miniconda>` to create a basic ``miniconda`` installation and associated modulefile for working with spack. Don't forget to log off and back on to forget about the conda environment. Use the following workaround to avoid the terminal being spammed by error messages about missing version information (``/usr/bin/lua5.3: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/miniconda-3.9.12-c5/lib/libtinfo.so.6: no version information available (required by /lib64/libreadline.so.7)``):
-
-.. code-block:: console
-
-   cd /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/miniconda-3.9.12-c5/lib
-   mv libtinfow.so.6.3 libtinfow.so.6.3.conda.original
-   ln -sf /lib64/libtinfo.so.6 libtinfow.so.6.3
-
 qt (qt@5)
-   The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to :numref:`Section %s <MaintainersSection_Qt5>` to install ``qt@5.15.2`` in ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/qt-5.15.2-c5``. Note that the installation must be done as a regular user due to problems with graphical applications for role accounts.
+   The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. After loading/unloading the modules as shown below, refer to :numref:`Section %s <MaintainersSection_Qt5>` to install ``qt@5.15.2`` in ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/qt-5.15.2``. :numref:`Section %s <MaintainersSection_Qt5>` describes how to export the X windows environment in order to install ``qt@5`` using the role account.
 
 .. code-block:: console
 
@@ -557,7 +567,7 @@ qt (qt@5)
    module load PrgEnv-gnu/8.3.3
 
 ecflow
-  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `qt5` and loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>`. Because of the dependency on ``miniconda``, that module must be loaded automatically in the ``ecflow`` module (similar to ``qt@5.15.2-c5``).  Ensure to follow the extra instructions in that section for Gaea C5.
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After installing `qt5` and loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>`. Because of the dependency on ``miniconda``, that module must be loaded automatically in the ``ecflow`` module (similar to ``qt@5.15.2-c5``).  Ensure to follow the extra instructions in that section for Gaea C5 in ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/ecflow-5.8.4``.
   
    Ensure to follow the extra instructions in that section for Gaea.
 
@@ -568,11 +578,11 @@ ecflow
    module load PrgEnv-gnu/8.3.3
    module load python/3.9.12
 
-   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/modulefiles-c5
+   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/modulefiles
    module load qt/5.15.2
 
 mysql
-  ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/mysql-8.0.31-c5``.
+  ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/mysql-8.0.31``.
 
 .. _MaintainersSection_Hera:
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -8,57 +8,53 @@ Directory ``configs/sites`` contains site configurations for several HPC systems
 Pre-configured sites are split into two categories: Tier 1 with officially supported spack-stack installations (see :numref:`Section %s <Preconfigured_Sites_Tier1>`), and Tier 2 (sites with configuration files that were tested or contributed by others in the past, but that are not officially supported by the spack-stack team; see :numref:`Section %s <Preconfigured_Sites_Tier2>`).
 
 =============================================================
-Officially supported spack-stack 1.4.0 installations (tier 1)
+Officially supported spack-stack 1.4.1 installations (tier 1)
 =============================================================
 
-Ready-to-use spack-stack 1.4.0 installations are available on the following, fully supported platforms. This version supports the JEDI Skylab release 5 of June 2023, and can be used for testing spack-stack with UFS applications (e.g. the UFS Weather Model, the UFS Short Range Weather Application, and the EMC Global Workflow). Amazon Web Services AMI are available in the US East 1 or 2 regions.
-
-.. note::
-
-   ``spack-stack-1.4.0`` was originally created with ``hdf5@1.14.1-2``. It turned out that there was a problem with the Fortran compiled module files when using Intel compilers to build this version of ``hdf5`` in spack-stack (see https://github.com/spack/spack/issues/37955). We therefore rebuilt ``spack-stack-1.4.0`` with ``hdf5@1.14.0`` on platforms using Intel or Intel+GNU. If those environments already had an installation with ``hdf5@1.14.1-2``, we named the environment with ``hdf5@1.14.0`` either ``unified-env-v2`` or ``unified-env-hdf5-1.14.0``.
+Ready-to-use spack-stack 1.4.1 installations are available on the following, fully supported platforms. This version supports the JEDI Skylab release 5 of June 2023, and the UFS Weather Model of July 2023. It can also be used for testing spack-stack with other UFS applications (e.g. the UFS Short Range Weather Application, and the EMC Global Workflow). Amazon Web Services AMI are available in the US East 1 or 2 regions for the previous 1.4.0 release (1.4.1 is not provided on AWS AMIs).
 
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | System                                                     | Maintainers                   | Location                                                                                                     |
 +============================================================+===============================+==============================================================================================================+
-| MSU Orion Intel/GNU                                        | Cam Book / Dom Heinzeller     | ``/work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0/envs/unified-env-v2``                        |
+| MSU Orion Intel/GNU                                        | Cam Book / Dom Heinzeller     | ``/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                                 |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| MSU Hercules Intel/GNU^*                                   | Cam Book / Dom Heinzeller     | ``/work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2``               |
+| MSU Hercules Intel/GNU^*                                   | Cam Book / Dom Heinzeller     | ``/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env``                        |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NASA Discover Intel/GNU                                    | Dom Heinzeller / ???          | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.0/envs/unified-env-v2``                                    |
+| NASA Discover Intel/GNU                                    | Dom Heinzeller / ???          | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.1/envs/unified-env``                                       |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NAVY HPCMP Narwhal Intel^**                                | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.4.0-hdf5-1.14.0``        |
+| NAVY HPCMP Narwhal Intel^**                                | Dom Heinzeller / ???          | **spack-stack-1.4.1 not supported on this platform, use 1.4.0**``                                            |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NAVY HPCMP Narwhal GNU^**                                  | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-gcc-10.3.0``                        |
+| NAVY HPCMP Narwhal GNU^**                                  | Dom Heinzeller / ???          | **spack-stack-1.4.1 not supported on this platform, use 1.4.0**``                                            |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NAVY HPCMP Nautilus Intel^*                                | Dom Heinzeller / ???          | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.4.0/envs/unified-env-intel-2021.5.0-hdf5-1.14.0``        |
+| NAVY HPCMP Nautilus Intel^*                                | Dom Heinzeller / ???          | **spack-stack-1.4.1 not supported on this platform, use 1.4.0**``                                            |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NAVY HPCMP Nautilus AMD clang/flang                        | Dom Heinzeller / ???          | **currently not supported**                                                                                  |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NCAR-Wyoming Casper Intel                                  | Dom Heinzeller / ???          | ``/glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.4.0-casper/envs/unified-env-v2``                   |
+| NCAR-Wyoming Casper Intel                                  | Dom Heinzeller / ???          | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.4.1/envs/unified-env``                      |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NCAR-Wyoming Cheyenne Intel/GNU                            | Cam Book / Dom Heinzeller     | ``/glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.4.0/envs/unified-env-v2``                          |
+| NCAR-Wyoming Cheyenne Intel/GNU                            | Cam Book / Dom Heinzeller     | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env``                    |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA Parallel Works (AWS, Azure, Gcloud) Intel             | Mark Potts / Cam Book         | **will be added later (on develop)**                                                                         |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA Acorn Intel                                           | Hang Lei / Alex Richert       | **will be added later (on develop)**                                                                         |
+| NOAA Acorn Intel                                           | Hang Lei / Alex Richert       | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.1/envs/unified-env``                              |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Gaea C4 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.0-c4/envs/unified-env-v2``                |
+| NOAA RDHPCS Gaea C4 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.1-c4/envs/unified-env``                   |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Gaea C5 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.0-c5/envs/unified-env-v2``                |
+| NOAA RDHPCS Gaea C5 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.4.1/envs/unified-env``                   |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Hera Intel/GNU                                 | Mark Potts / Dom Heinzeller   | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env-v2``                       |
+| NOAA RDHPCS Hera Intel/GNU                                 | Mark Potts / Dom Heinzeller   | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                          |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Jet Intel/GNU                                  | Cam Book / Dom Heinzeller     | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env-v2``                       |
+| NOAA RDHPCS Jet Intel/GNU                                  | Cam Book / Dom Heinzeller     | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                          |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| UW (Univ. of Wisc.) S4 Intel                               | Dom Heinzeller / Mark Potts   | ``/data/prod/jedi/spack-stack/spack-stack-1.4.0/envs/unified-env-v2``                                        |
+| UW (Univ. of Wisc.) S4 Intel                               | Dom Heinzeller / Mark Potts   | ``/data/prod/jedi/spack-stack/spack-stack-1.4.1/envs/unified-env``                                           |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | UW (Univ. of Wisc.) S4 GNU^**                              | Dom Heinzeller / Mark Potts   | **currently not supported**                                                                                  |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| Amazon Web Services Parallelcluster Ubuntu 20.04 Intel/GNU | Dom Heinzeller / ???          | ``/mnt/experiments-efs/skylab-v5/spack-stack-1.4.0/envs/unified-env-v2``                                     |
+| Amazon Web Services Parallelcluster Ubuntu 20.04 Intel/GNU | Dom Heinzeller / ???          | ``/mnt/experiments-efs/skylab-v5/spack-stack-1.4.1/envs/unified-env``                                        |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Red Hat 8 GNU                      | Dom Heinzeller / ???          | ``/home/ec2-user/spack-stack/spack-stack-1.4.0/envs/unified-env``                                            |
+| Amazon Web Services AMI Red Hat 8 GNU                      | Dom Heinzeller / ???          | **spack-stack-1.4.1 not supported on this platform, use 1.4.0**``                                            |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| Amazon Web Services AMI Ubuntu 20 GNU                      | Dom Heinzeller / ???          | ``/home/ubuntu/spack-stack/spack-stack-1.4.0/envs/unified-env``                                              |
+| Amazon Web Services AMI Ubuntu 20 GNU                      | Dom Heinzeller / ???          | **spack-stack-1.4.1 not supported on this platform, use 1.4.0**``                                            |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 
 ^* This system uses a different wgrib2 version 3.1.1 than the default 2.0.8.
@@ -87,23 +83,21 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.7
    module available
 
-For ``spack-stack-1.4.0`` with GNU, load the following modules after loading miniconda and ecflow:
-
-TODO TEST
+For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/10.2.0
    module load stack-openmpi/4.0.4
    module load stack-python/3.9.7
@@ -118,27 +112,27 @@ The following is required for building new spack environments and for using spac
 .. code-block:: console
 
    module purge
-   module use /work/noaa/epic-ps/role-epic-ps/spack-stack/modulefiles
-   module load ecflow/5.8.4-hercules
-   module load mysql/8.0.31-hercules
+   module use /work/noaa/epic/role-epic/spack-stack/hercules/modulefiles
+   module load ecflow/5.8.4
+   module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.7.1
    module load stack-intel-oneapi-mpi/2021.7.1
    module load stack-python/3.9.14
    module available
 
-For ``spack-stack-1.4.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/11.3.1
-   module load stack-openmpi/4.1.4
+   module load stack-openmpi/4.1.5
    module load stack-python/3.9.14
    module available
 
@@ -158,21 +152,21 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.0.1
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.9.7
    module available
 
-For ``spack-stack-1.4.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-openmpi/4.1.3
    module load stack-python/3.9.7
@@ -313,11 +307,11 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow.
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow.
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.4.0-casper/envs/unified-env-v2/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/19.1.1.217
    module load stack-intel-mpi/2019.7.217
    module load stack-python/3.9.12
@@ -340,21 +334,21 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow.
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow.
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env
    module load stack-intel/19.1.1.217
    module load stack-intel-mpi/2019.7.217
    module load stack-python/3.9.12
    module available
 
-For ``spack-stack-1.4.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env
    module load stack-gcc/10.1.0
    module load stack-openmpi/4.1.1
    module load stack-python/3.9.12
@@ -366,8 +360,11 @@ For ``spack-stack-1.4.0`` with GNU, load the following modules after loading min
 NOAA Acorn (WCOSS2 test system)
 -------------------------------
 
-.. note::
-   Support for spack-stack-1.4.0 will be added later on develop. The instructions below are for an older release.
+**This information is incomplete - need EMC to fill in**
+
+.. code-block:: console
+
+   module use /lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
 
 On WCOSS2 OpenSUSE sets `CONFIG_SITE` which causes libraries to be installed in `lib64`, breaking the `lib` assumption made by some packages.
 
@@ -387,6 +384,8 @@ As of spring 2023, there is an inconsistency in `libstdc++` versions on Acorn be
 ----------------------------------------
 NOAA Parallel Works (AWS, Azure, Gcloud)
 ----------------------------------------
+
+**Note. This section needs updating from EPIC**
 
 The following is required for building new spack environments and for using spack to build and run software. The default module path needs to be removed, otherwise spack detect the system as Cray. It is also necessary to add ``git-lfs`` and some other utilities to the search path (see :numref:`Section %s <MaintainersSection_Parallel_Works >`).
 
@@ -442,11 +441,11 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.0-c4/envs/unified-env-v2/install/modulefiles/Core
+   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.1-c4/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-cray-mpich/7.7.20
    module load stack-python/3.9.12
@@ -474,7 +473,7 @@ The following is required for building new spack environments and for using spac
    module load cray-mpich/8.1.25
    module load python/3.9.12
 
-   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/modulefiles-c5
+   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
@@ -482,14 +481,17 @@ For ``spack-stack-1.4.0`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.0-c5/envs/unified-env-v2/install/modulefiles/Core
+   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.2.1
    module load stack-cray-mpich/8.1.25
    module load stack-python/3.9.12
-   module available
+   module -t available
 
 .. note::
-   On Gaea, a current limitation is that any executable that is linked against the MPI library (``cray-mpich``) must be run through ``srun`` on a compute node, even if it is run serially (one process). This is in particular a problem when using ``ctest`` for unit testing created by the ``ecbuild add_test`` macro. A workaround is to use the `cmake` cross-compiling emulator for this:
+   On Gaea C5, running ``module available`` without the option ``-t`` leads to an error: ``/usr/bin/lua5.3: /opt/cray/pe/lmod/lmod/libexec/Spider.lua:568: stack overflow``
+
+.. note::
+   On Gaea C5, a current limitation is that any executable that is linked against the MPI library (``cray-mpich``) must be run through ``srun`` on a compute node, even if it is run serially (one process). This is in particular a problem when using ``ctest`` for unit testing created by the ``ecbuild add_test`` macro. A workaround is to use the `cmake` cross-compiling emulator for this:
 
 .. code-block:: console
 
@@ -511,26 +513,26 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.5.3
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.12
    module available
 
-For ``spack-stack-1.4.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.2.0
    module load stack-openmpi/4.1.5
    module load stack-python/3.9.12
    module available
-   
+
 Note that on Hera, a dedicated node exists for ``ecflow`` server jobs (``hecflow01``). Users starting ``ecflow_server`` on the regular login nodes will see their servers being killed every few minutes, and may be barred from accessing the system.
 
 .. _Preconfigured_Sites_Jet:
@@ -550,21 +552,21 @@ The following is required for building new spack environments and for using spac
    module use /lfs4/HFIP/hfv3gfs/role.epic/modulefiles
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.9.12
    module available
 
-For ``spack-stack-1.4.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.2.0
    module load stack-openmpi/3.1.4
    module load stack-python/3.9.12
@@ -584,11 +586,11 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /data/prod/jedi/spack-stack/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /data/prod/jedi/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.9.12
@@ -608,24 +610,24 @@ Amazon Web Services Parallelcluster Ubuntu 20.04
 
 Access to the JCSDA-managed AWS Parallel Cluster is not available to the public. The following instructions are for JCSDA core staff and in-kind contributors.
 
-For ``spack-stack-1.4.0`` with Intel, run the following commands/load the following modules:
+For ``spack-stack-1.4.1`` with Intel, run the following commands/load the following modules:
 
 .. code-block:: console
 
    module purge
    ulimit -s unlimited
    source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
-   module use /mnt/experiments-efs/skylab-v5/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /mnt/experiments-efs/skylab-v5/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.1.0
    module load stack-intel-oneapi-mpi/2021.6.0
    module load stack-python/3.10.8
    module available
 
-For ``spack-stack-1.4.0`` with GNU, run the following commands/load the following modules:
+For ``spack-stack-1.4.1`` with GNU, run the following commands/load the following modules:
 
    module purge
    ulimit -s unlimited
-   module use /mnt/experiments-efs/skylab-v5/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+   module use /mnt/experiments-efs/skylab-v5/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.4.0
    module load stack-openmpi/4.1.4
    module load stack-python/3.10.8

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -34,7 +34,7 @@ Ready-to-use spack-stack 1.4.1 installations are available on the following, ful
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NCAR-Wyoming Cheyenne Intel/GNU                            | Cam Book / Dom Heinzeller     | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env``                    |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA Parallel Works (AWS, Azure, Gcloud) Intel             | Mark Potts / Cam Book         | **will be added later (on develop)**                                                                         |
+| NOAA Parallel Works (AWS, Azure, Gcloud) Intel             | Mark Potts / Cam Book         | ``/contrib/EPIC/spack-stack/spack-stack-1.4.1/envs/unified-dev``                                             |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA Acorn Intel                                           | Hang Lei / Alex Richert       | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.1/envs/unified-env``                              |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -379,8 +379,6 @@ As of spring 2023, there is an inconsistency in ``libstdc++`` versions on Acorn 
 NOAA Parallel Works (AWS, Azure, Gcloud)
 ----------------------------------------
 
-**Note. This section needs updating from EPIC**
-
 The following is required for building new spack environments and for using spack to build and run software. The default module path needs to be removed, otherwise spack detect the system as Cray. It is also necessary to add ``git-lfs`` and some other utilities to the search path (see :numref:`Section %s <MaintainersSection_Parallel_Works >`).
 
 .. code-block:: console
@@ -391,30 +389,15 @@ The following is required for building new spack environments and for using spac
    module use /contrib/spack-stack/modulefiles/core
    module load miniconda/3.9.12
    module load mysql/8.0.31
-   # So far only on NOAA-AWS for spack-stack develop versions newer than 1.3.1
    module load ecflow/5.8.4
 
-.. note::
-   Support for spack-stack-1.4.1 will be added later on develop. The instructions below are for an older release.
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda, mysql and ecflow:
 
-For ``spack-stack-1.3.0`` with Intel, load the following modules after loading miniconda and ecflow:
-
-   module use /contrib/EPIC/spack-stack/spack-stack-1.3.0/envs/unified-env/install/modulefiles/Core
+   module use /contrib/EPIC/spack-stack/spack-stack-1.4.1/envs/unified-dev/install/modulefiles/Core
    module load stack-intel/2021.3.0
    module load stack-intel-oneapi-mpi/2021.3.0
    module load stack-python/3.9.12
    module available
-
-For ``spack-stack-1.3.1`` with Intel, load the following modules after loading miniconda and ecflow:
-
-   module use /contrib/EPIC/spack-stack/spack-stack-1.3.1/envs/unified-env/install/modulefiles/Core
-   module load stack-intel/2021.3.0
-   module load stack-intel-oneapi-mpi/2021.3.0
-   module load stack-python/3.9.12
-   module available
-
-.. note::
-   ``spack-stack-1.3.1`` is not yet available on Azure.
 
 .. _Preconfigured_Sites_Gaea:
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -360,21 +360,15 @@ For ``spack-stack-1.4.1`` with GNU, load the following modules after loading min
 NOAA Acorn (WCOSS2 test system)
 -------------------------------
 
-**This information is incomplete - need EMC to fill in**
+For spack-stack-1.4.1, the meta modules are in ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core``.
 
-.. code-block:: console
+On WCOSS2 OpenSUSE sets ``CONFIG_SITE`` which causes libraries to be installed in ``lib64``, breaking the ``lib`` assumption made by some packages. Therefore, ``CONFIG_SITE`` should be set to empty in ``compilers.yaml``. Also, don't use ``module purge`` on Acorn!
 
-   module use /lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
+When installing an official ``spack-stack`` on Acorn, be mindful of umask and group ownership, as these can be finicky. The umask value should be 002, otherwise various files can be assigned to the wrong group. In any case, running something to the effect of ``chgrp nceplibs <spack-stack dir> -R`` and ``chmod o+rX <spack-stack dir> -R`` after the whole installation is done is a good idea.
 
-On WCOSS2 OpenSUSE sets `CONFIG_SITE` which causes libraries to be installed in `lib64`, breaking the `lib` assumption made by some packages.
+Due to a combined quirk of Cray and Spack, the ``PrgEnv-gnu`` and ``gcc`` modules must be loaded when `ESMF` is being installed with ``gcc``.
 
-`CONFIG_SITE` should be set to empty in `compilers.yaml`. Don't use ``module purge`` on Acorn!
-
-When installing an official `spack-stack` on Acorn, be mindful of umask and group ownership, as these can be finicky. The umask value should be 002, otherwise various files can be assigned to the wrong group. In any case, running something to the effect of ``chgrp nceplibs <spack-stack dir> -R`` and ``chmod o+rX <spack-stack dir> -R`` after the whole installation is done is a good idea.
-
-Due to a combined quirk of Cray and Spack, the ``PrgEnv-gnu`` and ``gcc`` modules must be loaded when `ESMF` is being installed with `GCC`.
-
-As of spring 2023, there is an inconsistency in `libstdc++` versions on Acorn between the login and compute nodes. It is advisable to compile on the compute nodes, which requires running ``spack fetch`` prior to installing through a batch job.
+As of spring 2023, there is an inconsistency in ``libstdc++`` versions on Acorn between the login and compute nodes. It is advisable to compile on the compute nodes, which requires running ``spack fetch`` prior to installing through a batch job.
 
 .. note::
    System-wide ``spack`` software installations are maintained by NCO on this platform. The spack-stack official installations use those installations for some dependencies.
@@ -401,7 +395,7 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
 
 .. note::
-   Support for spack-stack-1.4.0 will be added later on develop. The instructions below are for an older release.
+   Support for spack-stack-1.4.1 will be added later on develop. The instructions below are for an older release.
 
 For ``spack-stack-1.3.0`` with Intel, load the following modules after loading miniconda and ecflow:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2023 '
 author = 'Dominikus Heinzeller, Alexander Richert, Cameron Book'
 
 # The short X.Y version
-version = ''
+version = '1.4'
 # The full version, including alpha/beta/rc tags
-release = ''
+release = '1.4.1'
 
 numfig = True
 
@@ -142,7 +142,7 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
-    'maketitle': r'\newcommand\sphinxbackoftitlepage{For referencing this document please use: \newline \break Heinzeller, D., A. Richert, C. Book, 2023. spack-stack documentation release v1.3.1. Available at https://spack-stack.readthedocs.io/\textunderscore/downloads/en/v1.3.1/pdf/.}\sphinxmaketitle'
+    'maketitle': r'\newcommand\sphinxbackoftitlepage{For referencing this document please use: \newline \break Heinzeller, D., A. Richert, C. Book, 2023. spack-stack documentation release v1.4.1. Available at https://spack-stack.readthedocs.io/\textunderscore/downloads/en/v1.4.1/pdf/.}\sphinxmaketitle'
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
### Summary

Final updates for spack-stack-1.4.1:
- Documentation
- Site config updates for Hercules and Gaea C5
- Tags instead of release branches

### Testing

Installed on all platforms that are updated in the documentation, tested on about half of them

### Applications affected

Primarily UFS WM; JEDI will use spack-stack-1.4.1 mainly for testing of `bufr@12`.

### Systems affected

All systems updated in the documentation (but existing spack-stack-1.4.0 installs remain in place).

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/637 (requires all boxes in the issue to be ticked or crossed out)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
