### PR TITLE
Update gsi-ncdiag version numbers in config/*

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -107,7 +107,7 @@
     gsibec:
       version: ['1.1.3']
     gsi-ncdiag:
-      version: ['1.1.1']
+      version: ['1.1.2']
     gsl-lite:
       version: ['0.37.0']
     hdf:

--- a/configs/templates/ufs-srw-dev/spack.yaml
+++ b/configs/templates/ufs-srw-dev/spack.yaml
@@ -53,6 +53,6 @@ spack:
   - wgrib2@2.0.8
   - wrf-io@1.2.0
   - ncio@1.1.2
-  - gsi-ncdiag@1.1.1
+  - gsi-ncdiag@1.1.2
   - met@11.1.0
   - metplus@5.1.0


### PR DESCRIPTION
### Summary

This updates the default version of the gsi-ncdiag library in the config/* yaml files to account for the newest version of that library.

### Testing

None

### Applications affected

GSI and GSI-monitor

### Systems affected

All

### Issue(s) addressed

JCSDA/spack#343

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.