### PR TITLE
Update documentation for creating new site configs (mostly macOS)

### DIFF
--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -21,7 +21,7 @@ General
 
 4. Installation of duplicate packages ``ecbuild``, ``hdf5``
 
-   One reason for this is an external ``cmake@3.20`` installation, which confuses the concretizer when building a complex environment such as the ``skylab-dev`` or ```jedi-ufs-all`` environment. For certain packages (and thus their dependencies), a newer version than ``cmake@3.20`` is required, for others ``cmake@3.20`` works, and spack then thinks that it needs to build two identical versions of the same package with different versions of ``cmake``. The solution is to remove any external ``cmake@3.20`` package (and best also earlier versions) in the site config and run the concretization step again. Another reason on Ubuntu 20 is the presence of external ``openssl`` packages, which should be removed before re-running the concretization step.
+   One reason for this is an external ``cmake@3.20`` installation, which confuses the concretizer when building a complex environment such as the ``skylab-dev`` or ```unified-dev`` environment. For certain packages (and thus their dependencies), a newer version than ``cmake@3.20`` is required, for others ``cmake@3.20`` works, and spack then thinks that it needs to build two identical versions of the same package with different versions of ``cmake``. The solution is to remove any external ``cmake@3.20`` package (and best also earlier versions) in the site config and run the concretization step again. Another reason on Ubuntu 20 is the presence of external ``openssl`` packages, which should be removed before re-running the concretization step.
 
 5. Installation of duplicate package ``nco``
 
@@ -111,9 +111,9 @@ macOS
 
    This error occurs on macOS Monterey with ``mpich-3.4.3`` installed via Homebrew when trying to build the jedi bundles that use ``ecbuild``. The reason was that the C compiler flag ``-fgnu89-inline`` from ``/usr/local/Cellar/mpich/3.4.3/lib/pkgconfig/mpich.pc`` was added to the C++ compiler flags by ecbuild. The solution was to set ``CC=mpicc FC=mpif90 CXX=mpicxx`` when calling ``ecbuild`` for those bundles. Note that it is recommended to install ``mpich`` or ``openmpi`` with spack-stack, not with Homebrew.
 
-2. Installation of ``poetry`` using ``pip3`` or test with ``python3`` fails
+2. Installation of ``gdal`` fails with error ``xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance``.
 
-   This can happen when multiple versions of Python were installed with Homebrew and ``pip3``/``python3`` point to different versions. Run ``brew doctor`` and check if there are issues with Python not being properly linked. Follow the instructions given by ``brew``, if applicable.
+   If this happens, install the full ``Xcode`` application in addition to the Apple command line utilities, and switch ``xcode-select`` over with ``sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`` (change the path if you installed Xcode somewhere else).
 
 3. Error ``AttributeError: Can't get attribute 'Mark' on <module 'ruamel.yaml.error' from ...`` when running ``spack install``
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -26,7 +26,7 @@ Miniconda (legacy)
 miniconda can be used to provide a basic version of Python that spack-stack uses to support its Python packages. This is not recommended on configurable systems (user workstations and laptops using GNU compiler) where Python gets installed by spack. But any system using Intel compilers with spack-stack will need an external Python to build ecflow with Python bindings (because ecflow requires a boost serialization function that does **not** work with Intel, a known yet ignored bug), and then both Python and ecflow are presented to spack as external packages. Often, it is possible to use the default (OS) Python if new enough (3.9+), or a module provided by the system administrators. If none of this works, use the following instructions to install a basic Python interpreter using miniconda:
 
 The following is for the example of `miniconda_ver="py39_4.12.0"` (for which `python_ver=3.9.12`) and `platform="MacOSX-x86_64"` or `platform="Linux-x86_64"`
-````
+```
    cd /path/to/top-level/spack-stack/
    mkdir -p miniconda-${python_ver}/src
    cd miniconda-${python_ver}/src
@@ -464,8 +464,6 @@ openmpi
    make check
    make install
 
-
-
 .. _MaintainersSection_WCOSS2:
 
 ------------------------------
@@ -836,53 +834,3 @@ Python packages can be added in various ways:
 
 .. note::
    Users are equally strongly advised to not use ``conda`` or ``miniconda`` in combination with Python modules provided by spack-stack, as well as not installing packages other than ``poetry`` in the basic ``miniconda`` installation for spack-stack (if using such a setup).
-
-.. _MaintainersSection_Directory_Layout:
-
-==============================
-Recommended Directory Layout
-==============================
-
-To support multiple installs it is recommended to use `bootstrap.sh` to setup Miniconda and create a standard directory layout.
-
-After running `bootstrap.sh -p <prefix>` the directory will have the following directories:
-
-* apps - Externally installed pre-requisites such as Miniconda and git-lfs.
-* modulefiles - External modules such as Miniconda that are not tied to Spack.
-* src - Prerequisite and spack-stack sources.
-* envs - Spack environment installation location.
-
-A single checkout of Spack can support multiple environments. To differentiate them spack-stack sources in `src` and corresponding environments in `envs` should be grouped by major version.
-
-For example, major versions of spack-stack v1.x.y should be checked out in the `src/spack-stack` directory as `v1` and each corresponding environment should be installed in `envs/v1`.
-
-.. code-block:: console
-
-   spack-stack
-   ├── apps
-   │   └── miniconda
-   │       └── py39_4.12.0
-   ├── envs
-   │   └── v1
-   │       ├── jedi-ufs-all
-   │       └── skylab-1.0.0
-   ├── modulefiles
-   │   └── miniconda
-   │       └── py39_4.12.0
-   └── src
-      ├── miniconda
-      │   └── py39_4.12.0
-      │       └── Miniconda3-py39_4.12.0-MacOSX-x86_64.sh
-      └── spack-stack
-         └── v1
-               ├── envs
-               │   ├── jedi-ufs-all
-               │   └── skylab-1.0.0
-
-
-The install location can be set from the command line with:
-
-.. code-block:: console
-
-   spack config add "config:install_tree:root:<prefix>/envs/v1/jedi-ufs-all"
-   spack config add "modules:default:roots:lmod:<prefix>/envs/v1/jedi-ufs-all/modulefiles"

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -25,8 +25,10 @@ Miniconda (legacy)
 
 miniconda can be used to provide a basic version of Python that spack-stack uses to support its Python packages. This is not recommended on configurable systems (user workstations and laptops using GNU compiler) where Python gets installed by spack. But any system using Intel compilers with spack-stack will need an external Python to build ecflow with Python bindings (because ecflow requires a boost serialization function that does **not** work with Intel, a known yet ignored bug), and then both Python and ecflow are presented to spack as external packages. Often, it is possible to use the default (OS) Python if new enough (3.9+), or a module provided by the system administrators. If none of this works, use the following instructions to install a basic Python interpreter using miniconda:
 
-The following is for the example of `miniconda_ver="py39_4.12.0"` (for which `python_ver=3.9.12`) and `platform="MacOSX-x86_64"` or `platform="Linux-x86_64"`
-```
+The following is for the example of ``miniconda_ver="py39_4.12.0"`` (for which ``python_ver=3.9.12``) and ``platform="MacOSX-x86_64"`` or ``platform="Linux-x86_64"``
+
+.. code-block:: console
+
    cd /path/to/top-level/spack-stack/
    mkdir -p miniconda-${python_ver}/src
    cd miniconda-${python_ver}/src
@@ -34,7 +36,7 @@ The following is for the example of `miniconda_ver="py39_4.12.0"` (for which `py
    sh Miniconda3-${miniconda_ver}-${platform}.sh -u -b -p /path/to/top-level/spack-stack/miniconda-${python_ver}
    eval "$(/path/to/top-level/spack-stack/miniconda-${python_ver}/bin/conda shell.bash hook)"
    conda install -y -c conda-forge libpython-static
-```
+
 After the successful installation, create modulefile ``/path/to/top-level/spack-stack/modulefiles/miniconda/${python_ver}`` from template ``doc/modulefile_templates/miniconda`` and update ``MINICONDA_PATH`` and the Python version in this file.
 
 ..  _MaintainersSection_Qt5:

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -13,9 +13,9 @@ It is also instructive to peruse the GitHub actions scripts in ``.github/workflo
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
 | Compiler                                  | Versions tested/in use in one or more site configs                   | Spack compiler identifier |
 +===========================================+======================================================================+===========================+
-| Intel classic (icc, icpc, ifort)          | 18.0.5.274 to the latest available version in oneAPI 2022.2.1        | ``intel@``                |
+| Intel classic (icc, icpc, ifort)          | 18.0.5.274 to the latest available version in oneAPI 2023.1.0        | ``intel@``                |
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
-| Intel mixed (icx, icpx, ifort)            | all versions up to latest available version in oneAPI 2022.2.1       | ``intel@``                |
+| Intel mixed (icx, icpx, ifort)            | all versions up to latest available version in oneAPI 2023.1.0       | ``intel@``                |
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
 | GNU (gcc, g++, gfortran)                  | 9.2.0 to 12.2.0 (note: 13.x.y is **not** yet supported)              | ``gcc@``                  |
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
@@ -47,10 +47,7 @@ A lot of binaries (iTerm2 for example) come in a "universal form" meaning they c
 Homebrew notes
 --------------
 
-When running with the Intel architecture, homebrew manages its downloads in ``/usr/local`` (as it has been doing in the past).
-When running with the Arm architecture, homebrew manages its downloads in ``/opt/homebrew``.
-Other than the different prefixes for Arm versus Intel, the paths for all the pieces of a given package are identical.
-This separation allows for both Arm and Intel environments to exist on one machine.
+When running with the Intel architecture, homebrew manages its downloads in ``/usr/local`` (as it has been doing in the past). When running with the Arm architecture, homebrew manages its downloads in ``/opt/homebrew``. Other than the different prefixes for Arm versus Intel, the paths for all the pieces of a given package are identical. This separation allows for both Arm and Intel environments to exist on one machine.
 
 For these instructions we will use the variable ``$HOMEBREW_ROOT`` to hold the prefix where homebrew manages its downloads (according to the architecture being used).
 
@@ -70,7 +67,7 @@ Prerequisites (one-off)
 
 These instructions are meant to be a reference that users can follow to set up their own system. Depending on the user's setup and needs, some steps will differ, some may not be needed and others may be missing. Also, the package versions may change over time.
 
-1. Install Apple's command line utilities
+1. Install Apple's command line utilities.
 
    - Launch the Terminal, found in ``/Applications/Utilities``
 
@@ -79,6 +76,10 @@ These instructions are meant to be a reference that users can follow to set up t
 .. code-block:: console
 
    xcode-select --install
+   sudo xcode-select --switch /Library/Developer/CommandLineTools
+
+.. note::
+   If you encounter build errors for gdal later on in spack-stack (see :numref:`Section %s <KnownIssues>`), you may need to install the full ``Xcode`` application and then switch ``xcode-select`` over with ``sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`` (change the path if you installed Xcode somewhere else).
 
 2. Set up a terminal and environment using the appropriate architecture
 
@@ -167,7 +168,7 @@ These instructions are meant to be a reference that users can follow to set up t
 
 .. code-block:: console
 
-   export PATH="/usr/local/texlive/2022/bin/universal-darwin:$PATH"
+   export PATH="/usr/local/texlive/2023/bin/universal-darwin:$PATH"
 
 This environment enables working with spack and building new software environments, as well as loading modules that are created by spack for building JEDI and UFS software.
 
@@ -186,18 +187,18 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
    source setup.sh
 
-2. Create a pre-configured environment with a default (nearly empty) site config and activate it (optional: decorate bash prompt with environment name; warning: this can scramble the prompt for long lines)
+2. Create a pre-configured environment with a default (nearly empty) site config and activate it (optional: decorate bash prompt with environment name; warning: this can scramble the prompt for long lines). The choice of the template depends on the applications you want to run, see ``configs/templates/`` in the spack-stack repo for the available options. The ``unified-dev`` templates creates the largest of all environments, because it contains everything needed for the NOAA Unified Forecast System, the JCSDA JEDI application, ...
 
 .. code-block:: console
 
-   spack stack create env --site macos.default [--template jedi-ufs-all] --name jedi-ufs.mymacos
-   spack env activate [-p] envs/jedi-ufs.mymacos
+   spack stack create env --site macos.default [--template unified-dev] --name unified-env.mymacos
+   spack env activate [-p] envs/unified-env.mymacos
 
-3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/jedi-ufs.mymacos/site``
+3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mymacos/site``
 
 .. code-block:: console
 
-   export SPACK_SYSTEM_CONFIG_PATH="$PWD/envs/jedi-ufs.mymacos/site"
+   export SPACK_SYSTEM_CONFIG_PATH="$PWD/envs/unified-env.mymacos/site"
 
 4. Find external packages, add to site config's ``packages.yaml``. If an external's bin directory hasn't been added to ``$PATH``, need to prefix command.
 
@@ -247,13 +248,13 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
    definitions:
    - compilers: ['%apple-clang']
 
-9. Edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/jedi-ufs.mymacos/spack.yaml``, etc.
+9. If needed, edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/unified-env.mymacos/spack.yaml``, etc.
 
 .. code-block:: console
 
-   vi envs/jedi-ufs.mymacos/spack.yaml
-   vi envs/jedi-ufs.mymacos/common/*.yaml
-   vi envs/jedi-ufs.mymacos/site/*.yaml
+   vi envs/unified-env.mymacos/spack.yaml
+   vi envs/unified-env.mymacos/common/*.yaml
+   vi envs/unified-env.mymacos/site/*.yaml
 
 10. Process the specs and install
 
@@ -273,7 +274,7 @@ Note that in the unified environment, there may be deliberate duplicates; consul
 
    spack module lmod refresh
 
-12. Create meta-modules for compiler, mpi, python. This will create a meta module at ``envs/jedi-ufs.mymacos/modulefiles/Core``.
+12. Create meta-modules for compiler, mpi, python. This will create a meta module at ``envs/unified-env.mymacos/modulefiles/Core``.
 
 .. code-block:: console
 
@@ -282,7 +283,7 @@ Note that in the unified environment, there may be deliberate duplicates; consul
 .. note::
    Unlike preconfigured environments and linux environments, MacOS users typically need to activate lmod's ``module`` tool within each shell session. This can be done by running ``source $HOMEBREW_ROOT/opt/lmod/init/profile``
 
-13. You now have a spack-stack environment that can be accessed by running ``module use ./envs/jedi-ufs.mymacos/install/modulefiles/Core``. The modules defined here can be loaded to build and run code as described in :numref:`Section %s <UsingSpackEnvironments>`.
+13. You now have a spack-stack environment that can be accessed by running ``module use ./envs/unified-env.mymacos/install/modulefiles/Core``. The modules defined here can be loaded to build and run code as described in :numref:`Section %s <UsingSpackEnvironments>`.
 
 
 ..  _NewSiteConfigs_Linux:
@@ -416,18 +417,18 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    source setup.sh
 
 
-2. Create a pre-configured environment with a default (nearly empty) site config and activate it (optional: decorate bash prompt with environment name; warning: this can scramble the prompt for long lines)
+2. Create a pre-configured environment with a default (nearly empty) site config and activate it (optional: decorate bash prompt with environment name; warning: this can scramble the prompt for long lines). The choice of the template depends on the applications you want to run, see ``configs/templates/`` in the spack-stack repo for the available options. The ``unified-dev`` templates creates the largest of all environments, because it contains everything needed for the NOAA Unified Forecast System, the JCSDA JEDI application, ...
 
 .. code-block:: console
 
-   spack stack create env --site linux.default [--template jedi-ufs-all] --name jedi-ufs.mylinux
-   spack env activate [-p] envs/jedi-ufs.mylinux
+   spack stack create env --site linux.default [--template unified-env-all] --name unified-env.mylinux
+   spack env activate [-p] envs/unified-env.mylinux
 
-3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/jedi-ufs.mylinux/site``
+3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mylinux/site``
 
 .. code-block:: console
 
-   export SPACK_SYSTEM_CONFIG_PATH="$PWD/envs/jedi-ufs.mylinux/site"
+   export SPACK_SYSTEM_CONFIG_PATH="$PWD/envs/unified-env.mylinux/site"
 
 4. Find external packages, add to site config's ``packages.yaml``. If an external's bin directory hasn't been added to ``$PATH``, need to prefix command.
 
@@ -484,7 +485,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   sed -i 's/tcl/lmod/g' envs/jedi-ufs.mylinux/site/modules.yaml
+   sed -i 's/tcl/lmod/g' envs/unified-env.mylinux/site/modules.yaml
 
 10. If applicable (depends on the environment), edit the main config file for the environment and adjust the compiler matrix to match the compilers for Linux, as above:
 
@@ -493,16 +494,16 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    definitions:
    - compilers: ['%gcc']
 
-11. Edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/jedi-ufs.mylinux/spack.yaml``, etc.
+11. Edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/unified-env.mylinux/spack.yaml``, etc.
 
 .. warning::
-   **Important:** Remove any external ``cmake@3.20`` package from ``envs/jedi-ufs.mylinux/site/packages.yaml``. It is in fact recommended to remove all versions of ``cmake`` up to ``3.20``. Further, on Red Hat/CentOS, remove any external curl that might have been found.
+   **Important:** Remove any external ``cmake@3.20`` package from ``envs/unified-env.mylinux/site/packages.yaml``. It is in fact recommended to remove all versions of ``cmake`` up to ``3.20``. Further, on Red Hat/CentOS, remove any external curl that might have been found.
 
 .. code-block:: console
 
-   vi envs/jedi-ufs.mylinux/spack.yaml
-   vi envs/jedi-ufs.mylinux/common/*.yaml
-   vi envs/jedi-ufs.mylinux/site/*.yaml
+   vi envs/unified-env.mylinux/spack.yaml
+   vi envs/unified-env.mylinux/common/*.yaml
+   vi envs/unified-env.mylinux/site/*.yaml
 
 12. Process the specs and install
 
@@ -528,4 +529,4 @@ Note that in the unified environment, there may be deliberate duplicates; consul
 
    spack stack setup-meta-modules
 
-15. You now have a spack-stack environment that can be accessed by running ``module use ./envs/jedi-ufs.mymacos/install/modulefiles/Core``. The modules defined here can be loaded to build and run code as described in :numref:`Section %s <UsingSpackEnvironments>`.
+15. You now have a spack-stack environment that can be accessed by running ``module use ./envs/unified-env.mymacos/install/modulefiles/Core``. The modules defined here can be loaded to build and run code as described in :numref:`Section %s <UsingSpackEnvironments>`.


### PR DESCRIPTION
### Summary

- Update `doc/source/KnownIssues.rst` and `doc/source/NewSiteConfigs.rst` to address a `gdal` build error on macOS and fix a few inconsistencies in instructions for generating new site configs
- Fix formatting in `doc/source/MaintainerSection.rst` and remove outdated (and now redundant, because in project charter) information on directory layouts.

Rendered documentation can be seen here: https://spack-stack--716.org.readthedocs.build/en/716/MaintainersSection.html

### Testing

The updated instructions were used to successfully install spack-stack on ...'s new macOS laptop.

### Applications affected

n/a

### Systems affected

macOS

### Dependencies

n/a

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/717

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
