### PR TITLE
Merge py-pandas, py-awscrt, texinfo, and ectrans bug fixes from release/1.5.1 (with mods from spack develop)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/merge_openpyxl_etc_from_release_151
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/merge_openpyxl_etc_from_release_151
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,7 +54,7 @@
       variants: +fckit +ectrans +tesselation +fftw
     ectrans:
       version: ['1.2.0']
-      variants: ~enable_mkl +fftw
+      variants: ~mkl +fftw
     eigen:
       version: ['3.4.0']
     # Attention - when updating the version also check the common modules.yaml

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -236,8 +236,8 @@
     py-numpy:
       version: ['1.22.3']
       variants: +blas +lapack
-    py-openpyxl:
-      version: ['3.0.3']
+    py-pandas:
+      variants: +excel
     # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
     # versions of py-poetry-core when using external/homebrew Python as
     # we do at the moment in spack-stack.

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -44,11 +44,12 @@ spack:
       externals:
       - spec: intel-oneapi-mpi@2021.6.0
         prefix: /opt/intel/oneapi
-    intel-oneapi-mkl:
-      buildable: false
-      externals:
-      - spec: intel-oneapi-mkl@2022.1.0
-        prefix: /opt/intel/oneapi
+    # Comment out for now so that fftw-api uses fftw and not mkl
+    #intel-oneapi-mkl:
+    #  buildable: false
+    #  externals:
+    #  - spec: intel-oneapi-mkl@2022.1.0
+    #    prefix: /opt/intel/oneapi
     gmake:
       buildable: false
       externals:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,5 +1,5 @@
   ### spack-stack-1.5.0 / skylab-6.0.0 containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
-  specs: [base-env@1.0.0, jedi-base-env@1.0.0 ~fftw, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
+  specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.0, ecbuild@3.7.2, eccodes@2.27.0, ecflow@5,
     eckit@1.24.4, ecmwf-atlas@0.35.0 +fckit +ectrans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.5.0,

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -373,9 +373,11 @@ The following is required for building new spack environments and for using spac
 .. code-block:: console
 
    module purge
-   # ignore that the sticky module ncarenv/... is not unloaded
+   ignore that the sticky module ncarenv/... is not unloaded
    export LMOD_TMOD_FIND_FIRST=yes
-   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
+   Temporary, until CISL created the module tree for the newest Intel compilers
+   module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra
+   module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.33
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -375,9 +375,7 @@ The following is required for building new spack environments and for using spac
    module purge
    # ignore that the sticky module ncarenv/... is not unloaded
    export LMOD_TMOD_FIND_FIRST=yes
-   # Temporary, until CISL created the module tree for the newest Intel compilers
-   module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra
-   module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.33
 


### PR DESCRIPTION
### Summary

This PR brings the bug fixes for the packages listed above that went into `release/1.5.1` first down to `develop`. There is a small update that is due to the modifications from spack `develop` (see https://github.com/JCSDA/spack/pull/346 for the glorious details), namely the addition of the `excel` variant for `py-pandas`.

Note that we need to stick with `py-pandas@1.5.3` for a while, because I encountered build problems on my macOS with newer versions due to some complicated `py-numba`-`llvm` compiler dependencies.

### Testing

- [x] @climbfuji's macOS
- [x] CI (ignore the failing container test, this is post-build when it is trying to post a message on the JCSDA CI slack channel, I haven't figured out why this works sometimes and sometimes not

### Applications affected

JEDI applications, although `py-pandas+excel` is really only used in `jedi-tools-env`.

### Systems affected

All systems that install the unified environment.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/346

### Issue(s) addressed

All Github issues were resolved when merging the updates into `release/1.5.1`, this is just bringing the improved and spack-sanctioned versions into `develop`. However, this PR does solve the current container CI failures for the Intel container (these run only twice a week on a nightly schedule using `develop`, errors are reported to the CI slack channel in the JCSDA workspace; see https://github.com/JCSDA/spack-stack/actions/runs/6516462554 for an example of a failed Intel container build).

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
