### PR TITLE
Remove external zlib from Hercules 

### DIFF
--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -164,10 +164,10 @@ packages:
     externals:
     - spec: wget@1.21.1
       prefix: /usr
-  # Need to use external zlib, because of qt dependence on it (otherwise issues with tar command)
-  zlib:
-    externals:
-    - spec: zlib@1.2.13
-      prefix: /apps/spack-managed/gcc-11.3.1/zlib-1.2.13-ltp4c3zzde3zi3gf7x4b7c7nj5ww4i4g
-      modules:
-      - zlib/1.2.13
+  # Do not use external zlib; causes issues with tar due to qt/zlib dependencies
+  # zlib:
+  #   externals:
+  #   - spec: zlib@1.2.13
+  #     prefix: /apps/spack-managed/gcc-11.3.1/zlib-1.2.13-ltp4c3zzde3zi3gf7x4b7c7nj5ww4i4g
+  #     modules:
+  #     - zlib/1.2.13

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -246,7 +246,7 @@ MSU Hercules
 ------------------------------
 
 ecflow
-  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library, using an available ``Qt5`` installation. After loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow`` in ``/work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4``.
+  ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library, using an available ``Qt5`` installation. After loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow`` in ``/work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4``. NOTE: do NOT include the ``Qt5`` module dependency in the ``ecflow`` modulefile, as it is only needed at build time (and causes issues with zlib/tar if the depedency is kept in the modulefile). 
 
 .. code-block:: console
 


### PR DESCRIPTION
### Summary

Using an external zlib was causing tar command failures during stack installations. qt requires this external zlib, and ecflow depends on qt at buildtime. however, ecflow does not need qt at runtime, so we can remove the qt dependency from the ecflow modulefile, and then remove the external zlib from the hercules packages.yaml. doing so allows spack to build zlib and the tar failures are fixed.

### Testing

test stack was built on hercules w/ both external zlib & ecflow moduefile qt module dependency removed. tar commands work during stack install. 

### Applications affected

none known.

### Systems affected

hercules.

### Dependencies

none

### Issue(s) addressed

potentially #609 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
