### PR TITLE
 Add symlinks for hdf5 library names when built in debug mode (in spack)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/hdf5_debug_jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/hdf5_debug_jcsda_emc_spack_stack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

This PR only updates the submodule pointer for spack for the changes described in https://github.com/JCSDA/spack/pull/366

### Testing

- [x] CI (not using the debug version of hdf5, but at least making sure that it doesn't break the existing build)
- [x] Built a chained environment with hdf+debug on my local macOS with these changes

### Applications affected

None directly (none of them uses hdf5+debug)

### Systems affected

None directly

### Dependencies

- [ ] waiting on https://github.com/JCSDA/spack/pull/366

### Issue(s) addressed

n/a

### Checklist

- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
