### PR TITLE
Update ecflow version to 5.11.4 (latest)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/srherbener/spack
-  branch = bugfix/ecflow-boost-cxx17
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/srherbener/spack
+  branch = bugfix/ecflow-boost-cxx17
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -45,7 +45,7 @@
       version: ['2.27.0']
       variants: +png
     ecflow:
-      version: ['5.8.4']
+      version: ['5.11.4']
       variants: +ui
     eckit:
       version: ['1.24.4']


### PR DESCRIPTION
### Summary

This PR contains an update to the ecflow version from 5.8.4 to 5.11.4. This is needed to enable building ecflow on the macOS using the new apple-clang@15.0.0 compilers.

### Testing

I have tested this manually on my Mac and verified that ecflow builds successfully. I also verified that using ecflow 5.84 doesn't work, which is why the version bump to 5.11.4 is necessary.

### Applications affected

This is only a change to the ecflow version, and my understanding is that JEDI is the only app using ecflow. Please correct me if this is wrong.

### Systems affected

macOS and HPC systems

### Dependencies

- [x] waiting on jcsda/spack/pull/370

### Issue(s) addressed

Resolves #877

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
