### PR TITLE
release/1.5.1: Update site configs for Derecho, Narwhal, Gaea C5, Discover, AWS ParallelCluster, S4

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -112,7 +112,7 @@
       version: ['0.37.0']
     hdf:
       version: ['4.2.15']
-      variants: ~fortran ~netcdf
+      variants: +external-xdr ~fortran ~netcdf
     hdf5:
       version: ['1.14.0']
       variants: +hl +fortran +mpi ~threadsafe +szip

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -207,6 +207,8 @@
     proj:
       version: ['8.1.0']
       variants: ~tiff
+    # Check site configs for the following systems when making changes here:
+    # Derecho, Narwhal, Gaea-C5
     python:
       version: ['3.10.8']
     py-attrs:

--- a/configs/sites/derecho/compilers.yaml
+++ b/configs/sites/derecho/compilers.yaml
@@ -10,7 +10,7 @@ compilers::
       operating_system: sles15
       target: x86_64
       modules:
-      - ncarenv/23.06
+      - ncarenv/23.09
       - intel/2023.2.1
       environment:
         prepend_path:
@@ -31,7 +31,7 @@ compilers::
       operating_system: sles15
       target: x86_64
       modules:
-      - ncarenv/23.06
+      - ncarenv/23.09
       - gcc/12.2.0
       environment:
         set:

--- a/configs/sites/derecho/compilers.yaml
+++ b/configs/sites/derecho/compilers.yaml
@@ -11,14 +11,12 @@ compilers::
       target: x86_64
       modules:
       - ncarenv/23.09
-      - intel/2023.2.1
+      - intel-classic/2023.2.1
       environment:
         prepend_path:
           PATH: '/opt/cray/pe/gcc/12.2.0/bin'
           CPATH: '/opt/cray/pe/gcc/12.2.0/snos/include'
-          LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2023.2.1/compiler/2023.2.1/linux/compiler/lib/intel64_lin:/opt/cray/pe/gcc/default/snos/lib:/opt/cray/pe/gcc/default/snos/lib64'
-        set:
-          CRAYPE_LINK_TYPE: 'dynamic'
+          LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2023.2.1/compiler/2023.2.1/linux/compiler/lib/intel64_lin:/opt/cray/pe/gcc/12.2.0/snos/lib:/opt/cray/pe/gcc/12.2.0/lib64'
       extra_rpaths: []
   - compiler:
       spec: gcc@12.2.0

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -2,7 +2,7 @@ packages:
   all:
     compiler:: [intel@2021.10.0, gcc@12.2.0]
     providers:
-      mpi:: [cray-mpich@8.1.25] # intel-oneapi-mpi@2021.8.0, 
+      mpi:: [cray-mpich@8.1.25] # intel-oneapi-mpi@2021.10.0,
     target: [core2]
 
 ### MPI, Python, MKL
@@ -10,10 +10,10 @@ packages:
     buildable: False
   #intel-oneapi-mpi:
   #  externals:
-  #  - spec: intel-oneapi-mpi@2021.8.0%intel@2021.8.0
-  #    prefix: /glade/u/apps/derecho/23.06/spack/opt/spack/intel-oneapi-mpi/2021.8.0/oneapi/2023.0.0/mhf4
+  #  - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0
+  #    prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/intel-oneapi-mpi/2021.10.0/oneapi/2023.2.1/ve6v
   #    modules:
-  #    - intel-mpi/2021.8.0
+  #    - intel-mpi/2021.10.0
   cray-mpich:
     externals:
     - spec: cray-mpich@8.1.25%intel@2021.10.0 +wrappers
@@ -39,13 +39,13 @@ packages:
   autoconf:
     externals:
     - spec: autoconf@2.71
-      prefix: /glade/u/apps/derecho/23.06/opt
+      prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: autoconf@2.69
       prefix: /usr
   automake:
     externals:
     - spec: automake@1.16.5
-      prefix: /glade/u/apps/derecho/23.06/opt
+      prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: automake@1.15.1
       prefix: /usr
   binutils:
@@ -62,8 +62,8 @@ packages:
       prefix: /usr
   curl:
     externals:
-    - spec: curl@8.0.1+nghttp2
-      prefix: /glade/u/apps/derecho/23.06/opt
+    - spec: curl@8.1.2+nghttp2
+      prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: curl@7.79.1+gssapi+ldap+nghttp2
       prefix: /usr
   cvs:
@@ -88,21 +88,21 @@ packages:
   flex:
     externals:
     - spec: flex@2.6.4+lex
-      prefix: /glade/u/apps/derecho/23.06/opt
+      prefix: /glade/u/apps/derecho/23.09/opt/view
   gawk:
     externals:
     - spec: gawk@4.2.1
       prefix: /usr
   git:
     externals:
-    - spec: git@2.40.0~tcltk
-      prefix: /glade/u/apps/derecho/23.06/opt
+    - spec: git@2.41.0+tcltk
+      prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: git@2.35.3+tcltk
       prefix: /usr
   git-lfs:
     externals:
     - spec: git-lfs@3.3.0
-      prefix: /glade/u/apps/derecho/23.06/opt
+      prefix: /glade/u/apps/derecho/23.09/opt/view
   gmake:
     externals:
     - spec: gmake@4.2.1
@@ -118,7 +118,7 @@ packages:
   libtool:
     externals:
     - spec: libtool@2.4.7
-      prefix: /glade/u/apps/derecho/23.06/opt
+      prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: libtool@2.4.6
       prefix: /usr
   m4:
@@ -128,8 +128,8 @@ packages:
   # Automatically detected, but don't use - missing "ninja" dependency
   #meson:
   #  externals:
-  #  - spec: meson@1.1.0
-  #    prefix: /glade/u/apps/derecho/23.06/opt
+  #  - spec: meson@1.2.0
+  #    prefix: /glade/u/apps/derecho/23.09/opt/view
   mysql:
     buildable: False
     externals:
@@ -140,7 +140,6 @@ packages:
     - spec: openssh@8.4p1
       prefix: /usr
   openssl:
-    buildable: False
     externals:
     - spec: openssl@1.1.1l
       prefix: /usr
@@ -158,8 +157,8 @@ packages:
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@7.0
-      prefix: /glade/u/apps/derecho/23.06/opt
+    - spec: texinfo@7.0.3
+      prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: texinfo@6.5
       prefix: /usr
   wget:

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -34,6 +34,10 @@ packages:
 ### Modification of common packages
   esmf:
     variants: ~xerces ~pnetcdf snapshot=none ~shared +external-parallelio esmf_os=Linux esmf_comm=mpich
+  # Until problems with OS openssh and spack openssl are resolved,
+  # also use openssl from OS and turn off ssl variant for python
+  python:
+    variants: ~ssl
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -144,6 +144,7 @@ packages:
     - spec: openssh@8.4p1
       prefix: /usr
   openssl:
+    buildable: False
     externals:
     - spec: openssl@1.1.1l
       prefix: /usr

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -17,19 +17,19 @@ packages:
   cray-mpich:
     externals:
     - spec: cray-mpich@8.1.25%intel@2021.10.0 +wrappers
-      prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
+      #prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
       modules:
       - craype/2.7.20
       - cray-mpich/8.1.25
-      - libfabric/1.15.2.0
-      - cray-pals/1.2.11
+      #- libfabric/1.15.2.0
+      #- cray-pals/1.2.11
     - spec: cray-mpich@8.1.25%gcc@12.2.0 +wrappers
-      prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
+      #prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
       modules:
       - craype/2.7.20
       - cray-mpich/8.1.25
-      - libfabric/1.15.2.0
-      - cray-pals/1.2.11
+      #- libfabric/1.15.2.0
+      #- cray-pals/1.2.11
 
 ### Modification of common packages
   esmf:

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -21,15 +21,15 @@ packages:
       modules:
       - craype/2.7.20
       - cray-mpich/8.1.25
-      #- libfabric/1.15.2.0
-      #- cray-pals/1.2.11
+      - libfabric/1.15.2.0
+      - cray-pals/1.2.11
     - spec: cray-mpich@8.1.25%gcc@12.2.0 +wrappers
       #prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
       modules:
       - craype/2.7.20
       - cray-mpich/8.1.25
-      #- libfabric/1.15.2.0
-      #- cray-pals/1.2.11
+      - libfabric/1.15.2.0
+      - cray-pals/1.2.11
 
 ### Modification of common packages
   esmf:

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -13,6 +13,12 @@ packages:
       - craype-network-ofi
       - cray-mpich/8.1.25
 
+### Modification of common packages
+  # Until problems with OS openssh and spack openssl are resolved,
+  # also use openssl from OS and turn off ssl variant for python
+  python:
+    variants: ~ssl
+
 ### All other external packages listed alphabetically
   autoconf:
     externals:

--- a/configs/sites/narwhal/packages.yaml
+++ b/configs/sites/narwhal/packages.yaml
@@ -28,6 +28,12 @@ packages:
   #    modules:
   #    - intel/2021.3.0
 
+### Modification of common packages
+  # Until problems with OS openssh and spack openssl are resolved,
+  # also use openssl from OS and turn off ssl variant for python
+  python:
+    variants: ~ssl
+
 ### All other external packages listed alphabetically
   autoconf:
     externals:

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -540,10 +540,6 @@ openmpi
 NCAR-Wyoming Derecho
 ------------------------------
 
-# DH* I don't think intel is needed anymore, but the other two are ...
-intel (temporary)
-  Until CISL makes the newest Intel compilers available in the default module tree, create directory ``/lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra/intel`` and copy ``/glade/work/csgteam/spack-deployments/derecho/23.06/envs/build/modules/23.06/Core/intel/2023.2.1.lua`` to this directory. Edit the file and remove the block of lines starting with ``-- Find custom moduleroots`` and ending with ``append_path("MODULEPATH", "/glade/work/csgteam/spack-deployments/derecho/23.06/envs/build/modules/23.06/oneapi/2023.2.1")``. Further, replace ``icx`` with ``icc`` and ``icpx`` with ``icpc`` and correct the path in environment variables ``CC``, ``CXX``, etc.
-
 libfabric (temporary)
   Until CISL fixes its unusual way of setting up Cray module environments, it is necessary to create a libfabrics module to be able to use the cray-mpich MPI library without Cray compiler wrappers. Create a module file based on the template ``doc/modulefile_templates/libfabric`` in directory ``/glade/work/epicufsrt/contrib/spack-stack/derecho/libfabric``. This module is currently listed in the dependency modules for the ``cray-mpich`` MPI provider in the Derecho site config. It is also necessary to "include" (a confusing term, it used to be "whitelist") the ``cray-mpich`` module in Derecho's ``modules.yaml`` file, because the CISL ``cray-mpich`` module cannot be loaded without loading their compiler modules.
 

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -540,14 +540,15 @@ openmpi
 NCAR-Wyoming Derecho
 ------------------------------
 
+# DH* I don't think intel is needed anymore, but the other two are ...
 intel (temporary)
   Until CISL makes the newest Intel compilers available in the default module tree, create directory ``/lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra/intel`` and copy ``/glade/work/csgteam/spack-deployments/derecho/23.06/envs/build/modules/23.06/Core/intel/2023.2.1.lua`` to this directory. Edit the file and remove the block of lines starting with ``-- Find custom moduleroots`` and ending with ``append_path("MODULEPATH", "/glade/work/csgteam/spack-deployments/derecho/23.06/envs/build/modules/23.06/oneapi/2023.2.1")``. Further, replace ``icx`` with ``icc`` and ``icpx`` with ``icpc`` and correct the path in environment variables ``CC``, ``CXX``, etc.
 
 libfabric (temporary)
-  Until CISL makes the newest Intel compilers available in the default module tree, it is necessary to create a libfabrics module to be able to use the cray-mpich MPI library without Cray compiler wrappers. Create directory ``/lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra/libfabric`` and create a module file based on the template ``doc/modulefile_templates/libfabric``. This module is currently listed in the dependency modules for the ``cray-mpich`` MPI provider in the Derecho site config. It is also necessary to "include" (a confusing term, it used to be "whitelist") the ``cray-mpich`` module in Derecho's ``modules.yaml`` file, because the CISL ``cray-mpich`` module cannot be loaded without loading their compiler modules (yes, they tend to make things difficult).
+  Until CISL fixes its unusual way of setting up Cray module environments, it is necessary to create a libfabrics module to be able to use the cray-mpich MPI library without Cray compiler wrappers. Create a module file based on the template ``doc/modulefile_templates/libfabric`` in directory ``/glade/work/epicufsrt/contrib/spack-stack/derecho/libfabric``. This module is currently listed in the dependency modules for the ``cray-mpich`` MPI provider in the Derecho site config. It is also necessary to "include" (a confusing term, it used to be "whitelist") the ``cray-mpich`` module in Derecho's ``modules.yaml`` file, because the CISL ``cray-mpich`` module cannot be loaded without loading their compiler modules.
 
 cray-pals (temporary)
-  Until CISL fixes its unusual way of setting up Cray module environments, it is necessary to create a cray-pals (parallel application launcher) module to be able to find ``mpirun`` etc. Create directory ``/lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra/cray-pals`` and copy file ``/opt/cray/pe/lmod/modulefiles/core/cray-pals/1.2.11.lua`` into this directory.
+  Until CISL fixes its unusual way of setting up Cray module environments, it is necessary to create a cray-pals (parallel application launcher) module to be able to find ``mpirun`` etc. Create directory ``/glade/work/epicufsrt/contrib/spack-stack/derecho/cray-pals`` and copy file ``/opt/cray/pe/lmod/modulefiles/core/cray-pals/1.2.11.lua`` into this directory.
 
 ecflow
   ``ecFlow`` must be built manually using the GNU compilers and linked against a static ``boost`` library. After loading the following modules, follow the instructions in :numref:`Section %s <MaintainersSection_ecFlow>` to install ``ecflow``. Be sure to follow the extra instructions for Derecho in that section.

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -329,6 +329,9 @@ For ``spack-stack-1.5.0`` with Intel, load the following modules after loading m
 NCAR-Wyoming Cheyenne
 ---------------------
 
+.. note::
+   Cheyenne will be decommissioned end of 2023. The last supported version of spack-stack on this system is 1.5.0.
+
 The following is required for building new spack environments and for using spack to build and run software.
 
 .. code-block:: console

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -28,7 +28,7 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NCAR-Wyoming        | Cheyenne                         | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.5.0/envs/{unified-env,ufs-env}``     | Cam Book / Dom Heinzeller     |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Derecho                          | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env-intel-test``     | Mark Potts / Dom Heinzeller   |
+|                     | Derecho                          | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env``                | Dom Heinzeller / Mark Potts   |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (NCEP)         | Acorn                            | Intel           | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.5.0/envs/unified-env``                         | Hang Lei / Alex Richert       |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -42,7 +42,7 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Narwhal                          | Intel           | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-intel-2021.4.0``               | Dom Heinzeller / Sarah King   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Narwhal                          | GCC             | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env-gcc-10.3.0``                   | Dom Heinzeller / Sarah King   |
+|                     | Narwhal                          | GCC             | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-gcc-10.3.0``                   | Dom Heinzeller / Sarah King   |
 | U.S. Navy (HPCMP)   +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Nautilus                         | Intel^*         | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env``                              | Dom Heinzeller / Sarah King   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -233,11 +233,11 @@ With GNU, the following is required for building new spack environments and for 
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.0`` with GNU, load the following modules after loading the above modules.
+For ``spack-stack-1.5.1`` with GNU, load the following modules after loading the above modules.
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env-gcc-10.3.0/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-gcc-10.3.0/install/modulefiles/Core
    module load stack-gcc/10.3.0
    module load stack-cray-mpich/8.1.14
    module load stack-python/3.10.8
@@ -385,8 +385,18 @@ For ``spack-stack-1.5.1`` with Intel, load the following modules after loading e
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env-intel-test/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.10.0
+   module load stack-cray-mpich/8.1.25
+   module load stack-python/3.10.8
+   module available
+
+For ``spack-stack-1.5.1`` with GNU, load the following modules after loading ecflow and mysql:
+
+.. code-block:: console
+
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module load stack-gcc/12.2.0
    module load stack-cray-mpich/8.1.25
    module load stack-python/3.10.8
    module available

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -48,7 +48,7 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Nautilus                         | AOCC            | *currently not supported*                                                                               | Dom Heinzeller / Sarah King   |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | S4                               | Intel           | ``/data/prod/jedi/spack-stack/spack-stack-1.5.0/envs/unified-env``                                      | Dom Heinzeller / Mark Potts   |
+|                     | S4                               | Intel           | ``/data/prod/jedi/spack-stack/spack-stack-1.5.1/envs/unified-env``                                      | Dom Heinzeller / Mark Potts   |
 | Univ. of Wisconsin  +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | S4                               | GCC             | *currently not supported*                                                                               | Dom Heinzeller / Mark Potts   |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -620,11 +620,11 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /data/prod/jedi/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /data/prod/jedi/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.5.0
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.10.8

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -22,7 +22,7 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 | MSU                 +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Orion                            | GCC, Intel      | ``/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.0/envs/unified-env``                      | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-| NASA                | Discover                         | GCC, Intel      | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.0/envs/unified-env``                                  | Dom Heinzeller / ???          |
+| NASA                | Discover                         | GCC, Intel      | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.1/envs/unified-env``                                  | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Casper                           | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.5.0/envs/unified-env``                 | Dom Heinzeller / ???          |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -158,21 +158,21 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.0.1
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.10.8
    module available
 
-For ``spack-stack-1.5.0`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.1`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-openmpi/4.1.3
    module load stack-python/3.10.8

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -28,19 +28,19 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NCAR-Wyoming        | Cheyenne                         | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/cheyenne/spack-stack-1.5.0/envs/{unified-env,ufs-env}``     | Cam Book / Dom Heinzeller     |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Derecho                          | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.0/envs/unified-env``                | Mark Potts / Dom Heinzeller   |
+|                     | Derecho                          | Intel           | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env-intel-test``     | Mark Potts / Dom Heinzeller   |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (NCEP)         | Acorn                            | Intel           | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.5.0/envs/unified-env``                         | Hang Lei / Alex Richert       |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Gaea C4                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/envs/unified-env``              | Dom Heinzeller / ???          |
+|                     | Gaea C4                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/envs/unified-env``              | Dom Heinzeller / Cam Book     |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Gaea C5                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.0/envs/unified-env``              | Dom Heinzeller / ???          |
+|                     | Gaea C5                          | Intel           | ``/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.1/envs/unified-env``              | Dom Heinzeller / Cam Book     |
 | NOAA (RDHPCS)       +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Hera^**                          | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512``            | Mark Potts / Dom Heinzeller   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Jet^**                           | GCC, Intel      | ``/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env``                     | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Narwhal                          | Intel           | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env-intel-2021.4.0``               | Dom Heinzeller / Sarah King   |
+|                     | Narwhal                          | Intel           | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-intel-2021.4.0``               | Dom Heinzeller / Sarah King   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Narwhal                          | GCC             | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env-gcc-10.3.0``                   | Dom Heinzeller / Sarah King   |
 | U.S. Navy (HPCMP)   +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -204,11 +204,11 @@ With Intel, the following is required for building new spack environments and fo
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.0`` with Intel, load the following modules after loading the above modules.
+For ``spack-stack-1.5.1`` with Intel, load the following modules after loading the above modules.
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.0/envs/unified-env-intel-2021.4.0/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-intel-2021.4.0/install/modulefiles/Core
    module load stack-intel/2021.4.0
    module load stack-cray-mpich/8.1.14
    module load stack-python/3.10.8
@@ -378,11 +378,11 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.33
 
-For ``spack-stack-1.5.0`` with Intel, load the following modules after loading ecflow and mysql:
+For ``spack-stack-1.5.1`` with Intel, load the following modules after loading ecflow and mysql:
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env-intel-test/install/modulefiles/Core
    module load stack-intel/2021.10.0
    module load stack-cray-mpich/8.1.25
    module load stack-python/3.10.8
@@ -496,11 +496,11 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.0`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.5.1`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2023.1.0
    module load stack-cray-mpich/8.1.25
    module load stack-python/3.10.8

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -375,6 +375,7 @@ The following is required for building new spack environments and for using spac
    module purge
    # ignore that the sticky module ncarenv/... is not unloaded
    export LMOD_TMOD_FIND_FIRST=yes
+   module load ncarenv/23.09
    module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.33

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -55,10 +55,8 @@ Ready-to-use spack-stack 1.5.0 installations are available on the following, ful
 | **Cloud platforms**                                                                                                                                                                                                |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | AMI Red Hat 8                    | GCC             | ``/home/ec2-user/spack-stack/spack-stack-1.5.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
-+                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-| Amazon Web Services | Parallelcluster JCSDA R&D        | Intel           | ``/mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env``                                   | Dom Heinzeller / ???          |
-+                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Parallelcluster JCSDA ROMEX      | Intel           | ``/mnt/experiments-efs/ROMEX/spack-stack-1.5.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
++ Amazon Web Services +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
+|                     | Parallelcluster JCSDA R&D        | Intel           | ``/mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env``                                   | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (RDHPCS)       | RDHPCS Cloud (Parallel Works)^** | Intel           | ``/contrib/spack-stack/spack-stack-1.5.0/envs/unified-env``                                             | Mark Potts / Cam Book / Dom H |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -633,24 +631,24 @@ Amazon Web Services Parallelcluster Ubuntu 20.04
 
 Access to the JCSDA-managed AWS Parallel Clusters is not available to the public. The following instructions are for JCSDA core staff and in-kind contributors.
 
-For ``spack-stack-1.5.0`` with Intel on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
+For ``spack-stack-1.5.1`` with Intel on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
 
 .. code-block:: console
 
    module purge
    ulimit -s unlimited
    source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
-   module use /mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.1.0
    module load stack-intel-oneapi-mpi/2021.6.0
    module load stack-python/3.10.8
    module available
 
-For ``spack-stack-1.5.0`` with GNU on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
+For ``spack-stack-1.5.1`` with GNU on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
 
    module purge
    ulimit -s unlimited
-   module use /mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+   module use /mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.4.0
    module load stack-openmpi/4.1.4
    module load stack-python/3.10.8
@@ -658,24 +656,7 @@ For ``spack-stack-1.5.0`` with GNU on the JCSDA R&D cluster (``hpc6a.48xlarge`` 
 
 .. note::
 
-   Users reported problems with parallel applications using GNU+OpenMPI in earlier versions of spack-stack. This may still be the case for ``spack-stack-1.5.0``. We recommend using the well-tested Intel setup.
-
-For ``spack-stack-1.5.0`` with Intel on the JCSDA ROMEX cluster (``c6i.32xlarge`` instances), run the following commands/load the following modules:
-
-.. code-block:: console
-
-   module purge
-   ulimit -s unlimited
-   source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
-   module use /mnt/experiments-efs/ROMEX/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
-   module load stack-intel/2022.1.0
-   module load stack-intel-oneapi-mpi/2021.6.0
-   module load stack-python/3.10.8
-   module available
-
-.. note::
-
-   There is no GNU option for the ROMEX cluster.
+   The GNU stack is currently under testing and may not work as expected. We recommend using the well-tested Intel setup.
 
 -----------------------------
 Amazon Web Services Red Hat 8


### PR DESCRIPTION
### Summary

Update site configs and documentation for release/1.5.1 on Derecho, Narwhal, Gaea C5, Discover, S4.

To avoid duplicate packages, the `+external_hdr` variant for `hdf` is now explicitly listed in `configs/common/packages.yaml` (the default is `True` anyway).

Included is also a workaround for https://github.com/JCSDA/spack-stack/issues/854, which entails turning off the `ssl` variant for Python on systems with old `libssh` (`openssh`) and `libssl` (`openssl`) OS packages.

### Testing

Installed successfully and tested in parts on all of the above platforms.

### Applications affected

None

### Systems affected

Derecho, Narwhal, Gaea C5, Discover

### Dependencies

n/a

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/819

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
