### PR TITLE
Update default ip to 4.1.0

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -102,7 +102,7 @@
       version: ['1.14.0']
       variants: +hl +fortran +mpi ~threadsafe +szip
     ip:
-      version: ['3.3.3']
+      version: ['4.1.0']
     ip2:
       version: ['1.1.2']
     jasper:


### PR DESCRIPTION
# This PR needs to include grib-util@1.3.0 (upcoming release) and w3emc@2.10.0

### Summary

This PR updates the default ip version to 4.1.0.

### Testing

IP 4.1.0 has been tested with UPP.

### Applications affected

UPP (UFSWM/GW/SRW)

### Systems affected

All

### Dependencies

none

### Issue(s) addressed

Fixes #661

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
