### PR TITLE
release/1.5.1: backport mpich4 workarounds for mapl@2.35.2 and mapl@2.40.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.5.1
-  url = https://github.com/climbfuji/spack
-  branch = feature/mpich4_mapl_backports
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = release/1.5.1
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.5.1
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.5.1
+  url = https://github.com/climbfuji/spack
+  branch = feature/mpich4_mapl_backports
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

Update submodule pointer for spack for the changes described in https://github.com/JCSDA/spack/pull/358.

### Testing

- [x] @climbfuji's macOS: build both `mapl@2.40.3` and `mapl@2.35.2` with the patches
- [x] MSU Hercules: build `mapl@2.35.2` with the patches using `mpich@4.1.2`, `openmpi@4.1.5`, `mvapich2@2.3.7`
- [x]  CI

### Applications affected

UFS applications using `mapl`

### Systems affected

All

### Dependencies

- [ ] waiting on https://github.com/JCSDA/spack/pull/358

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/608

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
