### PR TITLE
Change prod-util module to prod_util

### DIFF
--- a/configs/common/modules.yaml
+++ b/configs/common/modules.yaml
@@ -16,6 +16,7 @@ modules:
         nlohmann-json: '{compiler.name}/{compiler.version}/json/{version}'
         nlohmann-json-schema-validator: '{compiler.name}/{compiler.version}/json-schema-validator/{version}'
         libjpeg-turbo: '{compiler.name}/{compiler.version}/libjpeg/{version}'
+        prod-util: '{compiler.name}/{compiler.version}/prod_util/{version}'
       exclude:
       # List of packages for which we don't need modules
       - apple-libunwind
@@ -271,6 +272,7 @@ modules:
         nlohmann-json: 'json/{version}'
         nlohmann-json-schema-validator: 'json-schema-validator/{version}'
         libjpeg-turbo: 'libjpeg/{version}'
+        prod-util: 'prod_util/{version}'
       exclude:
       # List of packages for which we don't need modules
       - apple-libunwind


### PR DESCRIPTION
### Summary

This PR changes the prod-util module name to prod_util for consistency with existing installations/applications.

### Testing

Tested on Acorn on elsewhere.

### Applications affected

Global Workflow (which needs the change)

### Systems affected

all

### Dependencies

none

### Issue(s) addressed

#780

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
