### PR TITLE
Adding myst-parser to jedi-tools-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/ashley314/spack
+  branch = feature/add_sphinx
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/ashley314/spack
-  branch = feature/add_sphinx
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

Update submodule commit hash to point to the feature branch for https://github.com/JCSDA/spack/pull/305

### Testing

- CI testing
- @ashley314 and I both manually tested on our Mac. This covers intel base and arm based macs. https://github.com/JCSDA/spack/pull/305 worked successfully on both platforms.

### Applications affected

jedi-tools-env (this update is for building the html in the jedi-docs repo)

### Systems affected

Any platform where jedi-docs is being used - primarily mac laptops

### Dependencies

- [x] merge after https://github.com/JCSDA/spack/pull/305

### Issue(s) addressed

Fixes #234

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
