### PR TITLE
fms@2023.02.01 as default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = fms_20230201
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = fms_20230201
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -80,7 +80,7 @@
     fms:
       #version: ['2023.01']
       #variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
-      version: ['2023.02']
+      version: ['2023.02.01']
       variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release +use_fmsio
     fontconfig:
       variants: +pic


### PR DESCRIPTION
### Summary

Update fms to 2023.02.01 to get bug fix.

### Testing

--

### Applications affected

gmao-swell-env/package.py
jedi-fv3-env/package.py
jedi-ufs-env/package.py
ufs-srw-app-env/package.py
ufs-weather-model-env/package.py

### Systems affected

--

### Dependencies

https://github.com/JCSDA/spack/pull/345

### Issue(s) addressed

Addresses https://github.com/JCSDA/spack-stack/issues/823

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
