### PR TITLE
For develop: Define variants for metis and add metis to jedi-mpas-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_metis_to_jedi-mpas-env
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_metis_to_jedi-mpas-env
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -149,6 +149,8 @@
       variants: +python +grib2
     metplus:
       version: ['5.1.0']
+    metis:
+      require: "+int64 +real64"
     mpich:
       variants: ~hwloc +two_level_namespace
     mysql:


### PR DESCRIPTION
### Summary

This resolves https://github.com/JCSDA/spack-stack/issues/915.

Note that I have chosen to use 64bit integers and reals as default variants, because I've run into problems in the past with high-resolution meshes.

### Testing

- [x] Tested installation and use on aws-parallelcluster with Intel and GNU
- [x] CI

### Applications affected

None (only adding a package)

### Systems affected

All systems (since jedi-mpas-env is part of unified-env/skylab-env)

### Dependencies

- [ ] waiting on https://github.com/JCSDA/spack/pull/388

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/915

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
