### PR TITLE
Update to Boost version 1.83.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/srherbener/spack
-  branch = feature/add-boost-1.83.0
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/srherbener/spack
+  branch = feature/add-boost-1.83.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -19,7 +19,7 @@
     bison:
       version: ['3.8.2']
     boost:
-      version: ['1.78.0']
+      version: ['1.83.0']
       variants: ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=17 visibility=hidden
     bufr:
       version: ['12.0.1']


### PR DESCRIPTION
### Summary

This PR updates the common/packages.py to use the latest version of Boost (1.83.0) which contains a fix for a narrowing implicit integer conversion error in the boost include file: executor.hpp.

### Testing

Describe the testing done for this PR.
Testing building this on my arm64 mac and verified that the fix for the narrowing conversion works.
CI tests passed.

### Applications affected

JEDI, UFS, etc.

### Systems affected

MacOS and HPC platforms

### Dependencies

- [x] waiting on jcsda/spack/pull/367

### Issue(s) addressed

Resolves #874

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
