### PR TITLE
Update Hera/Jet/Cheyenne site configs

### DIFF
--- a/configs/sites/cheyenne/modules.yaml
+++ b/configs/sites/cheyenne/modules.yaml
@@ -5,3 +5,5 @@ modules:
     lmod:
       exclude:
       - ecflow
+      include:
+      - python

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -40,20 +40,6 @@ packages:
       prefix: /glade/u/apps/ch/opt/openmpi/4.1.1/gnu/10.1.0
       modules:
       - openmpi/4.1.1
-  python:
-    buildable: False
-    externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
-      modules:
-      - miniconda/3.9.12
-  py-pip:
-    buildable: False
-    externals:
-    - spec: py-pip@21.2.4
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
-      modules:
-      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -68,11 +54,6 @@ packages:
     externals:
     - spec: berkeley-db@4.8.30
       prefix: /usr
-  # Don't use, leads to duplicate packages being built
-  #bison:
-  # externals:
-  # - spec: bison@2.7
-  #   prefix: /usr
   bzip2:
     externals:
     - spec: bzip2@1.0.6
@@ -197,10 +178,6 @@ packages:
     externals:
     - spec: openssh@7.2p2
       prefix: /usr
-  openssl:
-    externals:
-    - spec: openssl@1.0.2p-fips
-      prefix: /usr
   # Pin patchelf to 0.15.0 for Intel compiler (no C++-17 features)
   patchelf:
     version:: ['0.15.0']
@@ -227,10 +204,6 @@ packages:
   sed:
     externals:
     - spec: sed@4.2.2
-      prefix: /usr
-  sqlite:
-    externals:
-    - spec: sqlite@3.8.10.2~fts~functions+rtree
       prefix: /usr
   texinfo:
     externals:

--- a/configs/sites/hera/mirrors.yaml
+++ b/configs/sites/hera/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///scratch1/NCEPDEV/global/spack-stack/source-cache
+      url: file:///scratch1/NCEPDEV/nems/role.epic/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///scratch1/NCEPDEV/global/spack-stack/source-cache
+      url: file:///scratch1/NCEPDEV/nems/role.epic/spack-stack/source-cache
       access_pair:
       - null
       - null

--- a/configs/sites/hera/modules.yaml
+++ b/configs/sites/hera/modules.yaml
@@ -5,3 +5,5 @@ modules:
     lmod:
       exclude:
       - ecflow
+      include:
+      - python

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -25,20 +25,6 @@ packages:
       modules:
       - gnu/9.2.0
       - openmpi/4.1.5
-  python:
-    buildable: False
-    externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
-      prefix: /scratch1/NCEPDEV/global/spack-stack/apps/miniconda/py39_4.12.0
-      modules:
-      - miniconda/3.9.12
-  py-pip:
-    buildable: False
-    externals:
-    - spec: py-pip@21.2.4
-      prefix: /scratch1/NCEPDEV/global/spack-stack/apps/miniconda/py39_4.12.0
-      modules:
-      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -57,22 +43,10 @@ packages:
     externals:
     - spec: berkeley-db@5.3.21
       prefix: /usr
-  # Don't use, can lead to duplicate packages
-  #bison:
-  #  externals:
-  #  - spec: bison@3.0.4
-  #    prefix: /usr
   bzip2:
     externals:
     - spec: bzip2@1.0.6
       prefix: /usr
-  # Don't use 3.20.x - issues with eckit
-  #cmake:
-  #  externals:
-  #  - spec: cmake@3.20.1
-  #    modules:
-  #    - cmake/3.20.1
-  #    prefix: /apps/cmake/3.20.1
   cpio:
     externals:
     - spec: cpio@2.11
@@ -183,10 +157,6 @@ packages:
     externals:
     - spec: openssh@7.4p1
       prefix: /usr
-  openssl:
-    externals:
-    - spec: openssl@1.0.2k-fips
-      prefix: /usr
   perl:
     externals:
     - spec: perl@5.16.3~cpanm+shared+threads
@@ -206,10 +176,6 @@ packages:
   sed:
     externals:
     - spec: sed@4.2.2
-      prefix: /usr
-  sqlite:
-    externals:
-    - spec: sqlite@3.7.17~fts~functions+rtree
       prefix: /usr
   tar:
     externals:

--- a/configs/sites/jet/modules.yaml
+++ b/configs/sites/jet/modules.yaml
@@ -2,3 +2,8 @@ modules:
   default:
     enable::
     - lmod
+    lmod:
+      exclude:
+      - ecflow
+      include:
+      - python

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -27,20 +27,6 @@ packages:
       modules:
       - gnu/9.2.0
       - openmpi/3.1.4
-  python:
-    buildable: False
-    externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
-      prefix: /lfs4/HFIP/hfv3gfs/spack-stack/apps/miniconda/py39_4.12.0
-      modules:
-      - miniconda/3.9.12
-  py-pip:
-    buildable: False
-    externals:
-    - spec: py-pip@21.2.4
-      prefix: /lfs4/HFIP/hfv3gfs/spack-stack/apps/miniconda/py39_4.12.0
-      modules:
-      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -59,11 +45,6 @@ packages:
     externals:
     - spec: berkeley-db@5.3.21
       prefix: /usr
-  # Do not use, can lead to duplicate versions of nco being installed
-  #bison:
-  #  externals:
-  #  - spec: bison@3.0.4
-  #    prefix: /usr
   bzip2:
     externals:
     - spec: bzip2@1.0.6
@@ -184,12 +165,6 @@ packages:
     externals:
     - spec: openssh@7.4p1
       prefix: /usr
-  openssl:
-    externals:
-    - spec: openssl@1.1.1m
-      prefix: /lfs4/HFIP/hfv3gfs/Kyle.Gerheiser/miniconda/miniconda-3.9.7
-    - spec: openssl@1.0.2k-fips
-      prefix: /usr
   perl:
     externals:
     - spec: perl@5.16.3~cpanm+shared+threads
@@ -210,10 +185,6 @@ packages:
     externals:
     - spec: sed@4.2.2
       prefix: /usr
-  sqlite:
-    externals:
-    - spec: sqlite@3.37.0+fts~functions+rtree
-      prefix: /lfs4/HFIP/hfv3gfs/Kyle.Gerheiser/miniconda/miniconda-3.9.7
   tar:
     externals:
     - spec: tar@1.26

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -36,9 +36,9 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Gaea C5                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-dev-20230717/envs/unified-env``       | Dom Heinzeller / ???          |
 | NOAA (RDHPCS)       +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Hera                             | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                     | Mark Potts / Dom Heinzeller   |
+|                     | Hera                             | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Mark Potts / Dom Heinzeller   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Jet                              | GCC, Intel      | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env``                     | Cam Book / Dom Heinzeller     |
+|                     | Jet                              | GCC, Intel      | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Narwhal                          | Intel           | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env-intel-2021.4.0``               | Dom Heinzeller / Sarah King   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -537,24 +537,24 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.5.3
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.0`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.1
-   module load stack-python/3.9.12
+   module load stack-python/3.10.8
    module available
 
-For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.0`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.4.0/envs/unified-env/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.2.0
    module load stack-openmpi/4.1.5
-   module load stack-python/3.9.12
+   module load stack-python/3.10.8
    module available
 
 Note that on Hera, a dedicated node exists for ``ecflow`` server jobs (``hecflow01``). Users starting ``ecflow_server`` on the regular login nodes will see their servers being killed every few minutes, and may be barred from accessing the system.
@@ -576,24 +576,24 @@ The following is required for building new spack environments and for using spac
    module use /lfs4/HFIP/hfv3gfs/role.epic/modulefiles
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.0`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
+   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.1
-   module load stack-python/3.9.12
+   module load stack-python/3.10.8
    module available
 
-For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.0`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
+   module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.2.0
    module load stack-openmpi/3.1.4
-   module load stack-python/3.9.12
+   module load stack-python/3.10.8
    module available
 
 ------------------------------


### PR DESCRIPTION
### Summary

Addressing checklist items from #765 for hera, jet, and cheyenne. 

since cheyenne is on a shared filesystem w/ casper & derecho, we will need to re-build the 3rdparty libraries and modules in the machine-specific subdirs under `/glade/work/epicufsrt/contrib/spack-stack`.

### Testing

Describe the testing done for this PR.

### Applications affected

probably any that use spack-stack 1.5.0

### Systems affected

hera/jet/cheyenne

### Dependencies

none

### Issue(s) addressed

#765 

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
