### PR TITLE
setup.sh, doco changes

### DIFF
--- a/doc/source/AddingTestPackages.rst
+++ b/doc/source/AddingTestPackages.rst
@@ -13,8 +13,8 @@ To install in an additional environment within an official spack-stack space, si
     cd envs/netcdf-test
     spack env activate .
     spack add ufs-weather-model-env%intel ^netcdf-c@5.0.0
-    spack concretize | tee log.concretize
-    spack install | tee log.install
+    spack concretize 2>&1 | tee log.concretize
+    spack install 2>&1 | tee log.install
     spack module lmod refresh --upstream-modules
     spack stack setup-meta-modules
 

--- a/doc/source/CreatingEnvironments.rst
+++ b/doc/source/CreatingEnvironments.rst
@@ -5,7 +5,7 @@ Creating and installing new environments
 
 The following instructions are a simplified version of the instructions found in :numref:`Sections %s <NewSiteConfigs_macOS>` and :numref:`%s <NewSiteConfigs_Linux>`, and should work for systems where spack-stack already has a site configuration, or where minimal configuration is necessary. For more detailed instructions, including how to generate new site configurations and more details of when and how to use external packages, see :numref:`Sections %s <NewSiteConfigs_macOS>` and :numref:`%s <NewSiteConfigs_Linux>`. To chain a new Spack environment to an existing one, such as to test a new package version based on dependencies already installed in the upstream environment, see :numref:`%s <Add_Test_Packages>`.
 
-Note that items in "<item>" should be replaced with the appropriate values (site names, etc.). "<site name>" and "<template name>" must match the names of directories found under 'configs/sites/' and 'configs/templates/', respectively; <environment name> is a user-chosen name for the Spack environment. <path to spack-stack directory> is the root directory created by cloning the spack-stack GitHub repository, which contains configs/, doc/, setup.sh, util/, etc.
+Note that items in "<>" should be replaced with the appropriate values (site names, etc.). *<site name>* and *<template name>* must match the names of directories found under 'configs/sites/' and 'configs/templates/', respectively; *<environment name>* is a user-chosen name for the Spack environment. *<path to spack-stack directory>* is the root directory created by cloning the spack-stack GitHub repository, which contains 'configs/', 'doc/', 'setup.sh', 'util/', etc.
 
 .. code-block:: console
 

--- a/doc/source/CreatingEnvironments.rst
+++ b/doc/source/CreatingEnvironments.rst
@@ -5,7 +5,7 @@ Creating and installing new environments
 
 The following instructions are a simplified version of the instructions found in :numref:`Sections %s <NewSiteConfigs_macOS>` and :numref:`%s <NewSiteConfigs_Linux>`, and should work for systems where spack-stack already has a site configuration, or where minimal configuration is necessary. For more detailed instructions, including how to generate new site configurations and more details of when and how to use external packages, see :numref:`Sections %s <NewSiteConfigs_macOS>` and :numref:`%s <NewSiteConfigs_Linux>`. To chain a new Spack environment to an existing one, such as to test a new package version based on dependencies already installed in the upstream environment, see :numref:`%s <Add_Test_Packages>`.
 
-Note that items in "<>" should be replaced with the appropriate values (site names, etc.). *<site name>* and *<template name>* must match the names of directories found under 'configs/sites/' and 'configs/templates/', respectively; *<environment name>* is a user-chosen name for the Spack environment. *<path to spack-stack directory>* is the root directory created by cloning the spack-stack GitHub repository, which contains 'configs/', 'doc/', 'setup.sh', 'util/', etc.
+Note that items in "<>" should be replaced with the appropriate values (site names, etc.), and items in '[]' are optional. *<site name>* and *<template name>* must match the names of directories found under 'configs/sites/' and 'configs/templates/', respectively; *<environment name>* is a user-chosen name for the Spack environment. *<path to spack-stack directory>* is the root directory created by cloning the spack-stack GitHub repository, which contains 'configs/', 'doc/', 'setup.sh', 'util/', etc.
 
 .. code-block:: console
 

--- a/doc/source/CreatingEnvironments.rst
+++ b/doc/source/CreatingEnvironments.rst
@@ -1,0 +1,33 @@
+.. _CreatingEnvironment:
+
+Creating and installing new environments
+****************************************
+
+The following instructions are a simplified version of the instructions found in :numref:`Sections %s <NewSiteConfigs_macOS>` and :numref:`%s <NewSiteConfigs_Linux>`, and should work for systems where spack-stack already has a site configuration, or where minimal configuration is necessary. For more detailed instructions, including how to generate new site configurations and more details of when and how to use external packages, see :numref:`Sections %s <NewSiteConfigs_macOS>` and :numref:`%s <NewSiteConfigs_Linux>`. To chain a new Spack environment to an existing one, such as to test a new package version based on dependencies already installed in the upstream environment, see :numref:`%s <Add_Test_Packages>`.
+
+Note that items in "<item>" should be replaced with the appropriate values (site names, etc.). "<site name>" and "<template name>" must match the names of directories found under 'configs/sites/' and 'configs/templates/', respectively; <environment name> is a user-chosen name for the Spack environment. <path to spack-stack directory> is the root directory created by cloning the spack-stack GitHub repository, which contains configs/, doc/, setup.sh, util/, etc.
+
+.. code-block:: console
+
+   # To generate a new spack-stack directory structure, run 'git clone --recurse-submodules https://github.com/JCSDA/spack-stack',
+   # optionally with, e.g., '-b release/1.4.1' to specify the version
+
+   . <path to spack-stack directory>/setup.sh
+
+   spack stack create env --site <site name> --template <template name> --name <environment name>
+
+   cd ${SPACK_STACK_DIR}/envs/<environment name>/
+
+   spack env activate .
+
+   # If not using an existing site configuration, you may wish to modify config files and/or populate them using commands
+   # such as 'spack external find' and 'spack compiler find'.
+   # See https://spack-tutorial.readthedocs.io/en/latest/tutorial_configuration.html
+
+   spack concretize |& tee log.concretize
+
+   spack install [--verbose] [--fail-fast] |& tee log.install
+
+   spack module lmod refresh
+
+   spack stack setup-meta-modules

--- a/doc/source/CreatingEnvironments.rst
+++ b/doc/source/CreatingEnvironments.rst
@@ -24,9 +24,9 @@ Note that items in "<>" should be replaced with the appropriate values (site nam
    # such as 'spack external find' and 'spack compiler find'.
    # See https://spack-tutorial.readthedocs.io/en/latest/tutorial_configuration.html
 
-   spack concretize |& tee log.concretize
+   spack concretize 2>&1 | tee log.concretize
 
-   spack install [--verbose] [--fail-fast] |& tee log.install
+   spack install [--verbose] [--fail-fast] 2>&1 | tee log.install
 
    spack module lmod refresh
 

--- a/doc/source/Environments.rst
+++ b/doc/source/Environments.rst
@@ -29,7 +29,8 @@ Environments can be constructed in two ways in spack-stack:
 
        spack stack create env --template=skylab-1.0.0
        ...
-       spack env activate envs/env-name
+       cd envs/env-name
+       spack env activate .
        ...
        spack add jedi-tools-env@1.0.0
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -384,7 +384,7 @@ ecflow
 mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31``.
 
-.. _MaintainersSection_Narwhal:
+.. _MaintainersSection_Nautilus:
 
 ------------------------------
 NAVY HPCMP Nautilus
@@ -451,6 +451,8 @@ mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/glade/work/jedipara/cheyenne/spack-stack/mysql-8.0.31``.
 
 openmpi
+
+.. code-block:: console
 
     module purge
     export LMOD_TMOD_FIND_FIRST=yes
@@ -571,7 +573,7 @@ ecflow
 mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/lustre/f2/pdata/esrl/gsd/spack-stack/mysql-8.0.31``.
 
-.. _MaintainersSection_Gaea:
+.. _MaintainersSection_GaeaC5:
 
 ------------------------------
 NOAA RDHPCS Gaea C5

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -764,10 +764,11 @@ Since all spack-stack installations are based on environments, we only cover spa
 4. If not already included in the environment (e.g. from the spack-stack site config), add the mirror:
 
 .. code-block:: console
+
    spack mirror list
    spack mirror add local-source file:///path/to/spack-source
 
-   The newly created local mirror should be listed at the top, which means that spack will search this directory first.
+The newly created local mirror should be listed at the top, which means that spack will search this directory first.
 
 7. Proceed with the installation as usual.
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -789,7 +789,8 @@ The procedure is similar to using spack mirrors for local reuse, but a few addit
 .. code-block:: console
 
    spack env create air_gapped_mirror_env spack.lock
-   spack env activate air_gapped_mirror_env
+   cd envs/air_gapped_mirror_env/
+   spack env activate .
    spack mirror create -a -d ./mirror/ 
 
 5. On the air-gapped system: Copy the directory from the system with internet access to the local destination for the spack mirror. It is recommended to use ``rsync`` to avoid deleting existing packages, if updating an existing mirror on the air-gapped system. For example, to use ``rsync`` to copy the mirror directory from the machine with full internet access to the air-gapped system (with the ``rsync`` initiated from the air-gapped system):

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -451,7 +451,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   spack external find --scope system # use '--exclude' for troublesome packages like bison@:3.3, openssl@1.1.1
+   spack external find --scope system # use '--exclude' for troublesome packages like bison@:3.3, openssl@1.1.1, and cmake 3.20 and earlier
    spack external find --scope system perl
    spack external find --scope system wget
    spack external find --scope system mysql
@@ -514,7 +514,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 11. Edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/unified-env.mylinux/spack.yaml``, etc.
 
 .. warning::
-   Remove any external ``cmake@3.20`` package from ``envs/unified-env.mylinux/site/packages.yaml``. It is in fact recommended to remove all versions of ``cmake`` up to ``3.20``. Further, on Red Hat/CentOS, remove any external curl that might have been found.
+   Remove any external ``cmake`` package version 3.20 or earlier from ``envs/unified-env.mylinux/site/packages.yaml`` (or use add ``--exclude cmake`` to the ``spack external find`` command). Further, on Red Hat/CentOS, remove any external ``curl`` that might have been found.
 
 .. code-block:: console
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -189,7 +189,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. code-block:: console
 
-   git clone --recursive https://github.com/jcsda/spack-stack.git
+   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -427,7 +427,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   git clone --recursive https://github.com/jcsda/spack-stack.git
+   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -514,7 +514,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 11. Edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/unified-env.mylinux/spack.yaml``, etc.
 
 .. warning::
-   **Important:** Remove any external ``cmake@3.20`` package from ``envs/unified-env.mylinux/site/packages.yaml``. It is in fact recommended to remove all versions of ``cmake`` up to ``3.20``. Further, on Red Hat/CentOS, remove any external curl that might have been found.
+   Remove any external ``cmake@3.20`` package from ``envs/unified-env.mylinux/site/packages.yaml``. It is in fact recommended to remove all versions of ``cmake`` up to ``3.20``. Further, on Red Hat/CentOS, remove any external curl that might have been found.
 
 .. code-block:: console
 
@@ -547,4 +547,4 @@ See the :ref:`documentation <Duplicate_Checker>` for usage information including
 
    spack stack setup-meta-modules
 
-15. You now have a spack-stack environment that can be accessed by running ``module use ./envs/unified-env.mymacos/install/modulefiles/Core``. The modules defined here can be loaded to build and run code as described in :numref:`Section %s <UsingSpackEnvironments>`.
+15. You now have a spack-stack environment that can be accessed by running ``module use ./envs/unified-env.mylinux/install/modulefiles/Core``. The modules defined here can be loaded to build and run code as described in :numref:`Section %s <UsingSpackEnvironments>`.

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -200,7 +200,8 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 .. code-block:: console
 
    spack stack create env --site macos.default [--template unified-dev] --name unified-env.mymacos
-   spack env activate [-p] envs/unified-env.mymacos
+   cd envs/unified-env.mymacos/
+   spack env activate [-p] .
 
 3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mymacos/site``
 
@@ -439,7 +440,8 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 .. code-block:: console
 
    spack stack create env --site linux.default [--template unified-dev] --name unified-env.mylinux
-   spack env activate [-p] envs/unified-env.mylinux
+   cd envs/unified-env.mylinux/
+   spack env activate [-p] .
 
 3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mylinux/site``
 

--- a/doc/source/Overview.rst
+++ b/doc/source/Overview.rst
@@ -22,12 +22,16 @@ spack-stack is maintained by:
 - Cameron Book (@ulmononian) and Mark Potts (@mark-a-potts), EPIC
 
 ===============
-Getting Started
+Getting started
 ===============
 
-In order to **access an existing spack-stack installation** on a given system, see the instructions in :numref:`Section %s <UsingSpackEnvironments>`. Ready-to-use spack-stack installations are available on a number of HPC and cloud platforms. A list of those platforms, along with special instructions and caveats for each, can be found in :numref:`Section %s <Preconfigured_Sites>`.
+If you wish to **access an existing spack-stack installation** on a given system, such as to load packages and compile and run a UFS or JEDI application, see the instructions in :numref:`Section %s <UsingSpackEnvironments>`. Ready-to-use spack-stack installations are available on a number of HPC and cloud platforms. A list of those platforms, along with special instructions and caveats for each, can be found in :numref:`Section %s <Preconfigured_Sites>`.
 
-If you wish to **create a new site configuration** in order to create a new spack-stack installation, see the instructions in :numref:`Section %s <NewSiteConfigs>`.
+If you wish to quickly **create a new spack-stack environment (stack installation)**, either on a personal machine or on a supported platform where you are the maintainer, see :numref:`Section %s <CreatingEnvironment>`.
+
+If you wish to **chain a new spack-stack environment to an existing installation**, such as to test a new package version on one of our supported HPC or cloud platforms based on already installed dependencies, see :numref:`Section %s <Add_Test_Packages>`.
+
+If you wish to **create a new site configuration** on a not-yet supported machine, including detailed instructions for Linux and macOS workstations, see :numref:`Section %s <NewSiteConfigs>`.
 
 .. note::
    As spack-stack is intended to support NOAA EMC, JCSDA, and EPIC applications, users seeking to install software for other purposes, such as developing non-NOAA/JCSDA/EPIC applications, even those that use weather-related libraries, are recommended to simply use `Spack <https://github.com/spack/spack>`_ instead.

--- a/doc/source/Overview.rst
+++ b/doc/source/Overview.rst
@@ -25,6 +25,9 @@ spack-stack is maintained by:
 Getting Started
 ===============
 
-Basic usage of spack-stack is described :numref:`Section %s <UsingSpackEnvironments>`. Using spack-stack requires that you have a fully configured and installed spack-stack environment. In Many of supported platforms ready-to-use spack-stack installations available locally. You can see a list of those sites and site-specific instructions and caveats in :numref:`Section %s <Preconfigured_Sites>`.
+In order to **access an existing spack-stack installation** on a given system, see the instructions in :numref:`Section %s <UsingSpackEnvironments>`. Ready-to-use spack-stack installations are available on a number of HPC and cloud platforms. A list of those platforms, along with special instructions and caveats for each, can be found in :numref:`Section %s <Preconfigured_Sites>`.
 
-If you are a developer looking to build and run software locally using spack-stack, or if you are looking to install spack-stack on a new platform you can follow the instructions in :numref:`Section %s <NewSiteConfigs>`.
+If you wish to **create a new site configuration** in order to create a new spack-stack installation, see the instructions in :numref:`Section %s <NewSiteConfigs>`.
+
+.. note::
+   As spack-stack is intended to support NOAA EMC, JCSDA, and EPIC applications, users seeking to install software for other purposes, such as developing non-NOAA/JCSDA/EPIC applications, even those that use weather-related libraries, are recommended to simply use `Spack <https://github.com/spack/spack>`_ instead.

--- a/doc/source/Overview.rst
+++ b/doc/source/Overview.rst
@@ -27,7 +27,7 @@ Getting started
 
 If you wish to **access an existing spack-stack installation** on a given system, such as to load packages and compile and run a UFS or JEDI application, see the instructions in :numref:`Section %s <UsingSpackEnvironments>`. Ready-to-use spack-stack installations are available on a number of HPC and cloud platforms. A list of those platforms, along with special instructions and caveats for each, can be found in :numref:`Section %s <Preconfigured_Sites>`.
 
-If you wish to quickly **create a new spack-stack environment (stack installation)**, either on a personal machine or on a supported platform where you are the maintainer, see :numref:`Section %s <CreatingEnvironment>`.
+If you wish to quickly **create a new spack-stack environment (stack installation)**, either on a personal machine or on a supported platform where you are the maintainer, see :numref:`Section %s <CreatingEnvironment>`. To find other details related to maintaining installations, including problematic packages and system-specific issues, see :numref:`Section %s <MaintainersSection>`.
 
 If you wish to **chain a new spack-stack environment to an existing installation**, such as to test a new package version on one of our supported HPC or cloud platforms based on already installed dependencies, see :numref:`Section %s <Add_Test_Packages>`.
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -767,7 +767,8 @@ The following instructions install a new spack environment on a pre-configured s
    #     Note: in some cases, this can mess up long lines in bash
    #     because color codes are not escaped correctly. In this
    #     case, use export SPACK_COLOR='never' first.
-   spack env activate [-p] envs/unified-dev.hera
+   cd envs/unified-dev.hera/
+   spack env activate [-p] .
 
    # Edit the main config file for the environment and adjust the compiler matrix
    # to match the compilers available on your system, or a subset of them (see

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -747,7 +747,7 @@ The following instructions install a new spack environment on a pre-configured s
 
 .. code-block:: console
 
-   git clone --recursive https://github.com/jcsda/spack-stack.git
+   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Ensure Python 3.8+ is available and the default before sourcing spack

--- a/doc/source/SpackStackExtension.rst
+++ b/doc/source/SpackStackExtension.rst
@@ -29,7 +29,7 @@ The full list of options for creating containers is:
 
    spack stack create ctr [--template TEMPLATE] [--name NAME] [--dir DIR] [--overwrite] [--packages PACKAGES] container
 
-``TEMPLATE`` is identical to creating environments, and ``container`` corresponds to a pre-defined container recipe (see :numref:`Section %s <EnvironmentsContainers>`). For all other options, consult the output of ``spack stack create ctr -h``.
+``TEMPLATE`` is identical to creating environments, and ``container`` corresponds to a pre-defined container recipe (see :numref:`Section %s <BuildingContainers>`). For all other options, consult the output of ``spack stack create ctr -h``.
 
 Following a successful creation of an environment (not a container), and the generation of the ``spack`` ``lmod/tcl`` module files via ``spack module [lmod|tcl] refresh``, the meta modules for compiler, Python interpreter and MPI library are generated with
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,6 @@
 .. spack-stack documentation master file
 
-Table of Contents
+Table of contents
 =================
 
 .. toctree::
@@ -10,8 +10,9 @@ Table of Contents
    Overview
    UsingSpackEnvironments
    PreConfiguredSites
-   NewSiteConfigs
+   CreatingEnvironments
    AddingTestPackages
+   NewSiteConfigs
    BuildingContainers
    Environments
    SpackStackExtension

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,13 @@
-# Use '-i' when sourcing this file to attempt to reset $PATH to system defaults (i.e., based on /etc/profile)
+# Use '-i' when sourcing this file to attempt to reset $PATH to system defaults (i.e., based on /etc/profile),
+# then load any modules (e.g., python) critical for loading and working with Spack.
 # This may have unwanted/unexpected behavior on some systems, so use carefully.
 if [ "$1" == "-i" ]; then
   echo "Resetting PATH to system defaults"
   PATH=$(env -u PATH -u PROFILEREAD bash -c 'echo $PATH')
+  case "$(hostname -s)" in
+    Orion-login-[1-4]) module load python/3.7.5
+    ;;
+  esac
 fi
 
 # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,16 @@
 # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
 # Portable way to get current directory
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SPACK_STACK_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-export SPACK_STACK_DIR=${SCRIPT_DIR}
+export SPACK_STACK_DIR
 echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 
-source ${SCRIPT_DIR}/spack/share/spack/setup-env.sh
-echo "Sourcing spack environment ${SCRIPT_DIR}/spack/share/spack/setup-env.sh"
+source ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh
+echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
+
+# Use '-i' when sourcing this file to get a fresh environment without user-specific PATH settings.
+# This may have unwanted/unexpected behavior on some systems, so use carefully.
+if [ "$1" == "-i" ]; then
+  echo "Creating fresh installation environment with PATH reset"
+  env -u PATH -u PROFILEREAD bash --rcfile /dev/null
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,16 @@
+# Use '-i' when sourcing this file to attempt to reset $PATH to system defaults (i.e., based on /etc/profile)
+# This may have unwanted/unexpected behavior on some systems, so use carefully.
+if [ "$1" == "-i" ]; then
+  echo "Resetting PATH to system defaults"
+  PATH=$(env -u PATH -u PROFILEREAD bash -c 'echo $PATH')
+fi
+
 # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
 # Portable way to get current directory
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SPACK_STACK_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-export SPACK_STACK_DIR=${SCRIPT_DIR}
+export SPACK_STACK_DIR
 echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 
-source ${SCRIPT_DIR}/spack/share/spack/setup-env.sh
-echo "Sourcing spack environment ${SCRIPT_DIR}/spack/share/spack/setup-env.sh"
+source ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh
+echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -3,10 +3,10 @@
 # This may have unwanted/unexpected behavior on some systems, so use carefully.
 if [ "$1" == "-i" ]; then
   echo "Resetting PATH to system defaults"
-  PATH=$(env -u PATH -u PROFILEREAD bash -c 'echo $PATH')
+  PATH=$(env -u PATH -u PROFILEREAD bash -i -c 'echo $PATH')
   case "$(hostname -s)" in
-    Orion-login-[1-4]) module load python/3.7.5
-    ;;
+    Orion-login-[1-4]) module load python/3.7.5 ;;
+    alogin0[1-3]) module load intel/19.1.3.304 python/3.8.6 ;;
   esac
 fi
 


### PR DESCRIPTION
### Summary

This PR:
1. Adds a '-i' option to setup.sh which attempts to reset $PATH to the system default. I believe we should try it out for our 1.5.0 release installations, and if it goes well, add it to the documentation.
2. Updates the overview documentation to clearly spell out the main use cases and where to go in the documentation for each (as well as a note on when to use spack-stack vs. Spack). It also adds a new section that is essentially the old quick start guide. I reordered a few sections; I'm not married to the current order but it feels like the logical order as far as introducing the various use cases in the Overview section.
3. Makes a few miscellaneous documentation changes (typos, stylistic tweaks, etc.).

### Testing

- For setup.sh changes, I tested concretizing and installing packages on Orion, Gaea C4, Hera, and Acorn. On each of Orion and Acorn, I ran one UFS WM RT.
- Doco updates tested with sphinx locally.

### Applications & systems affected

None directly affected, as I intend for us to further test 'setup.sh -i' where the new functionality is off by default (and I think it's fine for it to remain that way).

### Dependencies

none

### Issue(s) addressed

Addresses #746
Fixes #597

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
