### PR TITLE
(release/1.5.0) Update grib-util, w3emc, ip defaults

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = gributil130
+  url = https://github.com/jcsda/spack
+  branch = release/1.5.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.5.0
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = gributil130
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -103,7 +103,7 @@
       # the container builds.
       #version: ['2.11.0']
     grib-util:
-      version: ['1.2.3']
+      version: ['1.3.0']
     gsibec:
       version: ['1.1.3']
     gsi-ncdiag:
@@ -117,7 +117,7 @@
       version: ['1.14.0']
       variants: +hl +fortran +mpi ~threadsafe +szip
     ip:
-      version: ['3.3.3']
+      version: ['4.1.0']
     ip2:
       version: ['1.1.2']
     jasper:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -298,7 +298,7 @@
     upp:
       version: ['10.0.10']
     w3emc:
-      version: ['2.9.2']
+      version: ['2.10.0']
     w3nco:
       version: ['2.4.1']
     wget:


### PR DESCRIPTION
### Summary

Update grib-util to 1.3.0, w3emc to 2.10.0, ip to 4.1.0.

### Testing

Dependency chain works; in spack-stack context this will get tested over the weekend for the release.

### Applications affected

All the applications.

### Systems affected

All the systems.

### Dependencies

https://github.com/JCSDA/spack/pull/321

### Issue(s) addressed

Fixes #661

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
