### PR TITLE
ESMF@8.5.0, MAPL@2.40.3 as defaults

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   #url = https://github.com/spack/spack
   #branch = develop
   url = https://github.com/jcsda/spack
-  branch = release/1.5.1
+  branch = AlexanderRichert-NOAA-patch-1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   #url = https://github.com/spack/spack
   #branch = develop
   url = https://github.com/jcsda/spack
-  branch = AlexanderRichert-NOAA-patch-1
+  branch = release/1.5.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -61,7 +61,7 @@
     # config and update the projections for lmod/tcl.
     # Also, check the acorn and derecho site configs which have esmf modifications.
     esmf:
-      version: ['8.4.2']
+      version: ['8.5.0']
       variants: ~xerces ~pnetcdf snapshot=none ~shared +external-parallelio
       require:
         - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
@@ -141,7 +141,7 @@
       # errors with intel@2021.7.0+, see
       # https://github.com/JCSDA/spack-stack/issues/769
       # also: ... extdata2g segfault UFS?
-      version: ['2.35.2']
+      version: ['2.40.3']
       variants: ~shared ~extdata2g ~pflogger
     # If making changes here, also check the Discover site config and the CI workflows
     met:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -239,7 +239,7 @@
     py-openpyxl:
       version: ['3.0.3']
     py-pandas:
-      version: ['1.5.2']
+      version: ['1.5.3']
     # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
     # versions of py-poetry-core when using external/homebrew Python as
     # we do at the moment in spack-stack.

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -95,7 +95,7 @@
     gfsio:
       version: ['1.4.1']
     gftl-shared:
-      version: ['1.5.0']
+      version: ['1.6.1']
     #git-lfs:
       # Assume git-lfs is provided, hard to install
       # because of dependencies on go/go-bootstrap.

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -238,9 +238,8 @@
       variants: +blas +lapack
     py-openpyxl:
       version: ['3.0.3']
-    # DH* 20230719 try without version
-    #py-pandas:
-    #  version: ['1.4.0']
+    py-pandas:
+      version: ['1.5.2']
     # To avoid pip._vendor.pep517.wrappers.BackendInvalid errors with newer
     # versions of py-poetry-core when using external/homebrew Python as
     # we do at the moment in spack-stack.

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -27,7 +27,8 @@ spack:
 
       # Various fms tags (list all to avoid duplicate packages)
       - fms@release-jcsda
-      - fms@2023.02.01
+      - fms@2023.01
+      - fms@2023.02
 
       # Various crtm tags (list all to avoid duplicate packages)
       - crtm@2.4.0

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -28,7 +28,7 @@ spack:
       # Various fms tags (list all to avoid duplicate packages)
       - fms@release-jcsda
       - fms@2023.01
-      - fms@2023.02
+      - fms@2023.02.01
 
       # Various crtm tags (list all to avoid duplicate packages)
       - crtm@2.4.0

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -27,8 +27,7 @@ spack:
 
       # Various fms tags (list all to avoid duplicate packages)
       - fms@release-jcsda
-      - fms@2023.01
-      - fms@2023.02
+      - fms@2023.02.01
 
       # Various crtm tags (list all to avoid duplicate packages)
       - crtm@2.4.0


### PR DESCRIPTION
### Summary

Update ESMF and MAPL defaults per Oct 19 spack-stack meeting.

### Testing

UFS WM cpld_control_p8/intel successful on Orion; cpld_control_gfsv17 successful on Hera

### Applications affected

all

### Systems affected

all

### Dependencies

https://github.com/JCSDA/spack/pull/352

### Issue(s) addressed

Fixes #753

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
