### PR TITLE
Add mct and cprnc packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/cprnc_mct
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/cprnc_mct
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

This PR updates the submodule pointer for spack for the changes in PR https://github.com/JCSDA/spack/pull/379, which adds a new package `mct`, cherry-picks package `cprnc` from spack develop, and adds them to the relevant meta packages (`jedi-neptune-env`, `ufs-weather-model-env`).

### Testing

Tested on macOS and on Narwhal, plus CI

### Applications affected

ufs-weather-model and jedi-neptune

### Systems affected

n/a

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/379

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/885
Working towards https://github.com/JCSDA/spack-stack/issues/845

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
