### PR TITLE
Add utility for single-node parallel installations

### DIFF
--- a/doc/source/Utilities.rst
+++ b/doc/source/Utilities.rst
@@ -28,6 +28,18 @@ check_permissions.sh
 
 The utility located at util/check_permissions.sh can be run inside any spack-stack environment directory intended for multiple users (i.e., on an HPC or cloud platform). It will return errors if the environment directory is inaccessible to non-owning users and groups (i.e., if o+rx not set), as well as if any directories or files have permissions that make them inaccessible to other users.
 
+.. _Parallel_Install:
+
+------------------------------
+parallel_install.sh
+------------------------------
+
+The util/parallel_install.sh utility runs parallel installations by launching multiple ``spack install`` instances as backgrounded processes. It can be run as an executable or sourced; the latter option will cause the launched jobs to be associated with the current shell environment. It takes the number of ``spack install`` instances to launch and the number of threads per instance as arguments, in that order, and accepts optional arguments which are applied to each ``spack install`` instance. For instance, ``util/parallel_install.sh 4 8 --fail-fast`` will run four instances of ``spack install -j8 --fail-fast &``. Output files are automatically saved under the current Spack environment directory, ``$SPACK_ENV``.
+
+.. note::
+   The parallel_install.sh utility runs all installation instances on a single node, therefore be respectful of other users and of system usage policies, such as computing limits on HPC login nodes.
+
+
 .. _Acorn_Utilities:
 
 ------------------------------

--- a/util/parallel_install.sh
+++ b/util/parallel_install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+
+# This script launches backgrounded instances of the 'spack install' command
+# for an active Spack environment ($SPACK_ENV must be set). The first two
+# arguments are required, specifying the number of instances and number of
+# threads per instance, respectively. Remaining arguments are passed to the
+# 'spack install' command. It is strongly recommended to only run this utility
+# in a concretized environment. The script can be sourced so that the
+# backgrounded jobs are associated with the current shell environment (strongly
+# recommended when running inside a 'screen' or 'tmux' session).
+#
+# NOTE: If you are installing on a shared system (i.e., an HPC platform),
+# especially if not running through a job scheduler with specified resources,
+# be respectful of system resources and usage policies.
+#
+# *Depending on available resources*, for building the entire spack-stack
+# unified environment, 2-4 instances with 4-8 cores each is generally
+# reasonable. Six or more instances is generally overkill, as is more than 8
+# cores per package build.
+#
+# Example usage:
+#
+#  % ../../utils/parallel_install.sh 2 6
+# -or-
+#  % utils/parallel_install.sh 4 4 --fail-fast --verbose esmf
+
+argtext="Run as '$0 N M', where N=# of instances, M=# of threads per instance"
+n_instances=${1?"$argtext"}
+n_threads=${2?"$argtext"}
+shift 2
+
+if [[ ! " $(seq -s ' ' 10) " =~ " $n_instances " ]]; then echo "Invalid number of instances" ; exit 1; fi
+if [[ ! " $(seq -s ' ' 64) " =~ " $n_threads " ]]; then echo "Invalid number of threads" ; exit 1; fi
+
+echo "Installing with $n_instances instances and ${n_threads} threads in environment '${SPACK_ENV?"SPACK_ENV not set!"}'"
+
+for i in $(seq $n_instances); do
+  cmd="spack install -j $n_threads $*"
+  echo $cmd | tee ${SPACK_ENV}/log.install.proc${i}
+  $cmd &>> ${SPACK_ENV}/log.install.proc${i} &
+done
+
+# If running as executable:
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    wait
+fi

--- a/util/parallel_install.sh
+++ b/util/parallel_install.sh
@@ -24,15 +24,21 @@
 # -or-
 #  % . utils/parallel_install.sh 4 4 --fail-fast --verbose esmf
 
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit=exit
+else
+  exit=return
+fi
+
 argtext="Run as '$0 N M', where N=# of instances, M=# of threads per instance"
 n_instances=${1?"$argtext"}
 n_threads=${2?"$argtext"}
 shift 2
 
-if [[ ! " $(seq -s ' ' 10) " =~ " $n_instances " ]]; then echo "Invalid number of instances" ; exit 1; fi
-if [[ ! " $(seq -s ' ' 64) " =~ " $n_threads " ]]; then echo "Invalid number of threads" ; exit 1; fi
+if [[ ! " $(seq -s ' ' 10) " =~ " $n_instances " ]]; then echo "Invalid number of instances" ; $exit 1; fi
+if [[ ! " $(seq -s ' ' 64) " =~ " $n_threads " ]]; then echo "Invalid number of threads" ; $exit 1; fi
 
-echo "Installing with $n_instances instances and ${n_threads} threads in environment '${SPACK_ENV?"SPACK_ENV not set!"}'"
+echo "Installing with $n_instances instances and $n_threads threads in environment '${SPACK_ENV?"SPACK_ENV not set!"}'" || $exit 1
 
 for i in $(seq $n_instances); do
   cmd="spack install -j $n_threads $*"
@@ -51,5 +57,5 @@ fi
 
 if [ $iret -ne 0 ]; then
   echo "ERROR: One or more install processes exited non-zero!"
-  exit $iret
+  $exit $iret
 fi

--- a/util/parallel_install.sh
+++ b/util/parallel_install.sh
@@ -22,7 +22,7 @@
 #
 #  % ../../utils/parallel_install.sh 2 6
 # -or-
-#  % utils/parallel_install.sh 4 4 --fail-fast --verbose esmf
+#  % . utils/parallel_install.sh 4 4 --fail-fast --verbose esmf
 
 argtext="Run as '$0 N M', where N=# of instances, M=# of threads per instance"
 n_instances=${1?"$argtext"}


### PR DESCRIPTION
### Summary

This PR adds a utility for doing single-node parallel installations using backgrounded instances of `spack install`. Mostly suitable for small installations or interactive batch jobs; for larger installations using a batch job along the lines of what we have for Acorn probably makes more sense.

### Testing

Tested on personal machine.

### Applications affected

none

### Systems affected

none

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
