### PR TITLE
UFS and acorn updates

### DIFF
--- a/configs/sites/acorn/compilers.yaml
+++ b/configs/sites/acorn/compilers.yaml
@@ -21,6 +21,27 @@ compilers:
         CONFIG_SITE: ''
     extra_rpaths: []
 - compiler:
+    spec: intel@2022.0.2.262
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    modules:
+    - PrgEnv-intel/8.3.3
+    - craype/2.7.13
+    - intel-classic/2022.2.0.262
+    - libfabric
+    environment:
+      set:
+        # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so
+        # Automake-based builds are installed in lib64
+        # which confuses some packages.
+        CONFIG_SITE: ''
+    extra_rpaths: []
+- compiler:
     spec: gcc@11.2.0
     paths:
       cc: cc

--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -1,6 +1,6 @@
   packages:
     all:
-      compiler:: [intel@19.1.3.304,gcc@11.2.0]
+      compiler:: [intel@19.1.3.304,intel@2022.0.2.262,gcc@11.2.0]
       providers:
         mpi:: [cray-mpich@8.1.9]
     cray-mpich:

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -14,26 +14,24 @@ spack:
   - site
   - common
   specs:
-  - jasper@2.0.25~shared
-  - libjpeg-turbo~shared
-  - libpng@1.6.37 libs=static
-  - zlib@1.2.11~shared
   - bacio@2.4.1
   - crtm@2.4.0~fix
-  - esmf@8.4.1+debug~shared+external-parallelio
-  - esmf@8.4.1~debug~shared+external-parallelio
-  - fms@2022.04 constants=GFS
+  - esmf@8.4.2~shared+external-parallelio
+  - fms@2023.01 constants=GFS
   - g2@3.4.5
-  - g2tmpl@1.10.0
+  - g2tmpl@1.10.2
   - gftl-shared@1.5.0
   - hdf5@1.14.0+hl+mpi~shared~szip
   - ip@3.3.3
-  - mapl@2.35.2~pnetcdf+debug~shared
-  - mapl@2.35.2~pnetcdf~debug~shared
+  - jasper@2.0.32~shared
+  - libjpeg-turbo~shared
+  - libpng@1.6.37 libs=static
+  - mapl@2.35.2~pnetcdf~shared
   - netcdf-c@4.9.2~parallel-netcdf+mpi~shared~dap
   - netcdf-fortran@4.6.0~shared
   - parallel-netcdf@1.12.2~shared
-  - parallelio@2.5.9+fortran~pnetcdf~shared
+  - parallelio@2.5.10+fortran~pnetcdf~shared
+  - scotch@7.0.3
   - sp@2.3.3
   - w3emc@2.9.2
-  - scotch@7.0.3
+  - zlib@1.2.13~shared


### PR DESCRIPTION
### Summary

This PR adds another intel version on acorn, and updates the ufs-weather-model-static module.

### Testing

Tested on acorn with two intel compilers in one environment and everything seems okay. Tested ufs-weather-model-static changes on acorn with control_CubedSphereGrid RT, which passed.

### Applications affected

UFS WM when using static.

### Systems affected

Acorn.

### Dependencies

none

### Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/721

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
