### PR TITLE
release/1.5.1: fix Intel container build (ectrans error), update Derecho documentation Bugfix/container ectrans fftw derecho docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.5.1
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/rel_151_pandas_openpyxl_and_ectrans_fftw_mkl
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = release/1.5.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.5.1
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.5.1
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/rel_151_pandas_openpyxl_and_ectrans_fftw_mkl
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,7 +54,7 @@
       variants: +fckit +ectrans +tesselation +fftw
     ectrans:
       version: ['1.2.0']
-      variants: ~enable_mkl +fftw
+      variants: ~mkl +fftw
     eigen:
       version: ['3.4.0']
     # Attention - when updating the version also check the common modules.yaml

--- a/configs/containers/README.md
+++ b/configs/containers/README.md
@@ -4,7 +4,7 @@ To avoid hardcoding specs in the generic container recipes, we keep the specs li
 
 ### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
 ```
-  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
+  specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
     eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.0, gftl-shared@1.5.0,

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -45,11 +45,12 @@ spack:
       externals:
       - spec: intel-oneapi-mpi@2021.6.0
         prefix: /opt/intel/oneapi
-    intel-oneapi-mkl:
-      buildable: false
-      externals:
-      - spec: intel-oneapi-mkl@2022.1.0
-        prefix: /opt/intel/oneapi
+    # Comment out for now so that fftw-api uses fftw and not mkl
+    #intel-oneapi-mkl:
+    #  buildable: false
+    #  externals:
+    #  - spec: intel-oneapi-mkl@2022.1.0
+    #    prefix: /opt/intel/oneapi
     gmake:
       buildable: false
       externals:

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -375,9 +375,7 @@ The following is required for building new spack environments and for using spac
    module purge
    # ignore that the sticky module ncarenv/... is not unloaded
    export LMOD_TMOD_FIND_FIRST=yes
-   # Temporary, until CISL created the module tree for the newest Intel compilers
-   module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra
-   module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.33
 


### PR DESCRIPTION
### Summary

Same as for https://github.com/JCSDA/spack/pull/342: This time I am doing it the other way round, add to release/1.5.1 and then merge back to develop by cherry-picking the commits ...

1. Fix https://github.com/JCSDA/spack-stack/issues/820 correcting the `fftw` and `mkl` variants for `ectrans` and `jedi-base-env` in the container specs, and by commenting out `intel-oneapi-mkl` in the Intel container recipe (we want to use this in the future when we work on https://github.com/JCSDA/spack-stack/issues/759, therefore not deleting it).
2. A last-minute documentation update for Derecho didn't make it into the release/1.5.0 branch and consequently also not into develop.

### Testing

- [x] Manual build of docker-intel-impi container on Ubuntu CI instance - previously failing ectrans build now succeeds
- [x] CI

### Applications affected

None

### Systems affected

Ubuntu Intel Container builds

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/342

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/818
Resolves https://github.com/JCSDA/spack-stack/issues/820

### Checklist

- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
