### PR TITLE
Enable MET graphics and other variants, enable `gsi-env` in `unified-dev` template

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -92,6 +92,9 @@ jobs:
           spack config add "packages:all:compiler:[apple-clang@14.0.0]"
           sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
+          # Add additional variants for MET packages, different from config/common/packages.yaml
+          spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"
+
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -85,6 +85,9 @@ jobs:
           spack config add "packages:all:compiler:[apple-clang@14.0.0]"
           sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
+          # Add additional variants for MET packages, different from config/common/packages.yaml
+          spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"
+
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -123,6 +123,9 @@ jobs:
           spack config add "packages:all:compiler:[intel@2022.1.0]"
           sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel'\]/g" $ENVDIR/spack.yaml
 
+          # Add additional variants for MET packages, different from config/common/packages.yaml
+          spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"
+
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.intel-2022.1.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2022.1.0 -i fms -i crtm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/met_graphics
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/met_graphics
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -139,9 +139,10 @@
       # 2.35.2 goes with esmf@8.4.2, 2.40.3 goes with esmf@8.5.0
       version: ['2.35.2']
       variants: ~shared
+    # If making changes here, also check the Discover site config and the CI workflows
     met:
       version: ['11.1.0']
-      variants: +python +grib2 +graphics +lidar2nc +modis
+      variants: +python +grib2
     metplus:
       version: ['5.1.0']
     mpich:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -82,6 +82,8 @@
       variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release +use_fmsio
     fontconfig:
       variants: +pic
+    freetype:
+      variants: +pic
     g2:
       version: ['3.4.5']
     g2c:
@@ -128,6 +130,7 @@
       version: ['2.1.0']
     libpng:
       version: ['1.6.37']
+      variants: +pic
     libyaml:
       version: ['0.2.5']
     mapl:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -132,7 +132,7 @@
       variants: ~shared
     met:
       version: ['11.1.0']
-      variants: +python +grib2
+      variants: +python +grib2 +graphics +lidar2nc +modis
     metplus:
       version: ['5.1.0']
     mpich:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -183,6 +183,8 @@
       variants: +pnetcdf
     parallel-netcdf:
       version: ['1.12.2']
+    pixman:
+      variants: +pic
     # Do not build pkgconf - https://github.com/jcsda/spack-stack/issues/123
     pkgconf:
       buildable: False

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -22,6 +22,8 @@
     bufr:
       version: ['12.0.0']
       variants: +python
+    cairo:
+      variants: +pic
     # Newer versions of CDO require the C++-17 standard, which doesn't
     # work with all compilers that are currently in use in spack-stack
     cdo:
@@ -78,6 +80,8 @@
       #variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
       version: ['2023.02']
       variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release +use_fmsio
+    fontconfig:
+      variants: +pic
     g2:
       version: ['3.4.5']
     g2c:

--- a/configs/sites/discover/packages.yaml
+++ b/configs/sites/discover/packages.yaml
@@ -35,6 +35,11 @@ packages:
       modules:
       - miniconda/3.9.7
 
+### Modification of common packages
+
+  met:
+    variants: +python +grib2 +graphics +lidar2nc +modis
+
 ### All other external packages listed alphabetically
   autoconf:
     externals:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -9,7 +9,7 @@ spack:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
       - global-workflow-env
-      #- gsi-env
+      - gsi-env
       - ewok-env
       - jedi-fv3-env
       - jedi-mpas-env


### PR DESCRIPTION
### Summary

1. Add MET variants `+graphics +lidar2nc +modis` to CI tests and to Discover site config.
2. Enable `gsi-env` in `unified-dev` template
3. Added `pic` variant to a number of packages in `configs/common/packages.yaml`, required to build MET and its dependencies on Ubuntu CI with the Intel compiler. Credits for these changes go to @eap who first proposed them, but the PR went stale and never got merged (https://github.com/JCSDA/spack-stack/pull/625). I don't think that adding these variants hurts building on systems/in environments were static libraries are used, but maybe @AlexanderRichert-NOAA can test building the static ufs-weather-model environment (which, by the way, needs updating before the release) on Acorn?

### Testing

- [x] CI
- [x] @climbfuji's macOS

### Applications affected

CI, Discover when building unified-dev

### Systems affected

CI, Discover

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/316

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/739
Resolves https://github.com/JCSDA/spack-stack/issues/689

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [yes+no] These changes have been tested on the affected systems and applications (not yet on Discover, but in CI and on @climbfuji's macOS; if testing on DIscover requires any site-specific updates, these will be made on the release branches as part of the roll-out).
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
