### PR TITLE
release/1.5.1: cherry-pick hera bug fix, macOS CI aarch64 updates, and ecmwf-atlas@0.35.0 changes from develop

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -89,15 +89,15 @@ jobs:
 
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[openmpi]"
-          spack config add "packages:all:compiler:[apple-clang@14.0.0]"
+          spack config add "packages:all:compiler:[apple-clang@14.0.3]"
           sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
           spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"
 
           # Concretize and check for duplicates
-          spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm
+          spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.3
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm
 
           # Add and update source cache
           spack mirror add local-source file:///Users/ec2-user/spack-stack/source-cache/
@@ -111,12 +111,6 @@ jobs:
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
-          # Workaround for limited disk space on macOS arm instance
-          spack config add "config:build_stage:/Users/ec2-user/spack-stack/spack-cache/build_stage"
-          spack config add "config:test_stage:/Users/ec2-user/spack-stack/spack-cache/test_stage"
-          spack config add "config:source_cache:/Users/ec2-user/spack-stack/spack-cache/source_cache"
-          spack config add "config:misc_cache:/Users/ec2-user/spack-stack/spack-cache/misc_cache"
-
           # Break installation up in pieces and create build caches in between
           # This allows us to "spin up" builds that altogether take longer than
           # six hours, and/or fail later in the build process.
@@ -124,14 +118,14 @@ jobs:
           # base-env
           echo "base-env ..."
           # DH* 20230721 - todo remove --no-checksum
-          spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.apple-clang-14.0.0.base-env
+          spack install --fail-fast --source --no-check-signature --no-checksum base-env 2>&1 | tee log.install.apple-clang-14.0.3.base-env
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
           spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
           # the rest
           echo "${{ inputs.template || 'unified-dev' }} ..."
           # DH* 20230721 - todo remove --no-checksum
-          spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.apple-clang-14.0.0.${{ inputs.template || 'unified-dev' }}
+          spack install --fail-fast --source --no-check-signature --no-checksum 2>&1 | tee log.install.apple-clang-14.0.3.${{ inputs.template || 'unified-dev' }}
           # DH* 20230721 - todo remove || true (this was here all the time, but should not be needed if spack creates buildcaches correctly)
           spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ || true
 
@@ -158,7 +152,7 @@ jobs:
           ls -l ${ENVDIR}/install/modulefiles/Core
 
           module use ${ENVDIR}/install/modulefiles/Core
-          module load stack-apple-clang/14.0.0
+          module load stack-apple-clang/14.0.3
           module load stack-openmpi/4.1.5
           module load stack-python/3.10.8
           module available

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.5.1
-  url = https://github.com/climbfuji/spack
-  branch = feature/release_151_atlas_0350
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = release/1.5.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.5.1
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.5.1
+  url = https://github.com/climbfuji/spack
+  branch = feature/release_151_atlas_0350
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -51,7 +51,7 @@
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
       version: ['0.35.0']
-      variants: +fckit +trans
+      variants: +fckit +ectrans +cgal +tesselation +fftw
     ectrans:
       version: ['1.2.0']
       variants: ~enable_mkl

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,7 +54,7 @@
       variants: +fckit +ectrans +cgal +tesselation +fftw
     ectrans:
       version: ['1.2.0']
-      variants: ~enable_mkl
+      variants: ~enable_mkl +fftw
     eigen:
       version: ['3.4.0']
     # Attention - when updating the version also check the common modules.yaml

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -51,7 +51,7 @@
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
       version: ['0.35.0']
-      variants: +fckit +ectrans +cgal +tesselation +fftw
+      variants: +fckit +ectrans +tesselation +fftw
     ectrans:
       version: ['1.2.0']
       variants: ~enable_mkl +fftw

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -50,7 +50,7 @@
       version: ['1.24.4']
       variants: linalg=eigen,lapack compression=lz4,bzip2
     ecmwf-atlas:
-      version: ['0.34.0']
+      version: ['0.35.0']
       variants: +fckit +trans
     ectrans:
       version: ['1.2.0']

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,8 +6,8 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.35.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
-    fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +cgal +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
+    eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.0, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +cgal +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -6,7 +6,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 ```
   specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
-    eckit@1.24.4, ecmwf-atlas@0.34.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
+    eckit@1.24.4, ecmwf-atlas@0.35.0 +trans ~fftw, fiat@1.2.0, ectrans@1.2.0 ~fftw, eigen@3.4.0,
     fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,
     gsibec@1.1.3, hdf@4.2.15, hdf5@1.14.0, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -5,6 +5,8 @@ packages:
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.1.5]
       #mpi:: [intel-mpi@2018.0.4]
+    # To support hecflow01
+    target: [haswell]
   mpi:
     buildable: False
   intel-mpi:

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -5,6 +5,7 @@ packages:
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@3.1.4]
       #mpi:: [intel-mpi@2018.4.274]
+    # To support all generations of jet
     target: [core2]
   mpi:
     buildable: False

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -36,7 +36,7 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Gaea C5                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.0/envs/unified-env``              | Dom Heinzeller / ???          |
 | NOAA (RDHPCS)       +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Hera^**                          | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Mark Potts / Dom Heinzeller   |
+|                     | Hera^**                          | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512``            | Mark Potts / Dom Heinzeller   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Jet^**                           | GCC, Intel      | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -539,7 +539,7 @@ For ``spack-stack-1.5.0`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.1
    module load stack-python/3.10.8
@@ -549,15 +549,13 @@ For ``spack-stack-1.5.0`` with GNU, load the following modules after loading min
 
 .. code-block:: console
 
-   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core
    module load stack-gcc/9.2.0
    module load stack-openmpi/4.1.5
    module load stack-python/3.10.8
    module available
 
 Note that on Hera, a dedicated node exists for ``ecflow`` server jobs (``hecflow01``). Users starting ``ecflow_server`` on the regular login nodes will see their servers being killed every few minutes, and may be barred from accessing the system.
-
-Further, note that the ``spack-stack-1.5.0`` unified environment on Hera has an additional package ``yafyaml`` installed that does not exist in the default 1.5.0 installation.
 
 .. _Preconfigured_Sites_Jet:
 


### PR DESCRIPTION
### Summary

This PR cherry-picks the necessary commits from the develop branch to add `ecmwf-atlas@0.35.0` and the new variant `tesselation` required for the 1.5.1 release. It further contains a bug fix for Hera (also cherry-picked from develop) and an update of the macOS aarch64 CI workflow (ditto; without this the CI tests wouldn't succeed any longer).

### Testing

- [x] CI
- [x] All other updates tested on develop (macOS, CI)

### Applications affected

Applications using `ecmwf-atlas` now have access to the `tesselation` functionality (using `qhull` as an additional dependency).

### Systems affected

Hera

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/341

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
