### PR TITLE
Updated openblas version to 0.3.24 in the common packages.yaml spec.

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -112,10 +112,10 @@ jobs:
           spack buildcache list
 
           # Workaround for limited disk space on macOS arm instance
-          spack config add "config:build_stage:/Users/ec2-user/spack-stack/spack-cache/build_stage"
-          spack config add "config:test_stage:/Users/ec2-user/spack-stack/spack-cache/test_stage"
-          spack config add "config:source_cache:/Users/ec2-user/spack-stack/spack-cache/source_cache"
-          spack config add "config:misc_cache:/Users/ec2-user/spack-stack/spack-cache/misc_cache"
+          spack config add "config:build_stage:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/build_stage"
+          spack config add "config:test_stage:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/test_stage"
+          spack config add "config:source_cache:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/source_cache"
+          spack config add "config:misc_cache:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/misc_cache"
 
           # Break installation up in pieces and create build caches in between
           # This allows us to "spin up" builds that altogether take longer than

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/srherbener/spack
+  branch = feature/openblas-0.3.24
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/srherbener/spack
-  branch = feature/openblas-0.3.24
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -182,7 +182,7 @@
       version: ['1.4.6']
       variants: ~fortran
     openblas:
-      version: ['0.3.19']
+      version: ['0.3.24']
       variants: +noavx512
     openmpi:
       variants: +internal-hwloc +two_level_namespace


### PR DESCRIPTION
### Summary

This PR bumps the common version of openblas from 0.3.19 to 0.3.24. Hopefully, this will be acceptable across the board (simpler to maintain), but it's really only required for `apple-clang@15.x` as far as I know. I am completely open to keeping the common version on 0.3.19 and only using 0.3.24 for the Mac if that is what needs to be done.

### Testing

Tested building on my Mac using `apple-clang@15.0.0` and openblas builds successfully.

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.

it appears that openblas is a dependency for a fair number of applications. Here is what is reported on my Mac when building in the unified-dev environment (spack find openblas output):
```
==> In environment /Users/steveherbener/spack-stack/envs/unified.mymacos
==> Root specs
-- no arch / apple-clang ----------------------------------------
crtm@v2.4.1-jedi%apple-clang      jedi-mpas-env%apple-clang 
crtm@2.4.0%apple-clang            jedi-neptune-env%apple-clang 
ewok-env%apple-clang              jedi-tools-env%apple-clang 
fms@release-jcsda%apple-clang     jedi-ufs-env%apple-clang 
fms@2023.01%apple-clang           jedi-um-env%apple-clang 
fms@2023.02%apple-clang           madis@4.5%apple-clang 
global-workflow-env%apple-clang   soca-env%apple-clang 
gsi-env%apple-clang               ufs-srw-app-env%apple-clang 
jedi-fv3-env%apple-clang          ufs-weather-model-env%apple-clang 

==> Installed packages
-- darwin-ventura-m1 / apple-clang@15.0.0 -----------------------
openblas@0.3.24
==> 1 installed package
```

### Systems affected

Mac and, if acceptable to bump the common packages.yaml version to 0.3.24, all the HPC platforms.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/335

### Issue(s) addressed

Fixes the build of openblas on MacOS using `apple-clang@15.0.0` compiler.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications
    Only on my Mac so far
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
