### PR TITLE
Update srw-dev template specs.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/ulmononian/spack
-  branch = feature/update_srw_env
+  url = https://github.com/JCSDA/spack-stack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/JCSDA/spack-stack
+  url = https://github.com/jcsda/spack
   branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/ulmononian/spack
+  branch = feature/update_srw_env
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -32,14 +32,14 @@ spack:
   - hdf5@1.10.6
   - netcdf-c@4.7.4
   - netcdf-fortran@4.5.4
-  - parallelio@2.5.3
+  - parallelio@2.5.7
   - esmf@8.3.0b09
-  - fms@2022.01
+  - fms@2022.04
   - bufr@11.7.0
   - bacio@2.4.1
-  - crtm@2.3.0
+  - crtm@2.4.0
   - g2@3.4.5
-  - g2tmpl@1.10.0
+  - g2tmpl@1.10.2
   - ip@3.3.3
   - sp@2.3.3
   - w3nco@2.4.1
@@ -54,5 +54,5 @@ spack:
   - wrf-io@1.2.0
   - ncio@1.1.2
   - gsi-ncdiag@1.1.1
-  - met@10.1.0
-  - metplus@4.1.0
+  - met@10.1.2
+  - metplus@4.1.3

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -26,16 +26,16 @@ spack:
     unify: true
 
   specs:
-  - jasper@2.0.25
-  - zlib@1.2.11
+  - jasper@2.0.32
+  - zlib@1.2.13
   - libpng@1.6.37
-  - hdf5@1.10.6
-  - netcdf-c@4.7.4
-  - netcdf-fortran@4.5.4
-  - parallelio@2.5.7
-  - esmf@8.3.0b09
-  - fms@2022.04
-  - bufr@11.7.0
+  - hdf5@1.14.0
+  - netcdf-c@4.9.2
+  - netcdf-fortran@4.6.0
+  - parallelio@2.5.10
+  - esmf@8.4.2
+  - fms@2023.01
+  - bufr@12.0.0
   - bacio@2.4.1
   - crtm@2.4.0
   - g2@3.4.5
@@ -44,8 +44,8 @@ spack:
   - sp@2.3.3
   - w3nco@2.4.1
   - gftl-shared@1.5.0
-  - yafyaml@0.5.1
-  - mapl@2.22.0
+  - yafyaml@1.1.0
+  - mapl@2.35.2
   - nemsio@2.5.4
   - sfcio@1.4.1
   - sigio@2.3.2
@@ -54,5 +54,5 @@ spack:
   - wrf-io@1.2.0
   - ncio@1.1.2
   - gsi-ncdiag@1.1.1
-  - met@10.1.2
-  - metplus@4.1.3
+  - met@11.1.0
+  - metplus@5.1.0


### PR DESCRIPTION
### Summary

update the package versions in the ufs-srw-dev template so that they match what is found in https://github.com/ufs-community/ufs-srweather-app/blob/develop/modulefiles/srw_common.lua. i'll note that the srw is lagging the weather model and `spack-stack/1.5.0` pretty signiciantly at this point, so while building from this template will enable testing of the current srw-dev branch w/ spack-stack, the srw will need to be updated to work w/ `spack-stack/1.5.0`

### Testing

template build on orion. 

### Applications affected

SRW

### Systems affected

not machine specific, so should not affect any

### Dependencies

[spack #320](https://github.com/JCSDA/spack/pull/320)

### Issue(s) addressed

Fixes #736 

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
