### PR TITLE
Added note in known issues about apple-clang-15 not supported yet

### DIFF
--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -131,6 +131,10 @@ macOS
 
    Can happen when trying to use the raster plotting scripts in ``fv3-jedi-tools``. In that case, exporting ``DYLD_LIBRARY_PATH=/usr/lib/:$DYLD_LIBRARY_PATH`` can help. If ``git`` commands fail after this, you might need to verify where ``which git`` points to (Homebrew vs module) and unload the ``git`` module.
 
+6. ``apple-clang@15.0.0`` not yet supported
+
+   Building with ``apple-clang@15.0.0`` is under development and should be working soon. In the meantime, please use ``apple-clang@14.x`` or older versions.
+
 ==============================
 Ubuntu
 ==============================


### PR DESCRIPTION
### Summary

This PR adds a note in the documentation Known Issues about apple-clang@15 not being supported yet (ie still under development).

### Testing

Built in my local clone and viewed page in my browser.

### Applications affected

None - documentation update only

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

None - just a quick update

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged. (N/A)
