### PR TITLE
Detect external libiconv and make libiconv and git non-buildable on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/detect_external_libiconv
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/detect_external_libiconv
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/macos.default/packages.yaml
+++ b/configs/sites/macos.default/packages.yaml
@@ -1,10 +1,9 @@
 packages:
-  libiconv:
-    buildable: false
-    externals:
-    - spec: libiconv@1.17
-      prefix: /usr
-  wgrib2:
-    variants: ~openmp
   cairo:
     variants: ~png ~svg
+  git:
+    buildable: false
+  libiconv:
+    buildable: false
+  wgrib2:
+    variants: ~openmp


### PR DESCRIPTION
### Summary

Detect external libiconv and make libiconv and git non-buildable on macOS. This addresses the issue mentioned in https://github.com/JCSDA/spack-stack/pull/672#issuecomment-1677523132.

Making git and libiconv non-buildable on macOS avoids running these commands manually as users.

### Testing

Tested on my macOS laptop.

### Applications affected

n/a

### Systems affected

macOS systems

### Dependencies

- [ ] waiting on https://github.com/JCSDA/spack/pull/301

### Issue(s) addressed

See https://github.com/JCSDA/spack-stack/pull/672#issuecomment-1677523132

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
