### PR TITLE
crtm: use v2.4.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = crtm_update_dec23
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = crtm_update_dec23
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -37,7 +37,7 @@
       variants: +ownlibs
     # Attention - when updating also check the various jcsda-emc-bundles env packages
     crtm:
-      version: ['2.4.0']
+      version: ['2.4.0.1']
       variants: +fix
     ecbuild:
       version: ['3.7.2']


### PR DESCRIPTION
### Summary

This PR moves the default crtm to v2.4.0.1

### Testing

TBD

### Applications affected

Global Workflow, UPP, UFS SRW, UFS WM, GSI

### Systems affected

all

### Dependencies

https://github.com/JCSDA/spack/pull/376

### Issue(s) addressed

Related to https://github.com/NOAA-EMC/global-workflow/issues/1356

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
