### PR TITLE
Merge spack develop as of 2023/07/10 into jcsda_emc_spack_stack

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -101,7 +101,7 @@ jobs:
 
           # Add binary cache and reindex it
           spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
-          spack buildcache update-index -m local-binary
+          spack buildcache update-index local-binary
           echo "Packages in combined spack build caches:"
           spack buildcache list
 

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -100,7 +100,8 @@ jobs:
           spack mirror create -a -d /Users/ec2-user/spack-stack/source-cache/
 
           # Add binary cache and reindex it
-          spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
+          # DH* 20230721 - TODO CLEAN UP OLD BUILD CACHE AFTER MERGE
+          spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache-new/
           spack buildcache update-index local-binary
           echo "Packages in combined spack build caches:"
           spack buildcache list

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -103,7 +103,7 @@ jobs:
           # Add binary cache and reindex it
           spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
           # DH* 20230721 - todo remove || true
-          spack buildcache update-index -m local-binary || true
+          spack buildcache update-index local-binary || true
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
@@ -113,27 +113,17 @@ jobs:
 
           # base-env
           echo "base-env ..."
-<<<<<<< HEAD
-          spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
-          spack buildcache push -a -u local-binary || true
-
-          # the rest
-          echo "${{ inputs.template || 'unified-dev' }} ..."
-          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
-          spack buildcache push -a -u local-binary || true
-=======
           # DH* 20230721 - todo remove --no-checksum
           spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           # DH* 20230721 - todo remove --no-checksum
           spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
->>>>>>> jcsda/develop
+          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -139,6 +139,7 @@ jobs:
           export ENVNAME=ci-env.macos-ci-aarch64
           # *DH
           export ENVDIR=$PWD/envs/${ENVNAME}
+          ls -l ${ENVDIR}/install/modulefiles/Core
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-apple-clang/14.0.0

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -142,13 +142,13 @@ jobs:
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-apple-clang/14.0.0
-          module load stack-openmpi
+          module load stack-openmpi/4.1.5
           module load stack-python/3.10.8
           module available
 
-          module load jedi-ufs-env/unified-dev
-          module load ewok-env/unified-dev
-          module load soca-env/unified-dev
+          module load jedi-ufs-env/1.0.0
+          module load ewok-env/1.0.0
+          module load soca-env/1.0.0
           module list
 
       # Skip this for now, copied from other yaml

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -67,7 +67,7 @@ jobs:
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
-          spack external find --scope system --exclude bison
+          spack external find --scope system --exclude bison --exclude openssl
           spack external find --scope system perl
           spack external find --scope system wget
           PATH="/opt/homebrew/opt/curl/bin:$PATH" \

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -112,12 +112,12 @@ jobs:
           # base-env
           echo "base-env ..."
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache push -a -u local-binary || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache push -a -u local-binary || true
 
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -96,7 +96,7 @@ jobs:
           # Add binary cache and reindex it
           spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
           # DH* 20230721 - todo remove || true
-          spack buildcache update-index -m local-binary || true
+          spack buildcache update-index local-binary || true
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
@@ -109,14 +109,14 @@ jobs:
           # DH* 20230721 - todo remove --no-checksum
           spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           # DH* 20230721 - todo remove --no-checksum
           spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -105,12 +105,12 @@ jobs:
           # base-env
           echo "base-env ..."
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache push -a -u local-binary || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
-          spack buildcache create -a -r -u -d /Users/ec2-user/spack-stack/build-cache/ || true
+          spack buildcache push -a -u local-binary || true
 
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -130,6 +130,7 @@ jobs:
           export ENVNAME=ci-env.macos-ci-x86_64
           # *DH
           export ENVDIR=$PWD/envs/${ENVNAME}
+          ls -l ${ENVDIR}/install/modulefiles/Core
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-apple-clang/14.0.0

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -133,13 +133,13 @@ jobs:
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-apple-clang/14.0.0
-          module load stack-openmpi
+          module load stack-openmpi/4.1.5
           module load stack-python/3.10.8
           module available
 
-          module load jedi-ufs-env/unified-dev
-          module load ewok-env/unified-dev
-          module load soca-env/unified-dev
+          module load jedi-ufs-env/1.0.0
+          module load ewok-env/1.0.0
+          module load soca-env/1.0.0
           module list
 
       # Skip this for now, copied from other yaml

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -94,7 +94,7 @@ jobs:
 
           # Add binary cache and reindex it
           spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
-          spack buildcache update-index -m local-binary
+          spack buildcache update-index local-binary
           echo "Packages in combined spack build caches:"
           spack buildcache list
 

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -60,7 +60,7 @@ jobs:
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
-          spack external find --scope system --exclude bison
+          spack external find --scope system --exclude bison --exclude openssl
           spack external find --scope system perl
           spack external find --scope system wget
           PATH="/usr/local/opt/curl/bin:$PATH" \

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -93,7 +93,8 @@ jobs:
           spack mirror create -a -d /Users/ec2-user/spack-stack/source-cache/
 
           # Add binary cache and reindex it
-          spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
+          # DH* 20230721 - TODO CLEAN UP OLD BUILD CACHE AFTER MERGE
+          spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache-new/
           spack buildcache update-index local-binary
           echo "Packages in combined spack build caches:"
           spack buildcache list

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -60,7 +60,7 @@ jobs:
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
-          spack external find --scope system
+          spack external find --scope system --exclude bison --exclude openssl
           spack external find --scope system perl
           spack external find --scope system wget
           PATH="/usr/local/opt/curl/bin:$PATH" \

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -143,12 +143,12 @@ jobs:
           # base-env
           echo "base-env ..."
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.intel-2021.4.0.base-env
-          spack buildcache create -a -r -u -d /home/ubuntu/spack-stack/build-cache/ || true
+          spack buildcache push -a -u local-binary || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
-          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.intel@2021.4.0.${{ inputs.template || 'unified-dev' }}
-          spack buildcache create -a -r -u -d /home/ubuntu/spack-stack/build-cache/ || true
+          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.intel-2021.4.0.${{ inputs.template || 'unified-dev' }}
+          spack buildcache push -a -u local-binary || true
 
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -175,9 +175,9 @@ jobs:
           module load stack-python/3.10.8
           module available
 
-          module load jedi-ufs-env/unified-dev
-          module load ewok-env/unified-dev
-          module load soca-env/unified-dev
+          module load jedi-ufs-env/1.0.0
+          module load ewok-env/1.0.0
+          module load soca-env/1.0.0
           module list
 
       # Skip this for now, copied from other yaml

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -134,7 +134,7 @@ jobs:
           # Add binary cache and reindex it
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
           # DH* 20230721 - todo remove || true
-          spack buildcache update-index -m local-binary || true
+          spack buildcache update-index local-binary || true
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
@@ -147,14 +147,14 @@ jobs:
           # DH* 20230721 - todo remove --no-checksum
           spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.intel-2021.4.0.base-env
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
-          spack buildcache create -a -r -u -d /home/ubuntu/spack-stack/build-cache/ || true
+          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           # DH* 20230721 - todo remove --no-checksum
           spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.intel@2021.4.0.${{ inputs.template || 'unified-dev' }}
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
-          spack buildcache create -a -r -u -d /home/ubuntu/spack-stack/build-cache/ || true
+          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ || true
 
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -132,7 +132,7 @@ jobs:
 
           # Add binary cache and reindex it
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
-          spack buildcache update-index -m local-binary
+          spack buildcache update-index local-binary
           echo "Packages in combined spack build caches:"
           spack buildcache list
 

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -131,7 +131,8 @@ jobs:
           spack mirror create -a -d /home/ubuntu/spack-stack/source-cache/
 
           # Add binary cache and reindex it
-          spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
+          # DH* 20230721 - TODO CLEAN UP OLD BUILD CACHE AFTER MERGE
+          spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache-new/
           spack buildcache update-index local-binary
           echo "Packages in combined spack build caches:"
           spack buildcache list

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -168,6 +168,7 @@ jobs:
           export ENVNAME=ci-env.ubuntu-ci-x86_64
           # *DH
           export ENVDIR=$PWD/envs/${ENVNAME}
+          ls -l ${ENVDIR}/install/modulefiles/Core
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-intel/2021.4.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   ##url = https://github.com/spack/spack
   ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/merge_spack_develop_20230710
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/merge_spack_develop_20230710
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
+  #url = https://github.com/spack/spack
+  #branch = develop
   url = https://github.com/jcsda/spack
   branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]

--- a/configs/common/config.yaml
+++ b/configs/common/config.yaml
@@ -4,7 +4,7 @@ config:
   install_tree:
     root: $env/install
     projections:
-      all: "${COMPILERNAME}/${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+      all: "{compiler.name}/{compiler.version}/{name}-{version}-{hash}"
     # Needed for relocation of binary packages (build caches)
     #padded_length: true
 

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -16,7 +16,7 @@ modules:
         nlohmann-json: '{compiler.name}/{compiler.version}/json/{version}'
         nlohmann-json-schema-validator: '{compiler.name}/{compiler.version}/json-schema-validator/{version}'
         libjpeg-turbo: '{compiler.name}/{compiler.version}/libjpeg/{version}'
-      blacklist:
+      exclude:
       # List of packages for which we don't need modules
       - apple-libunwind
       - apple-libuuid
@@ -261,7 +261,7 @@ modules:
         nlohmann-json: 'json/{version}'
         nlohmann-json-schema-validator: 'json-schema-validator/{version}'
         libjpeg-turbo: 'libjpeg/{version}'
-      blacklist:
+      exclude:
       # List of packages for which we don't need modules
       - apple-libunwind
       - apple-libuuid

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -200,7 +200,7 @@
     #py-mysql-connector-python:
     #  version: ['8.0.32']
     py-netcdf4:
-      version: ['1.5.3']
+      version: ['1.5.8']
       variants: ~mpi
     py-numpy:
       version: ['1.22.3']

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -11,252 +11,252 @@
         lapack: [openblas]
         yacc: [bison]
     #
-    bacio:
-      version: [2.4.1]
+    bacio:  
+      version: ['2.4.1']
     bison:
-      version: [3.8.2]
+      version: ['3.8.2']
     # Attention - when updating also check orion site config
     boost:
-      version: [1.78.0]
+      version: ['1.78.0']
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
     bufr:
-      version: [12.0.0]
+      version: ['12.0.0']
       variants: +python
     # Newer versions of CDO require the C++-17 standard, which doesn't
     # work with all compilers that are currently in use in spack-stack
     cdo:
-      version: [2.0.5]
+      version: ['2.0.5']
       variants: ~openmp
     cmake:
-      version: [3.23.1]
+      version: ['3.23.1']
       variants: +ownlibs
     # Attention - when updating also check the various jcsda-emc-bundles env packages
     crtm:
-      version: [2.4.0]
+      version: ['2.4.0']
       variants: +fix
     ecbuild:
-      version: [3.7.2]
+      version: ['3.7.2']
     eccodes:
-      version: [2.27.0]
+      version: ['2.27.0']
     ecflow:
-      version: [5.8.4]
+      version: ['5.8.4']
       variants: +ui
     eckit:
-      version: [1.23.1]
+      version: ['1.23.1']
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: [0.33.0]
+      version: ['0.33.0']
       variants: +fckit +trans
     ectrans:
-      version: [1.2.0]
+      version: ['1.2.0']
       variants: ~enable_mkl
     eigen:
-      version: [3.4.0]
+      version: ['3.4.0']
     # Attention - when updating the version also check the common modules.yaml
     # config and update the projections for lmod/tcl
     # Note: Stay away from esmf@8.4.1 ... breaks all sorts of things
     #esmf:
-    #  version: [8.4.1]
+    #  version: ['8.4.1']
     #  variants: ~xerces ~pnetcdf +parallelio ~shared
     esmf:
-      version: [8.4.2]
+      version: ['8.4.2']
       variants: ~xerces ~pnetcdf snapshot=none ~shared +external-parallelio
     fckit:
-      version: [0.10.1]
+      version: ['0.10.1']
       variants: +eckit
     fftw:
-      version: [3.3.10]
+      version: ['3.3.10']
     fiat:
-      version: [1.1.0]
+      version: ['1.1.0']
     fms:
-      version: [2023.01]
+      version: ['2023.01']
       variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
     g2:
-      version: [3.4.5]
+      version: ['3.4.5']
     g2c:
-      version: [1.6.4]
+      version: ['1.6.4']
     g2tmpl:
-      version: [1.10.2]
+      version: ['1.10.2']
     gfsio:
-      version: [1.4.1]
+      version: ['1.4.1']
     gftl-shared:
-      version: [1.5.0]
+      version: ['1.5.0']
     #git-lfs:
       # Assume git-lfs is provided, hard to install
       # because of dependencies on go/go-bootstrap.
       # Note: Uncommenting this entry will break
       # the container builds.
-      #version: [2.11.0]
+      #version: ['2.11.0']
     grib-util:
-      version: [1.2.3]
+      version: ['1.2.3']
     gsibec:
-      version: [1.1.2]
+      version: ['1.1.2']
     gsi-ncdiag:
-      version: [1.1.1]
+      version: ['1.1.1']
     gsl-lite:
-      version: [0.37.0]
+      version: ['0.37.0']
     hdf:
-      version: [4.2.15]
+      version: ['4.2.15']
       variants: ~fortran ~netcdf
     hdf5:
-      version: [1.14.0]
+      version: ['1.14.0']
       variants: +hl +fortran +mpi ~threadsafe +szip
     ip:
-      version: [3.3.3]
+      version: ['3.3.3']
     ip2:
-      version: [1.1.2]
+      version: ['1.1.2']
     jasper:
-      version: [2.0.32]
+      version: ['2.0.32']
     jedi-cmake:
-      version: [1.4.0]
+      version: ['1.4.0']
     jpeg:
-      version: [9.1.0]
+      version: ['9.1.0']
     landsfcutil:
-      version: [2.4.1]
+      version: ['2.4.1']
     libjpeg-turbo:
-      version: [2.1.0]
+      version: ['2.1.0']
     libpng:
-      version: [1.6.37]
+      version: ['1.6.37']
     libyaml:
-      version: [0.2.5]
+      version: ['0.2.5']
     mapl:
       # 2.35.2 goes with esmf@8.4.1
-      version: [2.35.2]
+      version: ['2.35.2']
       variants: ~shared
     met:
-      version: [11.0.2]
+      version: ['11.0.2']
       variants: +python +grib2
     metplus:
-      version: [5.0.1]
+      version: ['5.0.1']
     mpich:
       variants: ~hwloc +two_level_namespace
     nco:
-      version: [5.0.6]
+      version: ['5.0.6']
       variants: ~doc
     # ncview - when adding information here, also check Orion
     # and Discover site configs
     nemsio:
-      version: [2.5.4]
+      version: ['2.5.4']
     nemsiogfs:
-      version: [2.5.3]
+      version: ['2.5.3']
     nccmp:
-      version: [1.9.0.1]
+      version: ['1.9.0.1']
     ncio:
-      version: [1.1.2]
+      version: ['1.1.2']
     netcdf-c:
-      version: [4.9.2]
+      version: ['4.9.2']
       # If using 4.9.1, turn off byterange variant to fix compile error: ~byterange
       variants: +dap +mpi ~parallel-netcdf
     netcdf-cxx4:
-      version: [4.3.1]
+      version: ['4.3.1']
     netcdf-fortran:
-      version: [4.6.0]
+      version: ['4.6.0']
     # ninja - when adding information here, also check Cheyenne
     # and Discover site configs
     nlohmann-json:
-      version: [3.10.5]
+      version: ['3.10.5']
     nlohmann-json-schema-validator:
-      version: [2.1.0]
+      version: ['2.1.0']
     odc:
-      version: [1.4.6]
+      version: ['1.4.6']
       variants: ~fortran
     openblas:
-      version: [0.3.19]
+      version: ['0.3.19']
       variants: +noavx512
     openmpi:
       variants: +internal-hwloc +two_level_namespace
     openssl:
       variants: +shared
     p4est:
-      version: [2.8]
+      version: ['2.8']
     parallelio:
-      version: [2.5.9]
+      version: ['2.5.9']
       variants: +pnetcdf
     parallel-netcdf:
-      version: [1.12.2]
+      version: ['1.12.2']
     # Do not build pkgconf - https://github.com/jcsda/spack-stack/issues/123
     pkgconf:
       buildable: False
     prod-util:
-      version: [1.2.2]
+      version: ['1.2.2']
     proj:
-      version: [8.1.0]
+      version: ['8.1.0']
       variants: ~tiff
     python:
-      version: [3.10.8]
+      version: ['3.10.8']
     py-cartopy:
       variants: +plotting
     py-click:
-      version: [8.0.3]
+      version: ['8.0.3']
     py-eccodes:
-      version: [1.4.2]
+      version: ['1.4.2']
     py-h5py:
-      version: [3.7.0]
+      version: ['3.7.0']
       variants: ~mpi
     # Comment out for now until build problems are solved
     # https://github.com/jcsda/spack-stack/issues/522
     # see also ewok-env virtual package and container
     # README.md
     #py-mysql-connector-python:
-    #  version: [8.0.32]
+    #  version: ['8.0.32']
     py-netcdf4:
-      version: [1.5.3]
+      version: ['1.5.3']
       variants: ~mpi
     py-numpy:
-      version: [1.22.3]
+      version: ['1.22.3']
       variants: +blas +lapack
     py-openpyxl:
-      version: [3.0.3]
+      version: ['3.0.3']
     py-pandas:
-      version: [1.4.0]
+      version: ['1.4.0']
     # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
     # versions of py-poetry-core when using external/homebrew Python as
     # we do at the moment in spack-stack.
     py-poetry-core:
-      version: [1.0.8]
+      version: ['1.0.8']
     py-pybind11:
-      version: [2.8.1]
+      version: ['2.8.1']
     py-pycodestyle:
-      version: [2.8.0]
+      version: ['2.8.0']
     py-pygithub:
-      version: [1.55]
+      version: ['1.55']
     py-pygrib:
-      version: [2.1.4]
+      version: ['2.1.4']
     py-pyhdf:
-      version: [0.10.4]
+      version: ['0.10.4']
     py-pyproj:
-      version: [3.1.0]
+      version: ['3.1.0']
     py-python-dateutil:
-      version: [2.8.2]
+      version: ['2.8.2']
     py-pythran:
       # Versions earlier than 0.11.0 don't compile on macOS with llvm-clang/13.0.0 and Python/3.9,
       # and 0.11.0 leads to downstream errors in py-scipy with the Intel compilers
-      version: [0.12.2]
+      version: ['0.12.2']
     py-pyyaml:
-      version: [6.0]
+      version: ['6.0']
     py-scipy:
-      version: [1.9.3]
+      version: ['1.9.3']
     # Pin the py-setuptools version to avoid duplicate Python packages
     py-setuptools:
-      version: [59.4.0]
+      version: ['59.4.0']
     # Pin the py-setuptools-scm version to avoid duplicate Python packages
     py-setuptools-scm:
-      version: [7.0.5]
+      version: ['7.0.5']
     py-shapely:
-      version: [1.8.0]
+      version: ['1.8.0']
     qt:
-      version: [5.15.3]
+      version: ['5.15.3']
     scotch:
-      version: [7.0.3]
+      version: ['7.0.3']
       variants: +mpi+metis~shared~threads~mpi_thread+noarch
     sfcio:
-      version: [1.4.1]
+      version: ['1.4.1']
     shumlib:
-      version: [macos_clang_linux_intel_port]
+      version: ['macos_clang_linux_intel_port']
     sigio:
-      version: [2.3.2]
+      version: ['2.3.2']
     sp:
-      version: [2.3.3]
+      version: ['2.3.3']
     #texlive:
       # Assume texlive is provided, hard to install
       # because of its dependencies. Both Linux and
@@ -264,26 +264,26 @@
       # can be added as external packages.
       # Note: Uncommenting this entry will break
       # the container builds.
-      #version: [2.11.0]
+      #version: ['2.11.0']
     udunits:
-      version: [2.2.28]
+      version: ['2.2.28']
     upp:
-      version: [10.0.10]
+      version: ['10.0.10']
     w3emc:
-      version: [2.9.2]
+      version: ['2.9.2']
     w3nco:
-      version: [2.4.1]
+      version: ['2.4.1']
     wget:
-      version: [1.21.2]
+      version: ['1.21.2']
     # When changing wgrib2, also check Hercules and Nautilus site configs
     wgrib2:
-      version: [2.0.8]
+      version: ['2.0.8']
     wrf-io:
-      version: [1.2.0]
+      version: ['1.2.0']
     yafyaml:
-      version: [0.5.1]
+      version: ['0.5.1']
     zlib:
-      version: [1.2.13]
+      version: ['1.2.13']
     zstd:
-      version: [1.5.2]
+      version: ['1.5.2']
       variants: +programs

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -203,12 +203,14 @@
       version: ['1.5.3']
       variants: ~mpi
     py-numpy:
-      version: ['1.22.3']
+      # DH* 20230719 try without version
+      #version: ['1.22.3']
       variants: +blas +lapack
     py-openpyxl:
       version: ['3.0.3']
-    py-pandas:
-      version: ['1.4.0']
+    # DH* 20230719 try without version
+    #py-pandas:
+    #  version: ['1.4.0']
     # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
     # versions of py-poetry-core when using external/homebrew Python as
     # we do at the moment in spack-stack.

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -203,8 +203,7 @@
       version: ['1.5.3']
       variants: ~mpi
     py-numpy:
-      # DH* 20230719 try without version
-      #version: ['1.22.3']
+      version: ['1.22.3']
       variants: +blas +lapack
     py-openpyxl:
       version: ['3.0.3']

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -11,7 +11,7 @@
         - craype-network-ofi
         - cray-mpich/8.1.9
     esmf:
-      version: [8.3.0b09]
+      version: ['8.3.0b09']
       variants: ~xerces ~pnetcdf +pio ~shared snapshot=b09 esmf_os=Linux esmf_comm=mpich3
     git:
       buildable: false
@@ -51,11 +51,11 @@
       - spec: pkg-config@0.29.2
         prefix: /usr
     patchelf:
-      version: [0.13.1]
+      version: ['0.13.1']
     gettext:
-      version: [0.19.7]
+      version: ['0.19.7']
     rhash:
-      version: [1.3.5]
+      version: ['1.3.5']
     gdal:
       variants: ~curl
     flex:

--- a/configs/sites/aws-pcluster/modules.yaml
+++ b/configs/sites/aws-pcluster/modules.yaml
@@ -3,6 +3,6 @@ modules:
     enable::
     - lmod
     lmod:
-      whitelist:
+      include:
       # List of packages for which we need modules that are blacklisted by default
       - python

--- a/configs/sites/casper/modules.yaml
+++ b/configs/sites/casper/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/casper/packages.yaml
+++ b/configs/sites/casper/packages.yaml
@@ -172,7 +172,7 @@ packages:
       prefix: /usr
   # Old re2c on Casper unable to build newer versions of ninja
   ninja:
-    version:: [1.10.2]
+    version:: ['1.10.2']
   openssh:
     externals:
     - spec: openssh@7.4p1
@@ -183,7 +183,7 @@ packages:
       prefix: /usr
   # Pin patchelf to 0.15.0 for Intel compiler (no C++-17 features)
   patchelf:
-    version:: [0.15.0]
+    version:: ['0.15.0']
   perl:
     externals:
     - spec: perl@5.16.3~cpanm+shared+threads

--- a/configs/sites/cheyenne/modules.yaml
+++ b/configs/sites/cheyenne/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -192,7 +192,7 @@ packages:
       prefix: /usr
   # Old re2c on Cheyenne unable to build newer versions of ninja
   ninja:
-    version:: [1.10.2]
+    version:: ['1.10.2']
   openssh:
     externals:
     - spec: openssh@7.2p2
@@ -203,7 +203,7 @@ packages:
       prefix: /usr
   # Pin patchelf to 0.15.0 for Intel compiler (no C++-17 features)
   patchelf:
-    version:: [0.15.0]
+    version:: ['0.15.0']
   perl:
     externals:
     - spec: perl@5.18.2~cpanm+shared+threads

--- a/configs/sites/discover/modules.yaml
+++ b/configs/sites/discover/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -179,7 +179,7 @@ packages:
       prefix: /usr
   # Old re2c on Discover unable to build newer versions of ninja
   ninja:
-    version:: [1.10.2]
+    version:: ['1.10.2']
   openssl:
     externals:
     - spec: openssl@1.0.2j-fips

--- a/configs/sites/emc-rhel/modules.yaml
+++ b/configs/sites/emc-rhel/modules.yaml
@@ -3,7 +3,7 @@ modules:
     enable::
     - lmod
     lmod:
-      whitelist:
+      include:
       # List of packages for which we need modules that are blacklisted by default
       - openmpi
       - mpich

--- a/configs/sites/frontera/modules.yaml
+++ b/configs/sites/frontera/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/gaea-c5/modules.yaml
+++ b/configs/sites/gaea-c5/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/gaea/modules.yaml
+++ b/configs/sites/gaea/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - tcl
     tcl:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/hera/modules.yaml
+++ b/configs/sites/hera/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/hercules/modules.yaml
+++ b/configs/sites/hercules/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -29,7 +29,7 @@ packages:
 ### Modifications of common packages
   # Version 2.0.8 doesn't compile on Hercules
   wgrib2:
-    version:: [3.1.1]
+    version:: ['3.1.1']
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/linux.default/modules.yaml
+++ b/configs/sites/linux.default/modules.yaml
@@ -3,7 +3,7 @@ modules:
     enable::
     - tcl
     tcl:
-      whitelist:
+      include:
       # List of packages for which we need modules that are blacklisted by default
       - openmpi
       - mpich

--- a/configs/sites/macos.default/modules.yaml
+++ b/configs/sites/macos.default/modules.yaml
@@ -3,7 +3,7 @@ modules:
     enable::
     - lmod
     lmod:
-      whitelist:
+      include:
       # List of packages for which we need modules that are blacklisted by default
       - openmpi
       - mpich

--- a/configs/sites/macos.default/packages.yaml
+++ b/configs/sites/macos.default/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  libiconv:
+    buildable: false
+    externals:
+    - spec: libiconv@1.17
+      prefix: /usr
   wgrib2:
     variants: ~openmp
   cairo:

--- a/configs/sites/narwhal/modules.yaml
+++ b/configs/sites/narwhal/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - tcl
     tcl:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/nautilus/modules.yaml
+++ b/configs/sites/nautilus/modules.yaml
@@ -3,8 +3,8 @@ modules:
     enable::
     - tcl
     tcl:
-      whitelist:
+      include:
       # List of packages for which we need modules that are blacklisted by default
       - python
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -45,7 +45,7 @@ packages:
 ### Modifications of common packages
   # Version 2.0.8 doesn't compile on Nautilus
   wgrib2:
-    version:: [3.1.1]
+    version:: ['3.1.1']
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/noaa-aws/modules.yaml
+++ b/configs/sites/noaa-aws/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/orion/modules.yaml
+++ b/configs/sites/orion/modules.yaml
@@ -3,5 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -46,7 +46,7 @@ packages:
 ### Modifications of common packages
   # Versions 1.73+ don't compile on orion (bootstrap.sh fails)
   boost:
-    version:: [1.72.0]
+    version:: ['1.72.0']
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/s4/modules.yaml
+++ b/configs/sites/s4/modules.yaml
@@ -3,7 +3,7 @@ modules:
     enable::
     - lmod
     lmod:
-      blacklist:
+      exclude:
       - ecflow
-      whitelist:
+      include:
       - mpich

--- a/configs/sites/s4/packages.yaml
+++ b/configs/sites/s4/packages.yaml
@@ -35,7 +35,7 @@ packages:
       - miniconda/3.9.12
   # Versions 1.73+ don't compile on s4 (bootstrap.sh fails)
   boost:
-    version:: [1.72.0]
+    version:: ['1.72.0']
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -8,13 +8,13 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
-      - ewok-env@skylab-dev
-      - jedi-fv3-env@skylab-dev
-      - jedi-mpas-env@skylab-dev
-      - jedi-neptune-env@skylab-dev
-      - jedi-ufs-env@skylab-dev
-      - jedi-um-env@skylab-dev
-      - soca-env@skylab-dev
+      - ewok-env
+      - jedi-fv3-env
+      - jedi-mpas-env
+      - jedi-neptune-env
+      - jedi-ufs-env
+      - jedi-um-env
+      - soca-env
 
       # Additional crtm tags
       - crtm@v2.4-jedi.2

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -8,22 +8,22 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
-      - global-workflow-env@unified-dev
-      #- gsi-env@unified-dev
-      - ewok-env@unified-dev
-      - jedi-fv3-env@unified-dev
-      - jedi-mpas-env@unified-dev
-      - jedi-neptune-env@unified-dev
-      - jedi-tools-env@unified-dev
-      - jedi-ufs-env@unified-dev
-      - jedi-um-env@unified-dev
-      #- nceplibs-env@unified-dev
-      - soca-env@unified-dev
-      - ufs-srw-app-env@unified-dev
-      #- ufs-utils-env@unified-dev
-      - ufs-weather-model-env@unified-dev
-      #- upp-env@unified-dev
-      #- ww3-env@unified-dev
+      - global-workflow-env
+      #- gsi-env
+      - ewok-env
+      - jedi-fv3-env
+      - jedi-mpas-env
+      - jedi-neptune-env
+      - jedi-tools-env
+      - jedi-ufs-env
+      - jedi-um-env
+      #- nceplibs-env
+      - soca-env
+      - ufs-srw-app-env
+      #- ufs-utils-env
+      - ufs-weather-model-env
+      #- upp-env
+      #- ww3-env
 
       # Additional esmf/mapl tags
       #- esmf@8.4.2~debug+external-parallelio

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -203,10 +203,8 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. code-block:: console
 
-   spack external find --scope system # use '--exclude' for troublesome packages like bison@:3.3
+   spack external find --scope system # use '--exclude' for troublesome packages like bison@:3.3, openssl@1.1.1
    spack external find --scope system perl
-   # Don't use any external Python, let spack build it
-   #spack external find --scope system python
    spack external find --scope system wget
    spack external find --scope system mysql
 
@@ -429,10 +427,8 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   spack external find --scope system
+   spack external find --scope system # use '--exclude' for troublesome packages like bison@:3.3, openssl@1.1.1
    spack external find --scope system perl
-   # Don't use any external Python, let spack build it
-   #spack external find --scope system python
    spack external find --scope system wget
    spack external find --scope system mysql
    spack external find --scope system texlive


### PR DESCRIPTION
### Summary

This is the spack-stack PR for https://github.com/JCSDA/spack/pull/295 (merge spack develop as of 2023/07/10 into jcsda_emc_spack_stack).

**Update:** many serious bugs with this version of spack.

**Note.** The only way to convince spack to use an existing, external `git` was to add `buildable: False` to `package.yaml` **and** using `spack concretize --reuse`.

### Testing

- [x] CI testing
- [x] jedi-bundle testing on AWS Parallel Cluster with Intel: Only the following tests fail, and these are not due to the spack update (yaml validation error in soca):
```
The following tests FAILED:
	1521 - test_soca_forecast_pseudo (Failed)
	1548 - test_soca_hofx_4d_pseudo (Failed)
	1555 - test_soca_3dvarfgat_pseudo (Failed)
```
- [x] There is still a bit of uncertainty of dealing with `_libiconv` vs `_iconv` on macOS with this update, but a working version for Rosetta2 on my macOS gives the following ctest errors for jedi-bundle (the usual/known problems):
```
The following tests FAILED:
	 14 - test_util_signal_trap (Failed)
	336 - saber_test_error_covariance_training_bump_hdiag-nicas_2_1-1 (Failed)
	412 - saber_test_error_covariance_training_bump_hdiag-nicas_2_2-1 (Failed)
	1042 - ufo_test_tier1_test_ufo_qc_variableassignment (Failed)
	1162 - ufo_test_tier1_test_ufo_opr_gnssrorefmetoffice (Failed)
	1166 - ufo_test_tier1_test_ufo_opr_gnssrobendmetoffice_nopseudo (Failed)
	1174 - ufo_test_tier1_test_ufo_opr_groundgnssmetoffice (Failed)
	1227 - ufo_test_tier1_test_ufo_opr_scatwind_neutral_metoffice (Failed)
	1400 - fv3jedi_test_tier1_errorcovariance (Failed)
	1444 - fv3jedi_test_tier1_errorcovariance_bump (Failed)
	1507 - test_soca_errorcovariance (Failed)
Errors while running CTest
Output from these tests are in: /Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/skylab-testing/build-release/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```

Notes from Alex:
 - added commit 27f148fe94302a33db6614b0255d7b624095ec09, which reflects the change in modules.yaml config from blacklist/whitelist to exclude/include.
 - updated py-netcdf4 to work with recent py-numpy


### Applications affected

Potentially all.

### Systems affected

All.

- [x] Hera (@AlexanderRichert-NOAA; tested with [UFS](https://github.com/ulmononian/ufs-weather-model/tree/feature/spack_stack_ue) cpld_control_p8 intel RT)
- [x] Acorn (@AlexanderRichert-NOAA; tested with [UFS](https://github.com/ulmononian/ufs-weather-model/tree/feature/spack_stack_ue) cpld_control_p8 intel RT)
- [x] Gaea (@AlexanderRichert-NOAA; tested with [UFS](https://github.com/ulmononian/ufs-weather-model/tree/feature/spack_stack_ue) control_48 intel _compile only_)
- [x] Cheyenne (@ulmononian; tested with [UFS](https://github.com/ulmononian/ufs-weather-model/tree/feature/spack_stack_ue)  S2SWA configuration _compile only_)
- [x] MacOS (@srherbener)
  - [x] Build error with undefined symbol `_iconv` (#698) has been fixed with commit: [6cc25bd](https://github.com/JCSDA/spack-stack/pull/672/commits/6cc25bd72e5f33094ffceaf8dd624ff93d1d29bb)
  - [x] Numpy crash during ctest: #699
- [x] JEDI (@srherbener)
  - [x] jedi-bundle, Orion (@srherbener)
  - [x] skylab-atm-land, Orion (@srherbener)

### Dependencies

- [x] https://github.com/JCSDA/spack/pull/295

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/667

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
