### PR TITLE
Update proj from spack develop as of 2023/10/17, disable pr push runs of CI container builds

### DIFF
--- a/.github/workflows/ubuntu-ci-containers-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-containers-x86_64.yaml
@@ -1,9 +1,9 @@
 name: ubuntu-ci-container-x86_64-build
 on:
-  pull_request:
-    # pull request to develop with label
-    branches: [develop]
-    types: [labeled]
+  #pull_request:
+  #  # pull request to develop with label
+  #  branches: [develop]
+  #  types: [labeled]
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
@@ -23,7 +23,7 @@ defaults:
 jobs:
   ubuntu-ci-container-x86_64-build:
     # For PRs only if label matches, and for workflow_dispatch and schedule events
-    if: ${{ github.event.label.name == 'container-ci' }} || ${{ github.event_name == 'workflow_dispatch' }} || ${{ github.event_name == 'schedule' }}
+    #if: ${{ github.event.label.name == 'container-ci' }} || ${{ github.event_name == 'workflow_dispatch' }} || ${{ github.event_name == 'schedule' }}
     runs-on: [ubuntu-ci-x86_64]
 
     steps:

--- a/.github/workflows/ubuntu-ci-containers-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-containers-x86_64.yaml
@@ -64,7 +64,7 @@ jobs:
           else
             # Day 7: The Sabbath of rest
             echo "Pruning all docker images"
-            docker system prune -a
+            docker system prune -a -f
             exit 0
           fi
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_proj_from_spack_dev_20231017
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_proj_from_spack_dev_20231017
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -7,9 +7,9 @@ Known Issues
 General
 ==============================
 
-1. ``gcc@13`` (``gcc``, ``g++``, ``gfortran``) not yet supported
+1. ``gcc@13`` (``gcc``, ``g++``, ``gfortran``) and ``apple-clang@15`` (``clang``, ``clang++``) not yet supported
 
-   Our software stack doesn't build with ``gcc@13`` yet. This is also true when combining the LLVM or Apple ``clang`` compiler with ``gfortran@13``.
+   Our software stack doesn't build with ``gcc@13`` yet. This is also true when combining the LLVM or Apple ``clang`` compiler with ``gfortran@13``. We also don't support the latest release of ``apple-clang@15`` yet.
 
 2. Build errors for ``mapl@2.35.2`` with ``mpich@4.1.1``
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -373,9 +373,9 @@ The following is required for building new spack environments and for using spac
 .. code-block:: console
 
    module purge
-   ignore that the sticky module ncarenv/... is not unloaded
+   # ignore that the sticky module ncarenv/... is not unloaded
    export LMOD_TMOD_FIND_FIRST=yes
-   Temporary, until CISL created the module tree for the newest Intel compilers
+   # Temporary, until CISL created the module tree for the newest Intel compilers
    module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra
    module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles
    module load ecflow/5.8.4


### PR DESCRIPTION
### Summary

Update the submodule pointer for spack for the changes in https://github.com/JCSDA/spack/pull/347 (Update proj from spack develop as of 2023/10/17).

Also:
1. Comment out github action for container builds to run on pull requests, because it doesn't work reliably. There are still the two options to run on schedule and to run via workflow dispatch.
2. Add a note to the Known Issues section in the documentation that `apple-clang@15` is currently not supported.

### Testing

- [x]  CI

### Applications affected

This should fix the issues building the UFS Coastal App on Orion reported in https://github.com/JCSDA/spack-stack/issues/807.

### Systems affected

All (w/ spack-stack-1.6.0)

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/347
 
### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/807

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
