### PR TITLE
release/1.5.1: bump bufr version to 12.0.1 (cherry-pick #797 from develop)

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -22,7 +22,7 @@
       version: ['1.78.0']
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=17 visibility=hidden
     bufr:
-      version: ['12.0.0']
+      version: ['12.0.1']
       variants: +python
     cairo:
       variants: +pic


### PR DESCRIPTION
### Summary

This PR is cherry-picked from develop (PR #797):
* Bumped bufr version to 12.0.1
* Updated spack submodule commit hash

### Testing

- [x] CI
- [x] Tested manually and in CI for develop

### Applications affected

UFS and JEDI

### Systems affected

All

### Dependencies

Upstream dependencies are merged.

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
