### PR TITLE
release/1.6.0 site config & documentation updates for Orion, Derecho, Narwhal/GNU, AWS ParallelCluster, AWS Single-Node AMI Red Hat 8, Casper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.6.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/rel160_repair_dockerfile_template
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = release/1.6.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = release/1.6.0
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.6.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/rel160_repair_dockerfile_template
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/aws-pcluster/config.yaml
+++ b/configs/sites/aws-pcluster/config.yaml
@@ -1,10 +1,15 @@
 config:
-  build_jobs: 24
+  build_jobs: 8
 
   # Overrides for spack build and staging areas to speed up builds
   # by using a local directory instead of the EFS shared filesystem
-
   build_stage: /tmp/spack-stack/cache/build_stage
   test_stage: /tmp/spack-stack/cache/test_stage
   source_cache: /tmp/spack-stack/cache/source_cache
   misc_cache: /tmp/spack-stack/cache/misc_cache
+
+  # Turn off file locking due to problems with EFS filesystem.
+  # Do not run parallel "spack install" commands on aws-pcluster!
+  db_lock_timeout: 60
+  package_lock_timeout: 60
+  locks: false

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -36,32 +36,22 @@ packages:
 ### All other external packages listed alphabetically
   autoconf:
     externals:
-    #- spec: autoconf@2.71
-    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: autoconf@2.69
       prefix: /usr
   automake:
     externals:
-    #- spec: automake@1.16.5
-    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: automake@1.15.1
       prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.37.20211103
       prefix: /usr
-  #cmake:
-  #  externals:
-  #  - spec: cmake@3.26.3
-  #    prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/cmake/3.26.3/gcc/7.5.0/k34x
   coreutils:
     externals:
     - spec: coreutils@8.32
       prefix: /usr
   curl:
     externals:
-    #- spec: curl@8.1.2+nghttp2
-    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: curl@7.79.1+gssapi+ldap+nghttp2
       prefix: /usr
   cvs:
@@ -83,10 +73,6 @@ packages:
     externals:
     - spec: findutils@4.8.0
       prefix: /usr
-  #flex:
-  #  externals:
-  #  - spec: flex@2.6.4+lex
-  #    prefix: /glade/u/apps/derecho/23.09/opt/view
   gawk:
     externals:
     - spec: gawk@4.2.1
@@ -113,21 +99,10 @@ packages:
     externals:
     - spec: krb5@1.19.2
       prefix: /usr/lib/mit
-  #libtool:
-  #  externals:
-  #  - spec: libtool@2.4.7
-  #    prefix: /glade/u/apps/derecho/23.09/opt/view
-  #  - spec: libtool@2.4.6
-  #    prefix: /usr
   m4:
     externals:
     - spec: m4@1.4.18
       prefix: /usr
-  # Automatically detected, but don't use - missing "ninja" dependency
-  #meson:
-  #  externals:
-  #  - spec: meson@1.2.0
-  #    prefix: /glade/u/apps/derecho/23.09/opt/view
   mysql:
     buildable: False
     externals:
@@ -161,8 +136,6 @@ packages:
       prefix: /usr
   texinfo:
     externals:
-    #- spec: texinfo@7.0.3
-    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: texinfo@6.5
       prefix: /usr
   wget:

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -147,6 +147,10 @@ packages:
     externals:
     - spec: pkg-config@0.29.2
       prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.4
+      prefix: /usr
   subversion:
     externals:
     - spec: subversion@1.14.1

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -36,32 +36,32 @@ packages:
 ### All other external packages listed alphabetically
   autoconf:
     externals:
-    - spec: autoconf@2.71
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+    #- spec: autoconf@2.71
+    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: autoconf@2.69
       prefix: /usr
   automake:
     externals:
-    - spec: automake@1.16.5
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+    #- spec: automake@1.16.5
+    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: automake@1.15.1
       prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.37.20211103
       prefix: /usr
-  cmake:
-    externals:
-    - spec: cmake@3.26.3
-      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/cmake/3.26.3/gcc/7.5.0/k34x
+  #cmake:
+  #  externals:
+  #  - spec: cmake@3.26.3
+  #    prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/cmake/3.26.3/gcc/7.5.0/k34x
   coreutils:
     externals:
     - spec: coreutils@8.32
       prefix: /usr
   curl:
     externals:
-    - spec: curl@8.1.2+nghttp2
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+    #- spec: curl@8.1.2+nghttp2
+    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: curl@7.79.1+gssapi+ldap+nghttp2
       prefix: /usr
   cvs:
@@ -83,10 +83,10 @@ packages:
     externals:
     - spec: findutils@4.8.0
       prefix: /usr
-  flex:
-    externals:
-    - spec: flex@2.6.4+lex
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+  #flex:
+  #  externals:
+  #  - spec: flex@2.6.4+lex
+  #    prefix: /glade/u/apps/derecho/23.09/opt/view
   gawk:
     externals:
     - spec: gawk@4.2.1
@@ -94,13 +94,13 @@ packages:
   git:
     externals:
     - spec: git@2.41.0+tcltk
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/git/2.41.0/gcc/7.5.0/jgni
     - spec: git@2.35.3+tcltk
       prefix: /usr
   git-lfs:
     externals:
     - spec: git-lfs@3.3.0
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/git-lfs/3.3.0/gcc/7.5.0/u3kh
   gmake:
     externals:
     - spec: gmake@4.2.1
@@ -113,12 +113,12 @@ packages:
     externals:
     - spec: krb5@1.19.2
       prefix: /usr/lib/mit
-  libtool:
-    externals:
-    - spec: libtool@2.4.7
-      prefix: /glade/u/apps/derecho/23.09/opt/view
-    - spec: libtool@2.4.6
-      prefix: /usr
+  #libtool:
+  #  externals:
+  #  - spec: libtool@2.4.7
+  #    prefix: /glade/u/apps/derecho/23.09/opt/view
+  #  - spec: libtool@2.4.6
+  #    prefix: /usr
   m4:
     externals:
     - spec: m4@1.4.18
@@ -157,8 +157,8 @@ packages:
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@7.0.3
-      prefix: /glade/u/apps/derecho/23.09/opt/view
+    #- spec: texinfo@7.0.3
+    #  prefix: /glade/u/apps/derecho/23.09/opt/view
     - spec: texinfo@6.5
       prefix: /usr
   wget:

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -3,6 +3,8 @@ packages:
     compiler:: [intel@2021.9.0, gcc@12.2.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.9.0, mvapich2@2.3.7]
+      # Alternative openmpi@4.1.6 with gcc@12.2.0 for testing
+      #mpi:: [openmpi@4.1.6]
 
 ### MPI, Python, MKL
   mpi:
@@ -20,6 +22,15 @@ packages:
       modules:
       - gcc/12.2.0
       - mvapich2/2.3.7
+  # Alternative openmpi@4.1.6 with gcc@12.2.0 for testing
+  #openmpi:
+  #  externals:
+  #  - spec: openmpi@4.1.6%gcc@12.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
+  #      schedulers=slurm
+  #    prefix: /work/noaa/epic/role-epic/spack-stack/hercules/openmpi-4.1.6/gcc-12.2.0-spack
+  #    modules:
+  #    - gcc/12.2.0
+  #    - openmpi/4.1.6-gcc-12.2.0-spack
 
 ### Modifications of common packages
 

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -125,10 +125,6 @@ packages:
     externals:
     - spec: libfuse@2.9.2
       prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.2
-      prefix: /usr
   libxpm:
     externals:
     - spec: libxpm@4.11.0

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -30,6 +30,9 @@ packages:
       - openmpi/4.0.4
 
 ### Modifications of common packages
+  # Temporary - see https://github.com/spack/spack/issues/41947
+  cdo:
+    require: '@2.0.5'
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/doc/source/MaintainersSection.rst
+++ b/doc/source/MaintainersSection.rst
@@ -270,7 +270,7 @@ mysql
   ``mysql`` must be installed separately from ``spack`` using a binary tarball provided by the MySQL community. Follow the instructions in :numref:`Section %s <MaintainersSection_MySQL>` to install ``mysql`` in ``/work/noaa/epic-ps/role-epic-ps/spack-stack/mysql-8.0.31-hercules``.
 
 mvapich2
-  Because of difficulties with ``openmpi`` on Hercules, we build ``mvapich2``. It is necessary to either load ``qt`` to use a consistent ``zlib``, or to load ``zlib`` directly (check the ``qt`` module). Create modulefile ``mvapich2`` from template ``doc/modulefile_templates/mvapich2``. **Important:** We identified a bug in ``gcc@11`` + ``mvapich2@2.3.7`` in MPI allgather operations. It is therefore necessary to switch to a newer GCC compiler.
+  Because of difficulties with ``openmpi`` on Hercules, we build ``mvapich2`` outside of spack and provide it as an external package. It is necessary to either load ``qt`` to use a consistent ``zlib``, or to load ``zlib`` directly (check the ``qt`` module). Create modulefile ``mvapich2`` from template ``doc/modulefile_templates/mvapich2``. **Important:** We identified a bug in ``gcc@11`` + ``mvapich2@2.3.7`` in MPI allgather operations. It is therefore necessary to switch to a newer GCC compiler.
 
 .. code-block:: console
 
@@ -286,6 +286,54 @@ mvapich2
        --with-slurm-include=/opt/slurm-23.02.6/include \
        --with-slurm-lib=/opt/slurm-23.02.6/lib \
        2>&1 | tee log.config./configure
+   make VERBOSE=1 -j4
+   make check
+   make install
+
+openmpi (currently only for testing)
+  Because of difficulties with the default ``openmpi`` on Hercules, we build ``openmpi`` outside of spack and provide it as an external package. It is necessary to load the ``gcc`` compiler module and the ``zlib`` module for consistency. The configuration options are mostly adopted from the default OpenMPI installations that were done by the system administrators using spack (many of them are default values), except that we use internal ``hwloc`` and ``pmix``. Create modulefile ``openmpi`` from template ``doc/modulefile_templates/openmpi``.
+
+.. code-block:: console
+
+   ./configure \
+       --enable-shared \
+       --disable-silent-rules \
+       --disable-builtin-atomics \
+       --with-pmi=/opt/slurm \
+       --enable-static \
+       --enable-mpi1-compatibility \
+       --without-hcoll \
+       --without-psm2 \
+       --without-knem \
+       --without-verbs \
+       --without-psm \
+       --without-cma \
+       --without-ucx \
+       --without-mxm \
+       --without-fca \
+       --without-xpmem \
+       --without-ofi \
+       --without-cray-xpmem \
+       --without-sge \
+       --without-lsf \
+       --without-loadleveler \
+       --without-alps \
+       --without-tm \
+       --with-slurm \
+       --disable-memchecker \
+       --with-pmix=internal \
+       --with-zlib=/apps/spack-managed/gcc-12.2.0/zlib-1.2.13-p3sxbyfgvvjy7jx4kizib2jwvhm4s6l4 \
+       --with-hwloc=internal \
+       --disable-java \
+       --disable-mpi-java \
+       --with-gpfs=no \
+       --without-cuda \
+       --enable-wrapper-rpath \
+       --disable-wrapper-runpath \
+       --disable-mpi-cxx \
+       --disable-cxx-exceptions \
+       --with-wrapper-ldflags="-Wl,-rpath,/apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/lib/gcc/x86_64-pc-linux-gnu/12.2.0 -Wl,-rpath,/apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/lib64" \
+       --prefix=/work/noaa/epic/role-epic/spack-stack/hercules/openmpi-4.1.6/gcc-12.2.0-spack 2>&1 | tee log.config
    make VERBOSE=1 -j4
    make check
    make install
@@ -621,7 +669,7 @@ mysql
 Amazon Web Services Parallelcluster Ubuntu 20.04
 ------------------------------------------------
 
-See ``configs/sites/aws-pcluster/README.md``.
+See ``configs/sites/aws-pcluster/README.md``. It is important to note that because the shared EFS filesystem is slow and had problems with the spack locking mechanism introduced mid 2023, all file locking is turned off in the site config. Therefore, one must never run more than one ``spack install`` command for the same environment - that is, no parallel ``spack install`` processes.
 
 .. _MaintainersSection_Testing_New_Packages:
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -453,6 +453,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    spack external find --scope system wget
    spack external find --scope system mysql
    spack external find --scope system texlive
+   spack external find --scope system sed
 
 5. Find compilers, add to site config's ``compilers.yaml``
 
@@ -490,8 +491,6 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    spack config add "packages:fontconfig:variants:+pic"
    spack config add "packages:pixman:variants:+pic"
    spack config add "packages:cairo:variants:+pic"
-   spack config add "packages:libffi:version:['3.3']"
-   spack config add "packages:flex:version:['2.6.4']"
 
 9. If you have manually installed lmod, you will need to update the site module configuration to use lmod instead of tcl. Skip this step if you followed the Ubuntu or Red Hat instructions above.
 

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -22,9 +22,11 @@ Ready-to-use spack-stack 1.6.0 installations are available on the following, ful
 | MSU                 +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Orion                            | GCC, Intel      | ``/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/unified-env``                      | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
+| MSU                 | Hercules gcc+openmpi alternative | GCC             | ``/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/ue-gcc12-openmpi416``           | Dom Heinzeller                |
++---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NASA                | Discover                         | GCC, Intel      | ``/gpfsm/dswdev/jcsda/spack-stack/spack-stack-1.6.0/envs/unified-env``                                  | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Casper                           | GCC             | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.5.1/envs/unified-env``                 | Dom Heinzeller / ???          |
+|                     | Casper                           | GCC             | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.6.0/envs/unified-env``                 | Dom Heinzeller / ???          |
 | NCAR-Wyoming        +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Derecho                          | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env``                | Dom Heinzeller / Mark Potts   |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -38,7 +40,7 @@ Ready-to-use spack-stack 1.6.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Narwhal                          | Intel           | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.6.0/envs/unified-env-intel-2021.4.0``               | Dom Heinzeller / Sarah King   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Narwhal                          | GCC             | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-gcc-10.3.0``                   | Dom Heinzeller / Sarah King   |
+|                     | Narwhal                          | GCC             | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.6.0/envs/unified-env-gcc-10.3.0``                   | Dom Heinzeller / Sarah King   |
 | U.S. Navy (HPCMP)   +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Nautilus                         | Intel           | ``/p/app/projects/NEPTUNE/spack-stack/spack-stack-1.6.0/envs/unified-env``                              | Dom Heinzeller / Sarah King   |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -50,9 +52,9 @@ Ready-to-use spack-stack 1.6.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | **Cloud platforms**                                                                                                                                                                                                |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | AMI Red Hat 8                    | GCC             | ``/home/ec2-user/spack-stack/spack-stack-1.5.1/envs/unified-env``                                       | Dom Heinzeller / ???          |
+|                     | AMI Red Hat 8                    | GCC             | ``/home/ec2-user/spack-stack/spack-stack-1.6.0/envs/unified-env``                                       | Dom Heinzeller / ???          |
 + Amazon Web Services +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Parallelcluster JCSDA R&D        | Intel           | ``/mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env``                                   | Dom Heinzeller / ???          |
+|                     | Parallelcluster JCSDA R&D        | Intel           | ``/mnt/experiments-efs/skylab-v7/spack-stack-1.6.0/envs/unified-env``                                   | Dom Heinzeller / ???          |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (RDHPCS)       | RDHPCS Cloud (Parallel Works)    | Intel           | ``/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env``                                             | Mark Potts / Cam Book / Dom H |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -137,6 +139,14 @@ For ``spack-stack-1.6.0`` with GNU, load the following modules after loading mys
    module load stack-python/3.10.13
    module available
 
+For testing, an additional version of spack-stack-1.6.0 with GNU+OpenMPI is available. Load the following modules after loading mysql and ecflow:
+
+   module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/ue-gcc12-openmpi416/install/modulefiles/Core/
+   module load stack-gcc/12.2.0
+   module load stack-openmpi/4.1.6
+   module load stack-python/3.10.13
+   module available
+
 .. note::
    spack-stack-1.6.0 on Hercules provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
 
@@ -204,7 +214,6 @@ With Intel, the following is required for building new spack environments and fo
    module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.31
-   module load node.js/20.10.0
 
 For ``spack-stack-1.6.0`` with Intel, load the following modules after loading the above modules.
 
@@ -234,16 +243,15 @@ With GNU, the following is required for building new spack environments and for 
    module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
    module load ecflow/5.8.4
    module load mysql/8.0.31
-   module load node.js/20.10.0
 
-For ``spack-stack-1.5.1`` with GNU, load the following modules after loading the above modules.
+For ``spack-stack-1.6.0`` with GNU, load the following modules after loading the above modules.
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.5.1/envs/unified-env-gcc-10.3.0/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.6.0/envs/unified-env-gcc-10.3.0/install/modulefiles/Core
    module load stack-gcc/10.3.0
    module load stack-cray-mpich/8.1.14
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
 
 .. _Preconfigured_Sites_Nautilus:
 
@@ -321,15 +329,15 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.1`` with GNU, load the following modules after loading the above modules.
+For ``spack-stack-1.6.0`` with GNU, load the following modules after loading the above modules.
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
 
    module load stack-gcc/12.2.0
    module load stack-openmpi/4.1.6
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
 .. _Preconfigured_Sites_Derecho:
@@ -578,27 +586,27 @@ Amazon Web Services Parallelcluster Ubuntu 20.04
 
 Access to the JCSDA-managed AWS Parallel Clusters is not available to the public. The following instructions are for JCSDA core staff and in-kind contributors.
 
-For ``spack-stack-1.5.1`` with Intel on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
+For ``spack-stack-1.6.0`` with Intel on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
 
 .. code-block:: console
 
    module purge
    ulimit -s unlimited
    source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
-   module use /mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /mnt/experiments-efs/skylab-v7/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.1.0
    module load stack-intel-oneapi-mpi/2021.6.0
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
-For ``spack-stack-1.5.1`` with GNU on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
+For ``spack-stack-1.6.0`` with GNU on the JCSDA R&D cluster (``hpc6a.48xlarge`` instances), run the following commands/load the following modules:
 
    module purge
    ulimit -s unlimited
-   module use /mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /mnt/experiments-efs/skylab-v7/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/9.4.0
    module load stack-openmpi/4.1.4
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
 .. note::
@@ -609,18 +617,18 @@ For ``spack-stack-1.5.1`` with GNU on the JCSDA R&D cluster (``hpc6a.48xlarge`` 
 Amazon Web Services Red Hat 8
 -----------------------------
 
-Use a c6i.4xlarge instance or larger if running out of memory with AMI "skylab-6.1.0-redhat8" (see JEDI documentation at https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest for more information).
+Use a c6i.4xlarge instance or larger if running out of memory with AMI "skylab-7.1.0-redhat8" (see JEDI documentation at https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest for more information).
 
-For ``spack-stack-1.5.1``, run:
+For ``spack-stack-1.6.0``, run:
 
 .. code-block:: console
 
    ulimit -s unlimited
    scl_source enable gcc-toolset-11
-   module use /home/ec2-user/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /home/ec2-user/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/11.2.1
    module load stack-openmpi/4.1.5
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
 .. _Configurable_Sites_CreateEnv:

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -20,7 +20,7 @@ Ready-to-use spack-stack 1.6.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Hercules                         | GCC, Intel      | ``/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env``                   | Cam Book / Dom Heinzeller     |
 | MSU                 +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Orion                            | GCC, Intel      | ``/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/unified-env``                      | Cam Book / Dom Heinzeller     |
+|                     | Orion                            | GCC, Intel      | ``/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env``                      | Cam Book / Dom Heinzeller     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | MSU                 | Hercules gcc+openmpi alternative | GCC             | ``/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/ue-gcc12-openmpi416``           | Dom Heinzeller                |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -28,7 +28,7 @@ Ready-to-use spack-stack 1.6.0 installations are available on the following, ful
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 |                     | Casper                           | GCC             | ``/glade/work/epicufsrt/contrib/spack-stack/casper/spack-stack-1.6.0/envs/unified-env``                 | Dom Heinzeller / ???          |
 | NCAR-Wyoming        +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Derecho                          | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env``                | Dom Heinzeller / Mark Potts   |
+|                     | Derecho                          | GCC, Intel      | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.6.0/envs/unified-env``                | Dom Heinzeller / Cam Book     |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (NCEP)         | Acorn                            | Intel           | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.5.1/envs/unified-env``                         | Hang Lei / Alex Richert       |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -85,25 +85,31 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.31
 
-For ``spack-stack-1.5.1`` with Intel, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.6.0`` with Intel, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2022.0.2
    module load stack-intel-oneapi-mpi/2021.5.1
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
-For ``spack-stack-1.5.1`` with GNU, load the following modules after loading miniconda and ecflow:
+For ``spack-stack-1.6.0`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/10.2.0
    module load stack-openmpi/4.0.4
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
+
+.. note::
+   The unified environment on Orion uses ``cdo@2.0.5`` instead of the default ``cdo@2.2.0`` because of a bug in the ``cdo`` package recipe that affects systems that don't have a ``python3`` interpreter in the default search paths (see https://github.com/spack/spack/issues/41947) for more information. This is a temporary change on Orion for the spack-stack-1.6.0 release and will be reverted once the ``cdo`` package is updated in the upstream spack develop code.
+
+.. note::
+   spack-stack-1.6.0 on Orion provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
 
 ------------------------------
 MSU Hercules
@@ -358,24 +364,24 @@ The following is required for building new spack environments and for using spac
    module load ecflow/5.8.4
    module load mysql/8.0.33
 
-For ``spack-stack-1.5.1`` with Intel, load the following modules after loading ecflow and mysql:
+For ``spack-stack-1.6.0`` with Intel, load the following modules after loading ecflow and mysql:
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-intel/2021.10.0
    module load stack-cray-mpich/8.1.25
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
-For ``spack-stack-1.5.1`` with GNU, load the following modules after loading ecflow and mysql:
+For ``spack-stack-1.6.0`` with GNU, load the following modules after loading ecflow and mysql:
 
 .. code-block:: console
 
-   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
    module load stack-gcc/12.2.0
    module load stack-cray-mpich/8.1.25
-   module load stack-python/3.10.8
+   module load stack-python/3.10.13
    module available
 
 .. note::


### PR DESCRIPTION
### Summary

Second round of site config and documentation updates for spack-stack-1.6.0: Orion, Derecho, Narwhal/GNU, AWS ParallelCluster, AWS Single-Node AMI Red Hat 8, Casper.

Also, add information for a new GNU+OpenMPI environment on Hercules that is available for testing.

Notes:
- Bug in CDO package requires reverting back to 2.0.5 on Orion instead of the default 2.2.0 (see https://github.com/spack/spack/issues/41947)
- Problems with recently activated file locking mechanism in spack require turning off locking on AWS ParallelCluster (i.e. when the shared, slow EFS filesystem is used)
- Submodule pointer update for spack for a container template bug fix (https://github.com/JCSDA/spack/pull/387)
- The Derecho site config updates fix the problem with `more` and `watch` not being functional, see https://github.com/JCSDA/spack-stack/issues/910

### Testing

Tested on all of the systems listed above, also for CI containers.

### Applications affected

n/a

### Systems affected

See above

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/387

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/910
Working towards #924 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
