### PR TITLE
Bump prod-util to 2.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/prod_util_211_jcsda_emc_spack_stack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/prod_util_211_jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -203,7 +203,7 @@
     pkgconf:
       buildable: False
     prod-util:
-      version: ['2.1.0']
+      version: ['2.1.1']
     proj:
       version: ['8.1.0']
       variants: ~tiff


### PR DESCRIPTION
### Summary

Bump prod-util to 2.1.1 in the common packages.yaml. Submodule pointer update for spack includes recently merged `py-boto3` dependency for `gmao-swell-env`.

### Testing

- [x] CI

### Applications affected

UFS & NASA applications

### Systems affected

n/a

### Dependencies

- [ ] waiting on https://github.com/JCSDA/spack/pull/381

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
