### PR TITLE
Bug fix to re-enable CI container notifications in slack channel

### DIFF
--- a/.github/workflows/ubuntu-ci-containers-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-containers-x86_64.yaml
@@ -48,20 +48,14 @@ jobs:
           if [[ $DOW == 1 || $DOW == 4 ]]; then
             export CONTAINER=${{ inputs.container || 'docker-ubuntu-clang-mpich' }}
             export SPECS=${{ inputs.specs || 'jedi-ci' }}
-            echo "::set-output name=report-status::true"
           elif [[ $DOW == 2 || $DOW == 5 ]]; then
             export CONTAINER=${{ inputs.container || 'docker-ubuntu-gcc-openmpi' }}
             export SPECS=${{ inputs.specs || 'jedi-ci' }}
-            echo "::set-output name=report-status::true"
           elif [[ $DOW == 3 || $DOW == 6 ]]; then
             export CONTAINER=${{ inputs.container || 'docker-ubuntu-intel-impi' }}
             export SPECS=${{ inputs.specs || 'jedi-ci' }}
-            echo "::set-output name=report-status::true"
           else
-            # Day 7: The Sabbath of rest
-            echo "Pruning all docker images"
-            docker system prune -a -f
-            echo "::set-output name=report-status::false"
+            # Day 7: The Sabbath of rest (but do some house keeping later on)
             exit 0
           fi
 
@@ -78,8 +72,7 @@ jobs:
 
       # Report status to JCSDA CI slack channel for nightly runs only
       - name: Report Status
-        #if: always()
-        if: steps.create-ctr.report-status == true
+        if: always()
         uses: ravsamhq/notify-slack-action@v1
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
@@ -98,3 +91,16 @@ jobs:
           # Default: notify channel
           mention_groups: '!channel'
           mention_groups_when: 'failure,warnings'
+
+      # We can only clean the docker image registry *after* reporting
+      # the status to the CI slack channel, because the cleanup is
+      # deleting the docker image for ravsamhq/notify-slack-action@v1
+      - name: clean-docker-registry
+        if: always()
+        run: |
+          # Get day of week (only run this on Sunday, which is 7)
+          DOW=$(date +%u)
+          if [[ $DOW == 7 ]]; then
+            echo "Pruning all docker images"
+            docker system prune -a -f
+          fi


### PR DESCRIPTION


### Summary

In a previous PR (#844), I added some fancy logic to bypass sending messages to the slack CI channel when the container registry is purged on Sundays. This was intended to fix errors arising from the container used for the CI notification action being deleted as part of the purge. Unfortunately, it didn't work as expected (and there is no good way to test this a priori), and no slack message were sent at all since then.

This PR fixes this in a different way, namely to run the container registry purge after the slack CI message is sent. There is one tiny little problem with this approach, namely that if errors occur during the purging, we wouldn't know from the slack CI channel, but I still get the emails about failed jobs (so we are safe).

### Testing

As before, we can only test the logic that applies on the current day (and the "Sunday" test is already past - in one week we'll know if everything works as expected).

### Applications affected

n/a

### Systems affected

CI

### Dependencies


### Issue(s) addressed

Issue is that current container CI does not send slack messages at all.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~ (see above)
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
