### PR TITLE
Remove esmf settings from acorn package.yaml

### DIFF
--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -10,8 +10,6 @@
         - libfabric
         - craype-network-ofi
         - cray-mpich/8.1.9
-    esmf:
-      variants: esmf_os=Linux esmf_comm=mpich3
     git:
       buildable: false
       externals:


### PR DESCRIPTION
### Summary

ESMF can correctly pick up on the OS & MPI settings on Acorn, so we don't need the special variant settings in acorn/package.yaml anymore.

### Testing

Tested build and a UFS WM RT on Acorn.

### Applications affected

UFS WM

### Systems affected

Acorn only

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
