### PR TITLE
release/1.5.0: final site and documentation updates (Cheyenne, Casper, AWS single-node AMI)

### DIFF
--- a/configs/sites/casper/compilers.yaml
+++ b/configs/sites/casper/compilers.yaml
@@ -1,23 +1,45 @@
 compilers::
+  #- compiler:
+  #    spec: intel@19.1.1.217
+  #    paths:
+  #      cc: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/icc
+  #      cxx: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/icpc
+  #      f77: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/ifort
+  #      fc: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/ifort
+  #    flags: {}
+  #    operating_system: centos7
+  #    target: x86_64
+  #    modules:
+  #    - intel/19.1.1
+  #    environment:
+  #      prepend_path:
+  #        PATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/bin'
+  #        CPATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/include'
+  #        LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/opt/intel/2020u1/compilers_and_libraries_2020.1.217/linux/mpi/intel64/libfabric/lib:/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/lib64'
+  #      set:
+  #        INTEL_LICENSE_FILE: '28518@128.117.177.41'
+  #        LM_LICENSE_FILE: '28518@128.117.177.41'
+  #        I_MPI_ROOT: '/glade/u/apps/opt/intel/2020u1/impi/2019.7.217/intel64'
+  #    extra_rpaths: []
   - compiler:
-      spec: intel@19.1.1.217
+      spec: intel@2022.0.2
       paths:
-        cc: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/icc
-        cxx: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/icpc
-        f77: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/ifort
-        fc: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/ifort
+        cc: /glade/u/apps/opt/intel/2022.1/compiler/2022.0.2/linux/bin/intel64/icc
+        cxx: /glade/u/apps/opt/intel/2022.1/compiler/2022.0.2/linux/bin/intel64/icpc
+        f77: /glade/u/apps/opt/intel/2022.1/compiler/2022.0.2/linux/bin/intel64/ifort
+        fc: /glade/u/apps/opt/intel/2022.1/compiler/2022.0.2/linux/bin/intel64/ifort
       flags: {}
       operating_system: centos7
       target: x86_64
       modules:
-      - intel/19.1.1
+      - intel/2022.1
       environment:
         prepend_path:
           PATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/bin'
           CPATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/include'
-          LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/opt/intel/2020u1/compilers_and_libraries_2020.1.217/linux/mpi/intel64/libfabric/lib:/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/lib64'
+          LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2022.1/compiler/latest/linux/compiler/lib/intel64_lin:/glade/u/apps/opt/intel/2022.1/mpi/2021.5.1/libfabric/lib:/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/lib64'
         set:
           INTEL_LICENSE_FILE: '28518@128.117.177.41'
           LM_LICENSE_FILE: '28518@128.117.177.41'
-          I_MPI_ROOT: '/glade/u/apps/opt/intel/2020u1/impi/2019.7.217/intel64'
+          #I_MPI_ROOT: '/glade/u/apps/opt/intel/2022.1/mpi/2021.5.1'
       extra_rpaths: []

--- a/configs/sites/casper/compilers.yaml
+++ b/configs/sites/casper/compilers.yaml
@@ -13,9 +13,9 @@ compilers::
       - intel/19.1.1
       environment:
         prepend_path:
-          PATH: '/glade/u/apps/dav/opt/gnu/9.1.0/bin'
-          CPATH: '/glade/u/apps/dav/opt/gnu/9.1.0/include'
-          LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/opt/intel/2020u1/compilers_and_libraries_2020.1.217/linux/mpi/intel64/libfabric/lib:/glade/u/apps/dav/opt/gnu/9.1.0/lib64'
+          PATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/bin'
+          CPATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/include'
+          LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/opt/intel/2020u1/compilers_and_libraries_2020.1.217/linux/mpi/intel64/libfabric/lib:/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/lib64'
         set:
           INTEL_LICENSE_FILE: '28518@128.117.177.41'
           LM_LICENSE_FILE: '28518@128.117.177.41'

--- a/configs/sites/casper/compilers.yaml
+++ b/configs/sites/casper/compilers.yaml
@@ -1,26 +1,4 @@
 compilers::
-  #- compiler:
-  #    spec: intel@19.1.1.217
-  #    paths:
-  #      cc: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/icc
-  #      cxx: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/icpc
-  #      f77: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/ifort
-  #      fc: /glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/bin/intel64/ifort
-  #    flags: {}
-  #    operating_system: centos7
-  #    target: x86_64
-  #    modules:
-  #    - intel/19.1.1
-  #    environment:
-  #      prepend_path:
-  #        PATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/bin'
-  #        CPATH: '/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/include'
-  #        LD_LIBRARY_PATH: '/glade/u/apps/opt/intel/2020u1/compilers_and_libraries/linux/lib/intel64_lin:/glade/u/apps/opt/intel/2020u1/compilers_and_libraries_2020.1.217/linux/mpi/intel64/libfabric/lib:/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0/lib64'
-  #      set:
-  #        INTEL_LICENSE_FILE: '28518@128.117.177.41'
-  #        LM_LICENSE_FILE: '28518@128.117.177.41'
-  #        I_MPI_ROOT: '/glade/u/apps/opt/intel/2020u1/impi/2019.7.217/intel64'
-  #    extra_rpaths: []
   - compiler:
       spec: intel@2022.0.2
       paths:
@@ -41,5 +19,6 @@ compilers::
         set:
           INTEL_LICENSE_FILE: '28518@128.117.177.41'
           LM_LICENSE_FILE: '28518@128.117.177.41'
-          #I_MPI_ROOT: '/glade/u/apps/opt/intel/2022.1/mpi/2021.5.1'
+          I_MPI_ROOT: '/glade/u/apps/opt/intel/2022.1/mpi/2021.5.1'
+
       extra_rpaths: []

--- a/configs/sites/casper/modules.yaml
+++ b/configs/sites/casper/modules.yaml
@@ -5,3 +5,5 @@ modules:
     lmod:
       exclude:
       - ecflow
+      include:
+      - python

--- a/configs/sites/casper/packages.yaml
+++ b/configs/sites/casper/packages.yaml
@@ -1,18 +1,25 @@
 packages:
   all:
-    compiler:: [intel@19.1.1.217]
+    #compiler:: [intel@19.1.1.217]
+    compiler:: [intel@2022.0.2]
     providers:
-      mpi:: [intel-mpi@2019.7.217]
+      #mpi:: [intel-mpi@2019.7.217]
+      mpi:: [intel-oneapi-mpi@2021.5.1]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
-  intel-mpi:
+  #intel-mpi:
+  #  externals:
+  #  - spec: intel-mpi@2019.7.217%intel@19.1.1.217
+  #    prefix: /glade/u/apps/opt/intel/2020u1
+  #    modules:
+  #    - impi/2019.7.217
+  intel-oneapi-mpi:
     externals:
-    - spec: intel-mpi@2019.7.217%intel@19.1.1.217
-      prefix: /glade/u/apps/opt/intel/2020u1
+    - spec: intel-oneapi-mpi@2021.5.1%intel@2022.0.2
       modules:
-      - impi/2019.7.217
+      - impi/2022.1
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -31,10 +38,6 @@ packages:
     externals:
     - spec: binutils@2.27.43
       prefix: /usr
-  #bison:
-  #  externals:
-  #  - spec: bison@3.0.4
-  #    prefix: /usr
   bzip2:
     externals:
     - spec: bzip2@1.0.6
@@ -73,11 +76,6 @@ packages:
       prefix: /glade/work/epicufsrt/contrib/spack-stack/casper/ecflow-5.8.4
       modules:
       - ecflow/5.8.4
-  # Don't use, leads to duplicate packages being built
-  #expat:
-  #  externals:
-  #  - spec: expat@1.6.0
-  #    prefix: /usr
   file:
     externals:
     - spec: file@5.11
@@ -168,8 +166,8 @@ packages:
     - spec: openssl@1.0.2k-fips
       prefix: /usr
   # Pin patchelf to 0.15.0 for Intel compiler (no C++-17 features)
-  patchelf:
-    version:: ['0.15.0']
+  #patchelf:
+  #  version:: ['0.15.0']
   perl:
     externals:
     - spec: perl@5.16.3~cpanm+shared+threads

--- a/configs/sites/casper/packages.yaml
+++ b/configs/sites/casper/packages.yaml
@@ -13,20 +13,6 @@ packages:
       prefix: /glade/u/apps/opt/intel/2020u1
       modules:
       - impi/2019.7.217
-  python:
-    buildable: False
-    externals:
-    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
-      modules:
-      - miniconda/3.9.12
-  py-pip:
-    buildable: False
-    externals:
-    - spec: py-pip@21.2.4
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
-      modules:
-      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -45,10 +31,10 @@ packages:
     externals:
     - spec: binutils@2.27.43
       prefix: /usr
-  bison:
-    externals:
-    - spec: bison@3.0.4
-      prefix: /usr
+  #bison:
+  #  externals:
+  #  - spec: bison@3.0.4
+  #    prefix: /usr
   bzip2:
     externals:
     - spec: bzip2@1.0.6
@@ -84,7 +70,7 @@ packages:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/ecflow-5.8.4
+      prefix: /glade/work/epicufsrt/contrib/spack-stack/casper/ecflow-5.8.4
       modules:
       - ecflow/5.8.4
   # Don't use, leads to duplicate packages being built
@@ -163,7 +149,7 @@ packages:
     buildable: False
     externals:
     - spec: mysql@8.0.31
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/mysql-8.0.31
+      prefix: /glade/work/epicufsrt/contrib/spack-stack/casper/mysql-8.0.31
       modules:
       - mysql/8.0.31
   ncurses:
@@ -195,7 +181,7 @@ packages:
   qt:
     externals:
     - spec: qt@5.15.2
-      prefix: /glade/work/jedipara/cheyenne/spack-stack/qt-5.15.2/5.15.2/gcc_64
+      prefix: /glade/work/epicufsrt/contrib/spack-stack/casper/qt-5.15.2
   rsync:
     externals:
     - spec: rsync@3.1.2
@@ -207,10 +193,6 @@ packages:
   sed:
     externals:
     - spec: sed@4.2.2
-      prefix: /usr
-  sqlite:
-    externals:
-    - spec: sqlite@3.8.10.2~fts~functions+rtree
       prefix: /usr
   subversion:
     externals:

--- a/configs/sites/casper/packages.yaml
+++ b/configs/sites/casper/packages.yaml
@@ -1,25 +1,23 @@
 packages:
   all:
-    #compiler:: [intel@19.1.1.217]
     compiler:: [intel@2022.0.2]
     providers:
-      #mpi:: [intel-mpi@2019.7.217]
       mpi:: [intel-oneapi-mpi@2021.5.1]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
-  #intel-mpi:
-  #  externals:
-  #  - spec: intel-mpi@2019.7.217%intel@19.1.1.217
-  #    prefix: /glade/u/apps/opt/intel/2020u1
-  #    modules:
-  #    - impi/2019.7.217
   intel-oneapi-mpi:
     externals:
     - spec: intel-oneapi-mpi@2021.5.1%intel@2022.0.2
+      prefix: /glade/u/apps/opt/intel/2022.1
       modules:
-      - impi/2022.1
+      - intel-oneapi-mpi/2021.5.1.lua
+
+### Modification of common packages
+  # Default gdal (3.7.0) doesn't build on Casper with intel@2022.0.2
+  gdal:
+    version:: ['3.6.3']
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/cheyenne/compilers.yaml
+++ b/configs/sites/cheyenne/compilers.yaml
@@ -54,6 +54,8 @@ compilers::
       target: x86_64
       modules:
       - gnu/10.1.0
-      environment: {}
+      environment:
+        set:
+          OMPI_MCA_rmaps_base_oversubscribe: '1'
       extra_rpaths: []
 

--- a/configs/sites/cheyenne/packages.yaml
+++ b/configs/sites/cheyenne/packages.yaml
@@ -40,6 +40,20 @@ packages:
       prefix: /glade/u/apps/ch/opt/openmpi/4.1.1/gnu/10.1.0
       modules:
       - openmpi/4.1.1
+  python:
+    buildable: False
+    externals:
+    - spec: python@3.9.12+bz2+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
+      modules:
+      - miniconda/3.9.12
+  py-pip:
+    buildable: False
+    externals:
+    - spec: py-pip@21.2.4
+      prefix: /glade/work/jedipara/cheyenne/spack-stack/miniconda-3.9.12
+      modules:
+      - miniconda/3.9.12
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -177,6 +191,10 @@ packages:
   openssh:
     externals:
     - spec: openssh@7.2p2
+      prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@1.0.2p-fips
       prefix: /usr
   # Pin patchelf to 0.15.0 for Intel compiler (no C++-17 features)
   patchelf:

--- a/doc/modulefile_templates/gcc
+++ b/doc/modulefile_templates/gcc
@@ -1,0 +1,23 @@
+#%Module1.0
+
+module-whatis "Provides a gcc-10.1.0 installation for use with spack."
+
+conflict gnu
+conflict gcc
+
+proc ModulesHelp { } {
+puts stderr "Provides a gcc-10.1.0 installation for use with spack."
+}
+
+
+# Set this value
+set GCC_PATH "/glade/work/epicufsrt/contrib/spack-stack/casper/gcc-10.1.0"
+
+prepend-path PATH "${GCC_PATH}/bin"
+prepend-path LD_LIBRARY_PATH "${GCC_PATH}/lib"
+prepend-path LD_LIBRARY_PATH "${GCC_PATH}/lib64"
+prepend-path LIBRARY_PATH "${GCC_PATH}/lib"
+prepend-path LIBRARY_PATH "${GCC_PATH}/lib64"
+prepend-path CPATH "${GCC_PATH}/include"
+prepend-path CMAKE_PREFIX_PATH "${GCC_PATH}"
+prepend-path MANPATH "${GCC_PATH}/share/man"

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -429,6 +429,9 @@ gcc
    make install 2>&1 | tee log.install
    # create modulefile
 
+intel-oneapi-mpi (module only)
+   The ``impi/2022.1`` module provided by CISL has the wrong ``I_MPI_ROOT`` and ``MPI_ROOT`` values. Copy the file to ``/glade/work/epicufsrt/contrib/spack-stack/casper/modulefiles/intel-oneapi-mpi/2021.5.1.lua`` and remove the offending entries, as well as the unnecessary ``ncarcompilers`` logic at the end.
+
 qt (qt@5)
    The default ``qt@5`` in ``/usr`` is incomplete and thus insufficient for building ``ecflow``. Follow these instructions to build ``qt@5.15.2`` using ``gcc@10.10.0``. See also https://wiki.qt.io/Building_Qt_5_from_Git#Getting_the_source_code for building qt from source.
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -453,7 +453,10 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   spack external find --scope system --exclude bison --exclude cmake --exclude curl
+   spack external find --scope system \
+       --exclude bison --exclude cmake \
+       --exclude curl --exclude openssl \
+       --exclude openssh
    spack external find --scope system perl
    spack external find --scope system wget
    spack external find --scope system mysql
@@ -512,9 +515,6 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    - compilers: ['%gcc']
 
 11. Edit site config files and common config files, for example to remove duplicate versions of external packages that are unwanted, add specs in ``envs/unified-env.mylinux/spack.yaml``, etc.
-
-.. warning::
-   Remove any external ``cmake`` package version 3.20 or earlier from ``envs/unified-env.mylinux/site/packages.yaml`` (or use add ``--exclude cmake`` to the ``spack external find`` command). Further, on Red Hat/CentOS, remove any external ``curl`` that might have been found.
 
 .. code-block:: console
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -453,13 +453,11 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   spack external find --scope system # use '--exclude' for troublesome packages like bison@:3.3, openssl@1.1.1, and cmake 3.20 and earlier
+   spack external find --scope system --exclude bison --exclude cmake --exclude curl
    spack external find --scope system perl
    spack external find --scope system wget
    spack external find --scope system mysql
    spack external find --scope system texlive
-   # On Ubuntu (but not on Red Hat):
-   spack external find --scope system curl
 
 5. Find compilers, add to site config's ``compilers.yaml``
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -24,7 +24,7 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NASA                | Discover                         | GCC, Intel      | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.0/envs/unified-env``                                  | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Casper                           | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.4.1/envs/unified-env``                 | Dom Heinzeller / ???          |
+|                     | Casper                           | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.5.0/envs/unified-env``                 | Dom Heinzeller / ???          |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NCAR-Wyoming        | Cheyenne                         | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.5.0/envs/{unified-env,ufs-env}``     | Cam Book / Dom Heinzeller     |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -315,14 +315,14 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda and ecflow.
+For ``spack-stack-1.5.0`` with Intel, load the following modules after loading miniconda and ecflow.
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core
-   module load stack-intel/19.1.1.217
-   module load stack-intel-mpi/2019.7.217
-   module load stack-python/3.9.12
+   module use /glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module load stack-intel/2022.0.2
+   module load stack-intel-oneapi-mpi/2021.5.1
+   module load stack-python/3.10.8
    module available
 
 .. _Preconfigured_Sites_Cheyenne:
@@ -400,7 +400,7 @@ For ``spack-stack-1.5.0`` with Intel, load the following modules after loading e
 NOAA Acorn (WCOSS2 test system)
 -------------------------------
 
-For spack-stack-1.4.1, the meta modules are in ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core``.
+For spack-stack-1.5.0, the meta modules are in ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core``.
 
 On WCOSS2 OpenSUSE sets ``CONFIG_SITE`` which causes libraries to be installed in ``lib64``, breaking the ``lib`` assumption made by some packages. Therefore, ``CONFIG_SITE`` should be set to empty in ``compilers.yaml``. Also, don't use ``module purge`` on Acorn!
 
@@ -508,10 +508,6 @@ For ``spack-stack-1.5.0`` with Intel, load the following modules after loading m
    module load stack-cray-mpich/8.1.25
    module load stack-python/3.10.8
    module -t available
-
-.. note::
-
-   The recent update to ``spack-stack-dev-20230717`` was required on Gaea C5 due to a bug in the Intel compilers used in ``spack-stack-1.4.1``.
 
 .. note::
    On Gaea C5, running ``module available`` without the option ``-t`` leads to an error: ``/usr/bin/lua5.3: /opt/cray/pe/lmod/lmod/libexec/Spider.lua:568: stack overflow``
@@ -688,7 +684,7 @@ For ``spack-stack-1.5.0`` with Intel on the JCSDA ROMEX cluster (``c6i.32xlarge`
 Amazon Web Services Red Hat 8
 -----------------------------
 
-Use a c6i.4xlarge instance or larger if running out of memory with AMI "skylab-6.0.0-redhat8" (ami-MISSING in region us-east-1, ami-01fcf5d75ced5a046 in region us-east-2).
+Use a c6i.4xlarge instance or larger if running out of memory with AMI "skylab-6.0.0-redhat8" (ami-059d445a90ad8b792 in region us-east-1, ami-01fcf5d75ced5a046 in region us-east-2).
 
 For ``spack-stack-1.5.0``, run:
 
@@ -715,7 +711,7 @@ TACC Frontera
 ------------------------------
 
 .. note::
-   ``spack-stack-1.4.0`` is currently not supported on this platform and may be added in the near future.
+   ``spack-stack-1.5.0`` is currently not supported on this platform.
 
 The following is required for building new spack environments and for using spack to build and run software.
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -26,7 +26,7 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Casper                           | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.4.1/envs/unified-env``                 | Dom Heinzeller / ???          |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-| NCAR-Wyoming        | Cheyenne                         | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env``               | Cam Book / Dom Heinzeller     |
+| NCAR-Wyoming        | Cheyenne                         | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.5.0/envs/{unified-env,ufs-env}``     | Cam Book / Dom Heinzeller     |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Derecho                          | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.0/envs/unified-env``                | Mark Potts / Dom Heinzeller   |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -54,11 +54,11 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | **Cloud platforms**                                                                                                                                                                                                |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | AMI Red Hat 8                    | GCC             | ``/home/ec2-user/spack-stack/spack-stack-1.4.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
+|                     | AMI Red Hat 8                    | GCC             | ``/home/ec2-user/spack-stack/spack-stack-1.5.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
 +                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-| Amazon Web Services | Parallelcluster JCSDA R&D        |                 | ``/mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env``                                   | Dom Heinzeller / ???          |
+| Amazon Web Services | Parallelcluster JCSDA R&D        | Intel           | ``/mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env``                                   | Dom Heinzeller / ???          |
 +                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Parallelcluster JCSDA ROMEX      |                 | ``/mnt/experiments-efs/ROMEX/spack-stack-1.5.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
+|                     | Parallelcluster JCSDA ROMEX      | Intel           | ``/mnt/experiments-efs/ROMEX/spack-stack-1.5.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (RDHPCS)       | RDHPCS Cloud (Parallel Works)^** | Intel           | ``/contrib/spack-stack/spack-stack-1.5.0/envs/unified-env``                                             | Mark Potts / Cam Book / Dom H |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -310,7 +310,7 @@ The following is required for building new spack environments and for using spac
 
    module purge
    export LMOD_TMOD_FIND_FIRST=yes
-   module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
+   module use /glade/work/epicufsrt/contrib/spack-stack/casper/modulefiles
    module load python/3.7.9
    module load ecflow/5.8.4
    module load mysql/8.0.31
@@ -342,21 +342,21 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.4.1`` with Intel, load the following modules after loading miniconda, ecflow and mysql.
+For ``spack-stack-1.5.0`` with Intel, please note that there is no support for the full unified environment (``unified-env``) due to the lack of support of the C++-17 standard in Intel 19. An environment for the Unified Forecast System is available by loading the following modules after loading miniconda, ecflow and mysql.
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env
+   module use /glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.5.0/envs/ufs-env/install/modulefiles/Core
    module load stack-intel/19.1.1.217
    module load stack-intel-mpi/2019.7.217
    module load stack-python/3.9.12
    module available
 
-For ``spack-stack-1.4.1`` with GNU, load the following modules after loading miniconda, ecflow and mysql.
+For ``spack-stack-1.5.0`` with GNU, load the following modules after loading miniconda, ecflow and mysql. Note that this is the full unified environment.
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.4.1/envs/unified-env
+   module use /glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-openmpi/4.1.1
    module load stack-python/3.9.12
@@ -688,33 +688,16 @@ For ``spack-stack-1.5.0`` with Intel on the JCSDA ROMEX cluster (``c6i.32xlarge`
 Amazon Web Services Red Hat 8
 -----------------------------
 
-Use a c6i.4xlarge instance or similar with AMI "skylab-5.0.0-redhat8" (ami-02324faac94a9cac9 in region us-east-1, ami-038d9beca351f9005 in region us-east-2).
+Use a c6i.4xlarge instance or larger if running out of memory with AMI "skylab-6.0.0-redhat8" (ami-MISSING in region us-east-1, ami-01fcf5d75ced5a046 in region us-east-2).
 
-For ``spack-stack-1.4.0``, run:
+For ``spack-stack-1.5.0``, run:
 
 .. code-block:: console
 
    ulimit -s unlimited
    scl enable gcc-toolset-11 bash
-   module use /home/ec2-user/spack-stack/spack-stack-1.4.0/envs/unified-env/install/modulefiles/Core
+   module use /home/ec2-user/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/11.2.1
-   module load stack-openmpi/4.1.5
-   module load stack-python/3.10.8
-   module available
-
------------------------------
-Amazon Web Services Ubuntu 20
------------------------------
-
-Use a c6i.4xlarge instance or similar with AMI "skylab-5.0.0-ubuntu20" (ami-09a8c9d3775feafcf in region us-east-1, ami-03e47cdb4ced34d7e in region us-east-2).
-
-For ``spack-stack-1.4.0``, run:
-
-.. code-block:: console
-
-   ulimit -s unlimited
-   module use /home/ubuntu/spack-stack/spack-stack-1.4.0/envs/unified-env/install/modulefiles/Core
-   module load stack-gcc/10.3.0
    module load stack-openmpi/4.1.5
    module load stack-python/3.10.8
    module available

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -311,7 +311,7 @@ The following is required for building new spack environments and for using spac
    module purge
    export LMOD_TMOD_FIND_FIRST=yes
    module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
-   module load miniconda/3.9.12
+   module load python/3.7.9
    module load ecflow/5.8.4
    module load mysql/8.0.31
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2023 '
 author = 'Dominikus Heinzeller, Alexander Richert, Cameron Book'
 
 # The short X.Y version
-version = '1.4'
+version = '1.5'
 # The full version, including alpha/beta/rc tags
-release = '1.4.1'
+release = '1.5.0'
 
 numfig = True
 


### PR DESCRIPTION
# WIP

### Summary

Final round of site and documentation updates for release 1.5.0:
- Cheyenne: no updates made unless necessary (system will be decommissioned end of this year)
    - Intel 19 does not support the C++-17 standard, therefore the unified environment is only built with GNU, and a separate environment for just the UFS is built with Intel
- Casper: major overhaul of external packages and update of Intel compiler to support the C++-17 standard
- Minor updates needed for AWS single-node AMI (in documentation for new site configurations for Linux)
- Final updates of documentation: see https://spack-stack--787.org.readthedocs.build/en/787/

### Testing

See https://github.com/JCSDA/spack-stack/issues/765

### Applications affected

All applications on said systems

### Systems affected

See above

### Dependencies

n/a

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/765

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
