### PR TITLE
Bugfix: Update spack submoduel and revert `.gitmodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/py_awscrt_linux
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

I missed pushing the latest update to revert `.gitmodules` and update `spack` when I merged my last PR - sorry.

I am going to merge this asap to fix the current status quo.
