### PR TITLE
ESMF & MADIS tweaks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-#  url = https://github.com/jcsda/spack
-#  branch = jcsda_emc_spack_stack
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = madis_argmismatch
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+#  url = https://github.com/jcsda/spack
+#  branch = jcsda_emc_spack_stack
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = madis_argmismatch
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -123,6 +123,10 @@ modules:
             'YAML_DIR': '{prefix}'
             'YAML_LIB': '{prefix}/lib'
             'YAML_INC': '{prefix}/include'
+      madis:
+        environment:
+          set:
+            'MADIS_ROOT': '{prefix}'
       mapl:
         suffixes:
           ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'
@@ -368,6 +372,10 @@ modules:
             'YAML_DIR': '{prefix}'
             'YAML_LIB': '{prefix}/lib'
             'YAML_INC': '{prefix}/include'
+      madis:
+        environment:
+          set:
+            'MADIS_ROOT': '{prefix}'
       mapl:
         suffixes:
           ^esmf@8.2.0~debug snapshot=none: 'esmf-8.2.0'

--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -158,6 +158,10 @@ modules:
             'BACIO_INC8': '{prefix}/include_8'
             'BACIO_LIB4': '{prefix}/lib/libbacio_4.a'
             'BACIO_LIB8': '{prefix}/lib/libbacio_8.a'
+      bufr:
+        environment:
+          set:
+            'BUFR_ROOT': '{prefix}'
       crtm:
         environment:
           set:
@@ -407,6 +411,10 @@ modules:
             'BACIO_INC8': '{prefix}/include_8'
             'BACIO_LIB4': '{prefix}/lib/libbacio_4.a'
             'BACIO_LIB8': '{prefix}/lib/libbacio_8.a'
+      bufr:
+        environment:
+          set:
+            'BUFR_ROOT': '{prefix}'
       crtm:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -58,6 +58,8 @@
     esmf:
       version: ['8.4.2']
       variants: ~xerces ~pnetcdf snapshot=none ~shared +external-parallelio
+      require:
+        - any_of: ['%intel fflags="-fp-model precise" cxxflags="-fp-model precise"', '@:']
     fckit:
       version: ['0.11.0']
       variants: +eckit

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -11,8 +11,7 @@
         - craype-network-ofi
         - cray-mpich/8.1.9
     esmf:
-      version: ['8.3.0b09']
-      variants: ~xerces ~pnetcdf +pio ~shared snapshot=b09 esmf_os=Linux esmf_comm=mpich3
+      variants: esmf_os=Linux esmf_comm=mpich3
     git:
       buildable: false
       externals:

--- a/configs/sites/hercules/compilers.yaml
+++ b/configs/sites/hercules/compilers.yaml
@@ -6,9 +6,7 @@ compilers:
       cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icpc
       f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
       fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
-    flags:
-      cflags: -diag-disable=10441
-      cxxflags: -diag-disable=10441
+    flags: {}
     operating_system: rocky9
     target: x86_64
     modules:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -35,6 +35,9 @@ spack:
       - crtm@v2.4-jedi.2
       - crtm@v2.4.1-jedi
 
+      # MADIS for WCOSS2 decoders.
+      - madis@4.5
+
   specs:
     - matrix:
       - [$packages]


### PR DESCRIPTION
### Summary

This PR adds the '-fp-model precise' flags for esmf%intel in the common packages.yaml, adds madis to the unified env (+sets MADIS_ROOT in modules), and deletes some old and unneeded esmf variant settings from the acorn packages.yaml.

### Testing

Testing in progress. ESMF concretizes correctly on Acorn.

### Applications affected

Everything that uses ESMF

### Systems affected

All, esp. Acorn

### Dependencies
Merge https://github.com/JCSDA/spack/pull/311 first

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
