### PR TITLE
Enable variant `png` for eccodes

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -38,6 +38,7 @@
       version: ['3.7.2']
     eccodes:
       version: ['2.27.0']
+      variants: +png
     ecflow:
       version: ['5.8.4']
       variants: +ui


### PR DESCRIPTION
### Summary

Simple change - enable variant `png` for eccodes. Required by https://github.com/JCSDA/spack-stack/issues/678

### Testing

I tested this on Orion. The `unified-dev` environment and I think also the `skylab-dev` environment) already provide the necessary dependencies. I built a test environment for @gthompsnJCSDA and he was able to run his code.

We should check the CI output that variant `png` is indeed enabled for `eccodes` and that the package is built from source (because the hash changes, i.e. the buildcache can't be used; same for `py-eccodes`).

### Applications affected

Potentially all JEDI applications, but since this is only enabling an additional capability in `eccodes`, I don't expect anything to break as long as it builds.

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/678

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
