### PR TITLE
Add esmf@8.6.0 to unified-dev and skylab-dev, keep 8.5.0 as default

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -86,7 +86,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.3
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///Users/ec2-user/spack-stack/source-cache/

--- a/.github/workflows/macos-ci-x86_64.yaml
+++ b/.github/workflows/macos-ci-x86_64.yaml
@@ -79,7 +79,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.0 -i fms -i crtm -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///Users/ec2-user/spack-stack/source-cache/

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -117,7 +117,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.intel-2022.1.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2022.1.0 -i fms -i crtm
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2022.1.0 -i fms -i crtm -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/

--- a/.github/workflows/ubuntu-rnd-x86_64.yaml
+++ b/.github/workflows/ubuntu-rnd-x86_64.yaml
@@ -76,7 +76,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.${ENVNAME}
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -c -d log.concretize.${ENVNAME} -i fms -i crtm
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -c -d log.concretize.${ENVNAME} -i fms -i crtm -i esmf -i mapl
 
           # Update spack source cache
           spack mirror create -a -d /mnt/experiments-efs/spack-stack/source-cache
@@ -128,7 +128,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.${ENVNAME}
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -c -d log.concretize.${ENVNAME} -i fms -i crtm
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -c -d log.concretize.${ENVNAME} -i fms -i crtm -i esmf -i mapl
 
           # Update spack source cache
           spack mirror create -a -d /mnt/experiments-efs/spack-stack/source-cache

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -12,7 +12,7 @@ spack:
       - jedi-fv3-env
       - jedi-mpas-env
       - jedi-neptune-env
-      - jedi-ufs-env
+      - jedi-ufs-env ^mapl@2.40.3 ^esmf@8.5.0
       - jedi-um-env
       - soca-env
 
@@ -23,6 +23,10 @@ spack:
       # Various crtm tags (list all to avoid duplicate packages)
       - crtm@2.4.0.1
       - crtm@v2.4.1-jedi
+
+      # Various esmf/mapl tags (list all to avoid duplicate packages)
+      - mapl@2.40.3 ^esmf@8.5.0
+      - mapl@2.40.3 ^esmf@8.6.0
 
   specs:
     - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -16,13 +16,13 @@ spack:
       - jedi-mpas-env
       - jedi-neptune-env
       - jedi-tools-env
-      - jedi-ufs-env
+      - jedi-ufs-env ^mapl@2.40.3 ^esmf@8.5.0
       - jedi-um-env
       #- nceplibs-env
       - soca-env
-      - ufs-srw-app-env
+      - ufs-srw-app-env ^mapl@2.40.3 ^esmf@8.5.0
       #- ufs-utils-env
-      - ufs-weather-model-env
+      - ufs-weather-model-env ^mapl@2.40.3 ^esmf@8.5.0
       #- upp-env
       #- ww3-env
 
@@ -33,6 +33,10 @@ spack:
       # Various crtm tags (list all to avoid duplicate packages)
       - crtm@2.4.0.1
       - crtm@v2.4.1-jedi
+
+      # Various esmf/mapl tags (list all to avoid duplicate packages)
+      - mapl@2.40.3 ^esmf@8.5.0
+      - mapl@2.40.3 ^esmf@8.6.0
 
       # MADIS for WCOSS2 decoders.
       - madis@4.5


### PR DESCRIPTION
### Summary

Explicitly add `mapl-esmf` versions in `configs/templates/skylab-dev/spack.yaml` and `configs/templates/unified-dev/spack.yaml` so that we build both `esmf@8.6.0` and `esmf@8.5.0`, but the latter will remain the default.

### Testing

Tested on macOS Monterey with `apple-clang@13.1.6` and `openmpi@4.1.6`

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

Resolves #895 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
