### PR TITLE
Various version updates for spack-stack-1.5.0 (parallelio, fms, met, metplus, eckit, fckit, fiat, ecmwf-atlas, scotch), set boost C++ std to C++-17

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -92,6 +92,7 @@ jobs:
           spack config add "packages:all:compiler:[apple-clang@14.0.0]"
           sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
+          # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm
 

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -85,6 +85,7 @@ jobs:
           spack config add "packages:all:compiler:[apple-clang@14.0.0]"
           sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
+          # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm
 

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -126,6 +126,7 @@ jobs:
           # Switch from default tcl to lmod modules
           sed -i "s/tcl/lmod/g" $ENVDIR/site/modules.yaml
 
+          # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.intel-2022.1.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2022.1.0 -i fms -i crtm
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/version_updates_20230817
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/version_updates_20230817
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -126,10 +126,10 @@
       version: ['2.35.2']
       variants: ~shared
     met:
-      version: ['11.0.2']
+      version: ['11.1.0']
       variants: +python +grib2
     metplus:
-      version: ['5.0.1']
+      version: ['5.1.0']
     mpich:
       variants: ~hwloc +two_level_namespace
     nco:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -18,7 +18,7 @@
     # Attention - when updating also check orion site config
     boost:
       version: ['1.78.0']
-      variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden
+      variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=17 visibility=hidden
     bufr:
       version: ['12.0.0']
       variants: +python

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -121,7 +121,7 @@
     libyaml:
       version: ['0.2.5']
     mapl:
-      # 2.35.2 goes with esmf@8.4.1
+      # 2.35.2 goes with esmf@8.4.2
       version: ['2.35.2']
       variants: ~shared
     met:
@@ -171,7 +171,7 @@
     p4est:
       version: ['2.8']
     parallelio:
-      version: ['2.5.9']
+      version: ['2.5.10']
       variants: +pnetcdf
     parallel-netcdf:
       version: ['1.12.2']

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -250,7 +250,7 @@
     qt:
       version: ['5.15.3']
     scotch:
-      version: ['7.0.3']
+      version: ['7.0.4']
       variants: +mpi+metis~shared~threads~mpi_thread+noarch
     sfcio:
       version: ['1.4.1']

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -69,9 +69,10 @@
     fiat:
       version: ['1.1.0']
     fms:
-      version: ['2023.01']
-      # when switching to 2023.02, need to add "+use_fmsio" to variants
-      variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
+      #version: ['2023.01']
+      #variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
+      version: ['2023.02']
+      variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release +use_fmsio
     g2:
       version: ['3.4.5']
     g2c:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -42,10 +42,10 @@
       version: ['5.8.4']
       variants: +ui
     eckit:
-      version: ['1.23.1']
+      version: ['1.24.4']
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: ['0.33.0']
+      version: ['0.34.0']
       variants: +fckit +trans
     ectrans:
       version: ['1.2.0']
@@ -62,12 +62,12 @@
       version: ['8.4.2']
       variants: ~xerces ~pnetcdf snapshot=none ~shared +external-parallelio
     fckit:
-      version: ['0.10.1']
+      version: ['0.11.0']
       variants: +eckit
     fftw:
       version: ['3.3.10']
     fiat:
-      version: ['1.1.0']
+      version: ['1.2.0']
     fms:
       #version: ['2023.01']
       #variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -31,7 +31,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
   specs: [base-env@1.0.0,
     bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
     eckit@1.23.1, ecmwf-atlas@0.33.0 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
-    fckit@0.10.1, fms@2023.01, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
+    fckit@0.10.1, fms@2023.02, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,8 +6,8 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.1, ecmwf-atlas@0.33.0 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
-    fckit@0.10.1, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
+    eckit@1.24.4, ecmwf-atlas@0.34.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
@@ -30,8 +30,8 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0,
     bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.23.1, ecmwf-atlas@0.33.0 +trans ~fftw, ectrans@1.2.0 ~fftw, eigen@3.4.0,
-    fckit@0.10.1, fms@2023.02, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
+    eckit@1.24.4, ecmwf-atlas@0.34.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    fckit@0.11.0, fms@2023.02, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -2,7 +2,7 @@
 
 To avoid hardcoding specs in the generic container recipes, we keep the specs list empty (`specs: []`) and manually add the specs for the particular spack-stack release and application as listed below, *after* running `spack stack create ctr`.
 
-### spack-stack-1.4.1 / skylab-5.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
+### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
@@ -11,23 +11,19 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
-    parallelio@2.5.9, parallel-netcdf@1.12.2, py-eccodes@1.4.2, py-f90nml@1.4.3,
+    parallelio@2.5.10, parallel-netcdf@1.12.2, py-eccodes@1.4.2, py-f90nml@1.4.3,
     py-gitpython@3.1.27, py-h5py@3.7.0, py-numpy@1.22.3,
     py-pandas@1.4.0, py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
-    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6,
+    sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, nco@5.0.6, esmf@8.4.2, mapl@2.35.2,
     yafyaml@0.5.1, zlib@1.2.13, odc@1.4.6, shumlib@macos_clang_linux_intel_port]
     # Don't build CRTM by default so that it gets built in the JEDI bundles:
     # crtm@v2.4.1-jedi
-    # Don't build ESMF and MAPL for now:
-    # https://github.com/JCSDA-internal/MPAS-Model/issues/38
-    # https://github.com/jcsda/spack-stack/issues/326
-    # jedi-ufs-env@1.0.0, esmf@8.4.2, mapl@2.35.2
     # Comment out for now until build problems are solved
     # https://github.com/jcsda/spack-stack/issues/522
     # py-mysql-connector-python@8.0.32
 ```
 
-### spack-stack-1.4.1 / ufs-weather-model-x.y.z containers for ufs-weather-model as of July 5, 2023
+### spack-stack-1.5.0 / ufs-weather-model-x.y.z containers for ufs-weather-model as of July 5, 2023
 
 **Note. This is not yet working correctly, some libraries are missing. Please do not use yet! Also, if using the clang-mpich container, need to disable openmp for fms, not clear how to do this cleanly.**
 
@@ -39,7 +35,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
-    parallelio@2.5.9, parallel-netcdf@1.12.2, py-eccodes@1.4.2, py-f90nml@1.4.3,
+    parallelio@2.5.10, parallel-netcdf@1.12.2, py-eccodes@1.4.2, py-f90nml@1.4.3,
     py-gitpython@3.1.27, py-h5py@3.7.0, py-numpy@1.22.3, py-pandas@1.4.0,
     py-pip, py-pyyaml@6.0, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3emc@2.9.2, w3nco@2.4.1, nco@5.0.6, esmf@8.4.2, mapl@2.35.2,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -31,7 +31,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
   specs: [base-env@1.0.0,
     bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
     eckit@1.24.4, ecmwf-atlas@0.34.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
-    fckit@0.11.0, fms@2023.02, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
+    fckit@0.11.0, fms@2023.01, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.2, hdf@4.2.15, hdf5@1.14.1-2, ip@3.3.3, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,

--- a/configs/sites/aws-pcluster/README.md
+++ b/configs/sites/aws-pcluster/README.md
@@ -299,7 +299,7 @@ echo "      prefix: /usr" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 echo "  boost:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 echo "    buildable: False" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 echo "    externals:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
-echo "    - spec: boost@1.71.0 +atomic +chrono +date_time +exception +filesystem +graph +iostreams +locale +log +math +mpi +numpy +pic +program_options +python +random +regex +serialization +signals +system +test +thread +timer ~wave cxxstd=14 visibility=hidden" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
+echo "    - spec: boost@1.71.0 +atomic +chrono +date_time +exception +filesystem +graph +iostreams +locale +log +math +mpi +numpy +pic +program_options +python +random +regex +serialization +signals +system +test +thread +timer ~wave cxxstd=17 visibility=hidden" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 echo "      prefix: /usr" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
 # Add external ecflow

--- a/configs/sites/aws-pcluster/packages.yaml
+++ b/configs/sites/aws-pcluster/packages.yaml
@@ -50,7 +50,7 @@ packages:
   boost:
     buildable: False
     externals:
-    - spec: boost@1.71.0 +atomic +chrono +date_time +exception +filesystem +graph +iostreams +locale +log +math +mpi +numpy +pic +program_options +python +random +regex +serialization +signals +system +test +thread +timer +wave cxxstd=14 visibility=hidden
+    - spec: boost@1.71.0 +atomic +chrono +date_time +exception +filesystem +graph +iostreams +locale +log +math +mpi +numpy +pic +program_options +python +random +regex +serialization +signals +system +test +thread +timer +wave cxxstd=17 visibility=hidden
       prefix: /usr
   # Don't use external cmake, this confuses the spack concretizer
   # leading to duplicate packages being installed.

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -16,10 +16,13 @@ spack:
       - jedi-um-env
       - soca-env
 
-      # Additional fms tags
+      # Various fms tags (list all to avoid duplicate packages)
+      - fms@release-jcsda
+      - fms@2023.01
       - fms@2023.02
 
-      # Additional crtm tags
+      # Various crtm tags (list all to avoid duplicate packages)
+      - crtm@2.4.0
       - crtm@v2.4-jedi.2
       - crtm@v2.4.1-jedi
 

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -16,6 +16,9 @@ spack:
       - jedi-um-env
       - soca-env
 
+      # Additional fms tags
+      - fms@2023.02
+
       # Additional crtm tags
       - crtm@v2.4-jedi.2
       - crtm@v2.4.1-jedi

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -25,10 +25,13 @@ spack:
       #- upp-env
       #- ww3-env
 
-      # Additional fms tags
+      # Various fms tags (list all to avoid duplicate packages)
+      - fms@release-jcsda
+      - fms@2023.01
       - fms@2023.02
 
-      # Additional crtm tags
+      # Various crtm tags (list all to avoid duplicate packages)
+      - crtm@2.4.0
       - crtm@v2.4-jedi.2
       - crtm@v2.4.1-jedi
 

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -25,10 +25,6 @@ spack:
       #- upp-env
       #- ww3-env
 
-      # Additional esmf/mapl tags
-      #- esmf@8.4.2~debug+external-parallelio
-      #- mapl@2.35.2~debug ^esmf@8.4.2~debug+external-parallelio
-
       # Additional crtm tags
       - crtm@v2.4-jedi.2
       - crtm@v2.4.1-jedi

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -25,6 +25,9 @@ spack:
       #- upp-env
       #- ww3-env
 
+      # Additional fms tags
+      - fms@2023.02
+
       # Additional crtm tags
       - crtm@v2.4-jedi.2
       - crtm@v2.4.1-jedi


### PR DESCRIPTION
### Note - to be merged as merge commit, not as squashed commit

I made sure that each commit was for a specific package only. Merging this as a merge commit allows us to identify the individual commits.

### Summary

Various version updates for spack-stack release 1.5.0 (all separate commits):
- Update parallelio to 2.5.10 in `configs/common/packages.yaml` and `configs/containers/README.md`
- Update fms to 2023.02 in `configs/common/packages.yaml` and `configs/containers/README.md` (in the latter case for UFS only for now, before JEDI can use something else than `fms@release-jcsda`, several PRs need to be merged). 
- **Note** that this does not make `fms@2023.02` the default version for `ufs-weather-model-env`, `ufs-srw-app-env` and `jedi-ufs-env`, because `fms@2023.01` is hardcoded in these virtual packages. Therefore, I added `fms@2023.02` manually to the `unified-dev` and `skykab-dev` templates for now. This led to duplicate packages being concretized. I found that by adding all versions of fms and crtm explicitly in the skylab-dev and unified-dev specs, these duplicates could be avoided (a spack concretizer bug?)
- Update default versions for met and metplus in `configs/common/packages.yaml`
- Update default versions for eckit, fckit, fiat, ecmwf-atlas in `configs/common/packages.yaml` and `configs/containers/README.md`
- Update default versions for scotch in `configs/common/packages.yaml`

### Testing

- Testing on Dom's macOS M1/`apple-clang@13.1.6`/`openmpi@4.1.5` with JEDI/Skylab:
    - jedi-bundle develop builds, there are a few test failures that are summarized [here](https://docs.google.com/spreadsheets/d/1JpKMHIwix7Izn127fITDrf_6rzyYbTWIlNXQ-RJ2-ZI/edit#gid=0) (mostly reference value mismatches)
    - JEDI Skylab experiments with jedi-bundle:
        - Experiment id: 1dda57 / Input YAML file: `qg-fullDA.yaml`
        - Experiment id: 7d1173 / Input YAML file: `l95-fullDA.yaml`
        - Experiment id: 19e55b and 50f39d / Input YAML file: `gfs-3dfgat-c12.yaml`
        - Experiment id: 271a6a / Input YAML file: `skylab-atm-land-small.yaml`
    - ufs-bundle builds, and the usual UFS tests run (`fv3jedi_test_tier1_model_ufs_warmstart`, `fv3jedi_test_tier1_forecast_ufs_warmstart`)
- Testing on AWS Parallel Cluster hpc6a.48xlarge (Ubuntu 20/`intel@2021.6.0`/`intel-oneapi-mpi`) with JEDI/Skylab:
    - jedi-bundle develop builds, **ctests still running**
    - **Still todo run some Skylab experiments** (not necessary to run all of them)
    - JEDI Skylab experiments with jedi-bundle:
        - Experiment id: 83de8c / Input YAML file: qg-fullDA.yaml
        - Experiment id: 9a983a / Input YAML file: l95-fullDA.yaml
        - Experiment id: 24ef0e / Input YAML file: skylab-atm-land-small.yaml
    - ufs-bundle builds, and the usual UFS tests run (`fv3jedi_test_tier1_model_ufs_warmstart`, `fv3jedi_test_tier1_forecast_ufs_warmstart`)
    - @cmgas Is there a way to run the Skylab UFS tests on this parallel cluster?

### Applications affected

All.

### Systems affected

All.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack-stack/pull/729
- [x] waiting on https://github.com/JCSDA/spack/pull/304

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/706
Closes https://github.com/JCSDA/spack-stack/issues/709
Closes https://github.com/JCSDA/spack-stack/issues/591
Closes https://github.com/JCSDA/spack-stack/issues/727
Closes https://github.com/JCSDA/spack-stack/issues/646
Closes https://github.com/JCSDA-internal/skylab/issues/65
Closes https://github.com/JCSDA/spack-stack/issues/686
Closes https://github.com/JCSDA/spack-stack/issues/627
Working towards https://github.com/JCSDA/spack-stack/issues/702 (need to remove `ecmwf-atlas` from automatically loaded modules for `jedi-base-env` module, but still build in `unified-dev`/`skylab-dev` templates)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
