### PR TITLE
Bumped bufr version to 12.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/srherbener/spack
-  branch = feature/bufr-12.0.1
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/srherbener/spack
+  branch = feature/bufr-12.0.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -22,7 +22,7 @@
       version: ['1.78.0']
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=17 visibility=hidden
     bufr:
-      version: ['12.0.0']
+      version: ['12.0.1']
       variants: +python
     cairo:
       variants: +pic


### PR DESCRIPTION
### Summary

This PR bumps the bufr version in common package.py to version 12.0.1. 

### Testing

I tested building on my Mac and was able to successfully build bufr@12.0.1.

### Applications affected

This affects JEDI ioda converters, and other applications that use the NCEPLIBS-bufr package.

### Systems affected

List all systems intentionally or unintentionally affected by this PR.

### Dependencies

- [x] waiting on jcsda/spack/pull/330

### Issue(s) addressed

This partially addresses #778

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
