### PR TITLE
Add fms@2023.02 to spack, don't make default yet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/fms_2023p02
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/fms_2023p02
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,6 +70,7 @@
       version: ['1.1.0']
     fms:
       version: ['2023.01']
+      # when switching to 2023.02, need to add "+use_fmsio" to variants
       variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
     g2:
       version: ['3.4.5']


### PR DESCRIPTION
### Summary

The purpose of this PR is to update the spack submodule pointer for the changes in https://github.com/JCSDA/spack/pull/302 and to verify that the new version isn't used by default.

### Testing

Installed on my macOS. Testing this version will require updates to the ufs-weather-model and JEDI codes.

### Applications affected

None for now (since the new version isn't used by default - confirmed by testing locally and inspecting CI output).

### Systems affected

n/a

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/302

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/709

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
