### PR TITLE
Update documentation for latest spack-stack installation (1.5.1+) on Discover, readthedocs conf.py update

### DIFF
--- a/doc/source/BuildingContainers.rst
+++ b/doc/source/BuildingContainers.rst
@@ -25,7 +25,7 @@ It is important to know that container builds do not allow for multiple versions
    spack stack create ctr -h
 
    # Create container spack definition (spack.yaml) in directory envs/<container-config>
-   spack stack create ctr container=docker-ubuntu-gcc-openmpi --specs=jedi-ci
+   spack stack create ctr --container=docker-ubuntu-gcc-openmpi --specs=jedi-ci
 
    # Descend into container environment directory
    cd envs/docker-ubuntu-gcc-openmpi

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -22,7 +22,7 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 | MSU                 +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Orion                            | GCC, Intel      | ``/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/unified-env``                      | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-| NASA                | Discover                         | GCC, Intel      | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.1/envs/unified-env``                                  | Dom Heinzeller / ???          |
+| NASA                | Discover^**                      | GCC, Intel      | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-dev-20231114/envs/unified-env``                           | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Casper                           | GCC             | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.5.1/envs/unified-env``                 | Dom Heinzeller / ???          |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -62,6 +62,8 @@ Ready-to-use spack-stack 1.5.1 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 
 ^* Uses a different ``wgrib2`` version 3.1.1 than the default 2.0.8.
+
+^** Uses a slightly newer version than the spack-stack 1.5.1 release, so that `gmao-swell-env` is available in the environment.
 
 For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/jcsda/spack-stack/issues>`_ and `discussions <https://github.com/jcsda/spack-stack/discussions>`_ first.
 
@@ -160,7 +162,7 @@ For ``spack-stack-1.5.1`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-dev-20231114/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.0.1
    module load stack-intel-oneapi-mpi/2021.5.0
    module load stack-python/3.10.8
@@ -170,7 +172,7 @@ For ``spack-stack-1.5.1`` with GNU, load the following modules after loading min
 
 .. code-block:: console
 
-   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-dev-20231114/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/10.1.0
    module load stack-openmpi/4.1.3
    module load stack-python/3.10.8

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,11 +24,9 @@ copyright = '2023 '
 author = 'Dominikus Heinzeller, Alexander Richert, Cameron Book'
 
 # The short X.Y version
-#version = '1.5'
 version = 'dev'
 
 # The full version, including alpha/beta/rc tags
-#release = '1.5.1'
 release = 'develop'
 
 numfig = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,9 +24,12 @@ copyright = '2023 '
 author = 'Dominikus Heinzeller, Alexander Richert, Cameron Book'
 
 # The short X.Y version
-version = '1.5'
+#version = '1.5'
+version = 'dev'
+
 # The full version, including alpha/beta/rc tags
-release = '1.5.1'
+#release = '1.5.1'
+release = 'develop'
 
 numfig = True
 


### PR DESCRIPTION
### Summary

In the title.

The readthedocs conf.py update is an attempt to reduce the confusion when looking at the "latest" version of spack-stack's readthedocs. So far, we simply kept the latest release tag in `conf.py`, which then found its way into the top left corner of the page. This PR replaces it with dev / develop.

### Testing

Describe the testing done for this PR.

### Applications affected

n/a

### Systems affected

Discover

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/878

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications. @danholdaway
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
