### PR TITLE
Restrict eckit version for intel 19 for acorn; remove acorn ext python

### DIFF
--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -22,13 +22,6 @@
       externals:
       - spec: git-lfs@2.11.0
         modules: [git-lfs/2.11.0]
-    python:
-      buildable: false
-      externals:
-      - spec: python@3.8.6%intel
-        prefix: /apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk
-      - spec: python@3.8.6%gcc
-        prefix: /apps/spack/python/3.8.6/gcc/11.2.0/gr4zqejk5oxwsrmxvkenmye4nni4zt6e
     perl:
       buildable: false
       externals:
@@ -61,3 +54,7 @@
       externals:
       - spec: flex@2.6.4+lex
         prefix: /usr
+    eckit:
+      require:
+      - any_of: ["@1.23.1"]
+        when: "%intel@19.1.3.304"


### PR DESCRIPTION
### Summary

This PR sets eckit one version back for intel 19 because otherwise odc can't build. Also, it removes the external python on acorn. If any other systems have similar issues, we can move the eckit logic to common/packages.yaml.

### Testing

Installed with intel 2022 and 19 on Acorn, and the UFS WM control_CubedSphereGrid RT builds and runs successfully.

### Applications affected

UFS WM

### Systems affected

Acorn

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
