### PR TITLE
Bug fix for ESMF: extra compile options for Intel

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -59,7 +59,12 @@
       version: ['8.4.2']
       variants: ~xerces ~pnetcdf snapshot=none ~shared +external-parallelio
       require:
-        - any_of: ['%intel fflags="-fp-model precise" cxxflags="-fp-model precise"', '@:']
+        - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
+          when: "%intel"
+          message: "Extra ESMF compile options for Intel"
+        - any_of: ['']
+          when: "%gcc"
+          message: "Extra ESMF compile options for GCC"
     fckit:
       version: ['0.11.0']
       variants: +eckit


### PR DESCRIPTION
### Summary

Follow up to PR #743 (see comment there for more information)

### Testing

Tested on AWS parallelcluster (which has both GNU and Intel)

### Applications affected

n/a

### Systems affected

All

### Dependencies

n/a

### Issue(s) addressed

n/a (see #743)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
