### PR TITLE
Fix typo in NewSiteConfigs.rst Linux section

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -438,7 +438,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   spack stack create env --site linux.default [--template unified-env-all] --name unified-env.mylinux
+   spack stack create env --site linux.default [--template unified-dev] --name unified-env.mylinux
    spack env activate [-p] envs/unified-env.mylinux
 
 3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mylinux/site``


### PR DESCRIPTION
### Summary

Replace template `unified-env-all` with `unified-dev` in `NewSiteConfigs.rst`, section Linux.

### Testing

n/a (doc only)

### Applications affected

n/a (doc only)

### Systems affected

n/a (doc only)

### Dependencies

n/a

### Issue(s) addressed

Part of https://github.com/JCSDA/spack-stack/issues/746

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
