### PR TITLE
Set python 3.11.6 and corresponding py-numpy for gsi-addon-dev template

### DIFF
--- a/configs/templates/gsi-addon-dev/spack.yaml
+++ b/configs/templates/gsi-addon-dev/spack.yaml
@@ -23,3 +23,9 @@ spack:
   - matrix:
     - [$packages]
     - [$compilers]
+
+  packages:
+    python::
+      require: ['@3.11.6']
+    py-numpy::
+      require: ['@1.23.4']


### PR DESCRIPTION
### Summary

This PR adds python@3.11.6 to the gsi addon environment template. Note the `::` is needed to override the `require:` settings from common/packages.yaml. I chose 3.11.6 because it's listed as preferred in the recipe, and 1.23.4 build with intel whereas various prior and later versions don't work with intel and/or python@3.11. I suggest putting this is 1.6.0 release so that the gsi addon environment _should_ work right out of the box.

### Testing

Tested building as unchained environment on Hera.

### Applications affected

GSi

### Systems affected

all systems where gsi-addon-env will be installed

### Dependencies

none

### Issue(s) addressed

Addresses https://github.com/JCSDA/spack-stack/issues/908

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
