### PR TITLE
Enable use of tcl modules on lmod systems, test in Ubuntu CI

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -123,9 +123,6 @@ jobs:
           spack config add "packages:all:compiler:[intel@2022.1.0]"
           sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel'\]/g" $ENVDIR/spack.yaml
 
-          # Switch from default tcl to lmod modules
-          sed -i "s/tcl/lmod/g" $ENVDIR/site/modules.yaml
-
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.intel-2022.1.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2022.1.0 -i fms -i crtm
@@ -163,7 +160,7 @@ jobs:
           # Next steps: synchronize source and build cache to a central/combined mirror?
           echo "Next steps ..."
           spack clean -a
-          spack module lmod refresh -y
+          spack module tcl refresh -y
           spack stack setup-meta-modules
           spack env deactivate
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/fix_tcl_on_lmod_systems
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/fix_tcl_on_lmod_systems
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

The changes in the spack submodule PR https://github.com/JCSDA/spack/pull/318 enable the use of `tcl` modules on systems running `lmod`. This PR reverts the recently made switch from `tcl` to `lmod` in Ubuntu CI, so that we test using `tcl` modules on `lmod` systems regularly.

### Testing

- [x] CI
- [x] @climbfuji's macOS (manually changed the site config from `lmod` to `tcl` and verified that modules loaded correctly)

### Applications affected

n/a

### Systems affected

If any, then systems using `tcl` modules (`narwhal`, `gaea` (C4), `linux.default`)

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/318

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/761

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
