### PR TITLE
Update fms default to 2023.02.01

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.5.1
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = fms_spackstack151
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = fms_spackstack151
+  url = https://github.com/jcsda/spack
+  branch = release/1.5.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -80,7 +80,7 @@
     fms:
       #version: ['2023.01']
       #variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release
-      version: ['2023.02']
+      version: ['2023.02.01']
       variants: precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release +use_fmsio
     fontconfig:
       variants: +pic


### PR DESCRIPTION
### Summary

Bringing fms 2023.02.01 updates to 1.5.1 release. Couldn't cherry pick commit because of submodule conflict.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
