### PR TITLE
Add ecmwf-atlas@0.35.0 and update its build variants

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_ecmwf_from_spack_add_atlas_0p35p0
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_ecmwf_from_spack_add_atlas_0p35p0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -51,7 +51,7 @@
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
       version: ['0.35.0']
-      variants: +fckit +trans
+      variants: +fckit +ectrans +cgal +tesselation +fftw
     ectrans:
       version: ['1.2.0']
       variants: ~enable_mkl

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,7 +54,7 @@
       variants: +fckit +ectrans +cgal +tesselation +fftw
     ectrans:
       version: ['1.2.0']
-      variants: ~enable_mkl
+      variants: ~enable_mkl +fftw
     eigen:
       version: ['3.4.0']
     # Attention - when updating the version also check the common modules.yaml

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -51,7 +51,7 @@
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
       version: ['0.35.0']
-      variants: +fckit +ectrans +cgal +tesselation +fftw
+      variants: +fckit +ectrans +tesselation +fftw
     ectrans:
       version: ['1.2.0']
       variants: ~enable_mkl +fftw

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -50,7 +50,7 @@
       version: ['1.24.4']
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: ['0.34.0']
+      version: ['0.35.0']
       variants: +fckit +trans
     ectrans:
       version: ['1.2.0']

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,7 +1,7 @@
   ### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +cgal +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,7 +1,7 @@
   ### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.34.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,7 +1,7 @@
   ### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +cgal +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +cgal +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,8 +1,8 @@
   ### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.35.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
-    fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.5.0,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +cgal +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw,
+    eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,


### PR DESCRIPTION
### Summary

Add ecmwf-atlas@0.35.0 and update its build variants, especially set consistent `fftw` values for `ectrans` and `ecmwf-atlas` (note that internally, both had `fftw` enabled via the usual ECMWF way of autodetecting features rather than let the user decide, so this is only making it consistent).

### Testing

- [x] CI
- [x] @climbfuji's macOS

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.

### Systems affected

See title. The PR also enables the `fftw` variant for `ectrans` for consistency.

These changes, together with a subset of https://github.com/JCSDA/spack/pull/340, need to be merged back into release/1.5.1.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/340

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/783

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
