### PR TITLE
Update gaea c5 intel compiler version

### DIFF
--- a/configs/sites/gaea-c5/compilers.yaml
+++ b/configs/sites/gaea-c5/compilers.yaml
@@ -1,6 +1,6 @@
 compilers:
 - compiler:
-    spec: intel@2022.2.1
+    spec: intel@2023.1.0
     paths:
       cc: cc
       cxx: CC
@@ -10,7 +10,7 @@ compilers:
     operating_system: sles15
     modules:
     - PrgEnv-intel/8.3.3
-    - intel-classic/2022.2.1
+    - intel-classic/2023.1.0
     - craype/2.7.20
     environment:
       prepend_path:

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [intel@2022.2.1]
+    compiler:: [intel@2023.1.0]
     providers:
       mpi:: [cray-mpich@8.1.25]
 

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -7,7 +7,7 @@ packages:
 ### MPI, Python, MKL
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.25%intel@2022.2.1~wrappers
+    - spec: cray-mpich@8.1.25%intel@2023.1.0~wrappers
       prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
       modules:
       - craype-network-ofi

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -460,7 +460,7 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -18,7 +18,7 @@ Ready-to-use spack-stack 1.4.1 installations are available on the following, ful
 +============================================================+===============================+==============================================================================================================+
 | MSU Orion Intel/GNU                                        | Cam Book / Dom Heinzeller     | ``/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                                 |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| MSU Hercules Intel/GNU^*                                   | Cam Book / Dom Heinzeller     | ``/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env``                        |
+| MSU Hercules Intel/GNU^*                                   | Cam Book / Dom Heinzeller     | ``/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-dev-20230717/envs/unified-env``                        |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NASA Discover Intel/GNU                                    | Dom Heinzeller / ???          | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.4.1/envs/unified-env``                                       |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -40,7 +40,7 @@ Ready-to-use spack-stack 1.4.1 installations are available on the following, ful
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA RDHPCS Gaea C4 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/spack-stack-1.4.1-c4/envs/unified-env``                   |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
-| NOAA RDHPCS Gaea C5 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.4.1/envs/unified-env``                   |
+| NOAA RDHPCS Gaea C5 Intel                                  | Dom Heinzeller / ???          | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-dev-20230717/envs/unified-env``                   |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
 | NOAA RDHPCS Hera Intel/GNU                                 | Mark Potts / Dom Heinzeller   | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                          |
 +------------------------------------------------------------+-------------------------------+--------------------------------------------------------------------------------------------------------------+
@@ -116,25 +116,28 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-dev-20230717`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
-   module load stack-intel/2021.7.1
-   module load stack-intel-oneapi-mpi/2021.7.1
+   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-dev-20230717/envs/unified-env/install/modulefiles/Core
+   module load stack-intel/2021.9.0
+   module load stack-intel-oneapi-mpi/2021.9.0
    module load stack-python/3.9.14
    module available
 
-For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-dev-20230717`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-dev-20230717/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/11.3.1
    module load stack-openmpi/4.1.5
    module load stack-python/3.9.14
    module available
+
+.. note::
+   The recent update to ``spack-stack-dev-20230717`` was required on Hercules due to a bug in the Intel compilers used in ``spack-stack-1.4.1``.
 
 .. _Preconfigured_Sites_Discover:
 
@@ -452,7 +455,7 @@ The following is required for building new spack environments and for using spac
 .. code-block:: console
 
    module load PrgEnv-intel/8.3.3
-   module load intel-classic/2022.2.1
+   module load intel-classic/2023.1.0
    module load cray-mpich/8.1.25
    module load python/3.9.12
 
@@ -460,15 +463,19 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-20230717`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
-   module load stack-intel/2022.2.1
+   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-dev-20230717/envs/unified-env/install/modulefiles/Core
+   module load stack-intel/2023.1.0
    module load stack-cray-mpich/8.1.25
    module load stack-python/3.9.12
    module -t available
+
+.. note::
+
+   The recent update to ``spack-stack-dev-20230717`` was required on Gaea C5 due to a bug in the Intel compilers used in ``spack-stack-1.4.1``.
 
 .. note::
    On Gaea C5, running ``module available`` without the option ``-t`` leads to an error: ``/usr/bin/lua5.3: /opt/cray/pe/lmod/lmod/libexec/Spider.lua:568: stack overflow``

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -452,7 +452,7 @@ The following is required for building new spack environments and for using spac
 .. code-block:: console
 
    module load PrgEnv-intel/8.3.3
-   module load intel-classic/2022.2.1
+   module load intel-classic/2023.1.0
    module load cray-mpich/8.1.25
    module load python/3.9.12
 


### PR DESCRIPTION
### Summary

same story as #673, but the gfdl/gaea-c5 translation of the tale.

### Testing

coupled model (s2swa; cpld_control_p8) ran successfully when built/run against intel 2023 test stack built on c5.

### Applications affected

ufs-wm

### Systems affected

gaea c5

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
