### PR TITLE
Add awscli to ewok-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_awscli
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_awscli
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -11,6 +11,8 @@
         lapack: [openblas]
         yacc: [bison]
     #
+    awscli:
+      version: ['1.29.41']
     bacio:  
       version: ['2.4.1']
     bison:


### PR DESCRIPTION
### Summary

Add awscli@1.29.41 to ewok-env and pin version (because of the complicated dependencies).

### Testing

- [x] CI
- [x] @climbfuji's macOS

### Applications affected

JEDI

### Systems affected

All systems using JEDI (`ewok-env`).

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/319

### Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/728

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
