### PR TITLE
Update AWS RH8 instructions

### DIFF
--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -680,7 +680,7 @@ For ``spack-stack-1.5.1``, run:
 .. code-block:: console
 
    ulimit -s unlimited
-   scl enable gcc-toolset-11 bash
+   scl_source enable gcc-toolset-11
    module use /home/ec2-user/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/11.2.1
    module load stack-openmpi/4.1.5


### PR DESCRIPTION
### Summary

The instructions in the Amazon Web Services RedHat 8 section should be reverted back to `scl_source enable gcc-toolset-11`

### Testing

Describe the testing done for this PR.

### Applications affected

JEDI

### Systems affected

AMS RH8

### Dependencies

None

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.

