### PR TITLE
release/1.6.0: change crtm build type to release, remove qhull from module blacklist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.6.0
-  url = https://github.com/climbfuji/spack
-  branch = feature/rel160_crtm_release
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = release/1.6.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.6.0
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.6.0
+  url = https://github.com/climbfuji/spack
+  branch = feature/rel160_crtm_release
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -71,7 +71,6 @@ modules:
       - openssl
       - perl
       - pkgconf
-      - qhull
       - qt
       - randrproto
       - readline

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -73,7 +73,6 @@ modules:
       - openssl
       - perl
       - pkgconf
-      - qhull
       - qt
       - randrproto
       - readline


### PR DESCRIPTION
### Summary

Submodule pointer update only for the changes described in https://github.com/JCSDA/spack/pull/385. Needed for release/1.6.0.

Also included a tiny change to generate the module for `qhull`, which is a dependency of `ecmwf-atlas` since spack-stack-1.5.1.

### Testing

- [x] CI

### Applications affected

All applications are affected that use crtm from spack-stack, but no impact expected.

### Systems affected

n/a

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/385

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/827

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
