### PR TITLE
release/1.5.0: Update tag for spack submodule in .gitmodules and container recipes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   #url = https://github.com/spack/spack
   #branch = develop
   url = https://github.com/jcsda/spack
-  branch = release/1.5.0
+  branch = spack-stack-1.5.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -110,7 +110,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/jcsda/spack
-        ref: release/1.5.0
+        ref: spack-stack-1.5.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -98,7 +98,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/jcsda/spack
-        ref: release/1.5.0
+        ref: spack-stack-1.5.0
         resolve_sha: false
 
     # Whether or not to strip binaries

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -115,7 +115,7 @@ spack:
       os: ubuntu:20.04
       spack:
         url: https://github.com/jcsda/spack
-        ref: release/1.5.0
+        ref: spack-stack-1.5.0
         resolve_sha: false
 
     # Whether or not to strip binaries


### PR DESCRIPTION
### Summary

Final PR for release/1.5.0: Update tag for spack submodule in .gitmodules and container recipes

### Testing

n/a

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

- [x] spack tag `spack-stack-1.5.0` created

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
