### PR TITLE
Enable awscli-v2 in unified-dev template (ewok-env/jedi-tools-env), add gmao-swell-env

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -89,15 +89,15 @@ jobs:
 
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[openmpi]"
-          spack config add "packages:all:compiler:[apple-clang@14.0.0]"
+          spack config add "packages:all:compiler:[apple-clang@14.0.3]"
           sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
           spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"
 
           # Concretize and check for duplicates
-          spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm
+          spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.3
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm
 
           # Add and update source cache
           spack mirror add local-source file:///Users/ec2-user/spack-stack/source-cache/
@@ -111,12 +111,6 @@ jobs:
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
-          # Workaround for limited disk space on macOS arm instance
-          spack config add "config:build_stage:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/build_stage"
-          spack config add "config:test_stage:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/test_stage"
-          spack config add "config:source_cache:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/source_cache"
-          spack config add "config:misc_cache:/tmp/tmp-mount-MGMMwD/diskspace_workaround_spack_stack/misc_cache"
-
           # Break installation up in pieces and create build caches in between
           # This allows us to "spin up" builds that altogether take longer than
           # six hours, and/or fail later in the build process.
@@ -124,14 +118,14 @@ jobs:
           # base-env
           echo "base-env ..."
           # DH* 20230721 - todo remove --no-checksum
-          spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
+          spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.apple-clang-14.0.3.base-env
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
           spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           # DH* 20230721 - todo remove --no-checksum
-          spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
+          spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.apple-clang-14.0.3.${{ inputs.template || 'unified-dev' }}
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
           spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
@@ -158,7 +152,7 @@ jobs:
           ls -l ${ENVDIR}/install/modulefiles/Core
 
           module use ${ENVDIR}/install/modulefiles/Core
-          module load stack-apple-clang/14.0.0
+          module load stack-apple-clang/14.0.3
           module load stack-openmpi/4.1.5
           module load stack-python/3.10.8
           module available

--- a/.github/workflows/ubuntu-ci-containers-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-containers-x86_64.yaml
@@ -82,7 +82,6 @@ jobs:
       # Report status to JCSDA CI slack channel for nightly runs only
       - name: Report Status
         if: always()
-        #'!cancelled()' && ${{ github.event_name == 'schedule' }}
         uses: ravsamhq/notify-slack-action@v1
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/enable_awscli_v2_update_swell
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/enable_awscli_v2_update_swell
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -248,8 +248,8 @@
       version: ['1.0.8']
     py-pybind11:
       version: ['2.8.1']
-    py-pycodestyle:
-      version: ['2.8.0']
+    #py-pycodestyle:
+    #  version: ['2.8.0']
     py-pygithub:
       version: ['1.55']
     py-pygrib:
@@ -264,9 +264,9 @@
       # Versions earlier than 0.11.0 don't compile on macOS with llvm-clang/13.0.0 and Python/3.9,
       # and 0.11.0 leads to downstream errors in py-scipy with the Intel compilers
       version: ['0.12.2']
-    # This version of py-pyyaml goes with awscli@1.27.84
-    py-pyyaml:
-      version: ['5.4.1']
+    ## This version of py-pyyaml goes with awscli@1.27.84
+    #py-pyyaml:
+    #  version: ['5.4.1']
     py-scipy:
       version: ['1.9.3']
     # Pin the py-setuptools version to avoid duplicate Python packages

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -238,9 +238,6 @@
       variants: +blas +lapack
     py-openpyxl:
       version: ['3.0.3']
-    # DH* 20230719 try without version
-    #py-pandas:
-    #  version: ['1.4.0']
     # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
     # versions of py-poetry-core when using external/homebrew Python as
     # we do at the moment in spack-stack.
@@ -248,8 +245,6 @@
       version: ['1.0.8']
     py-pybind11:
       version: ['2.8.1']
-    #py-pycodestyle:
-    #  version: ['2.8.0']
     py-pygithub:
       version: ['1.55']
     py-pygrib:
@@ -264,9 +259,6 @@
       # Versions earlier than 0.11.0 don't compile on macOS with llvm-clang/13.0.0 and Python/3.9,
       # and 0.11.0 leads to downstream errors in py-scipy with the Intel compilers
       version: ['0.12.2']
-    ## This version of py-pyyaml goes with awscli@1.27.84
-    #py-pyyaml:
-    #  version: ['5.4.1']
     py-scipy:
       version: ['1.9.3']
     # Pin the py-setuptools version to avoid duplicate Python packages
@@ -290,14 +282,6 @@
       version: ['2.3.2']
     sp:
       version: ['2.3.3']
-    #texlive:
-      # Assume texlive is provided, hard to install
-      # because of its dependencies. Both Linux and
-      # macOS provide easy-to-install packages that
-      # can be added as external packages.
-      # Note: Uncommenting this entry will break
-      # the container builds.
-      #version: ['2.11.0']
     udunits:
       version: ['2.2.28']
     upp:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -11,7 +11,7 @@
     py-pandas@1.5.3, py-pip, py-pyyaml@5.4.1, py-scipy@1.9.3, py-shapely@1.8.0, py-xarray@2022.3.0,
     sp@2.3.3, udunits@2.2.28, w3nco@2.4.1, w3emc@2.10.0, nco@5.0.6, esmf@8.4.2, mapl@2.35.2,
     yafyaml@0.5.1, zlib@1.2.13, zstd@1.5.2, odc@1.4.6, shumlib@macos_clang_linux_intel_port,
-    awscli@1.27.84, py-globus-cli@3.16.0]
+    awscli-v2@2.13.22, py-globus-cli@3.16.0]
     # Notes:
     # 1. Remove mapl@2.35.2 from clang/mpich container, because mapl doesn't work with mpich@4
     # 2. Don't build CRTM by default so that it gets built in the JEDI bundles

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -5,6 +5,8 @@ packages:
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.5]
       #mpi:: [intel-mpi@2018.0.4]
+    # To support hecflow01
+    target: [haswell]
   mpi:
     buildable: False
   intel-mpi:

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -5,6 +5,7 @@ packages:
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@3.1.4]
       #mpi:: [intel-mpi@2018.4.274]
+    # To support all generations of jet
     target: [core2]
   mpi:
     buildable: False

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -9,6 +9,7 @@ spack:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
   - packages:
       - global-workflow-env
+      - gmao-swell-env
       - gsi-env
       - ewok-env
       - jedi-fv3-env

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -36,7 +36,7 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Gaea C5                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.0/envs/unified-env``              | Dom Heinzeller / ???          |
 | NOAA (RDHPCS)       +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Hera^**                          | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Mark Potts / Dom Heinzeller   |
+|                     | Hera^**                          | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512``            | Mark Potts / Dom Heinzeller   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Jet^**                           | GCC, Intel      | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -539,7 +539,7 @@ For ``spack-stack-1.5.0`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.10.8
@@ -549,15 +549,13 @@ For ``spack-stack-1.5.0`` with GNU, load the following modules after loading min
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core
    module load stack-gcc/9.2.0
    module load stack-openmpi/4.1.5
    module load stack-python/3.10.8
    module available
 
 Note that on Hera, a dedicated node exists for ``ecflow`` server jobs (``hecflow01``). Users starting ``ecflow_server`` on the regular login nodes will see their servers being killed every few minutes, and may be barred from accessing the system.
-
-Further, note that the ``spack-stack-1.5.0`` unified environment on Hera has an additional package ``yafyaml`` installed that does not exist in the default 1.5.0 installation.
 
 .. _Preconfigured_Sites_Jet:
 


### PR DESCRIPTION
### Summary

- Replace `awscli` with `awscli-v2`
- Add `gmao-swell-env` to `unified-env`
- Remove some versions from the common `packages.yaml` since they are either not needed or are leading to duplicate versions being built
- Add target `haswell` to Hera packages config to address https://github.com/JCSDA/spack-stack/issues/812

### Testing

- [x] @climbfuji's macOS
- [x] CI

### Applications affected

All applications using `unified-dev`

### Systems affected

All systems using `unified-dev`

### Dependencies

- [ ] waiting on https://github.com/JCSDA/spack/pull/338

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/242
Resolves https://github.com/JCSDA/spack-stack/issues/801 
Resolves https://github.com/JCSDA/spack-stack/issues/812

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
