### PR TITLE
Remove libtool form Gaea, Hera and Jet.

### DIFF
--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -122,10 +122,6 @@ packages:
       prefix: /usr
   libtirpc:
     variants: ~gssapi
-  libtool:
-    externals:
-    - spec: libtool@2.4.6
-      prefix: /usr
   # This package is currently incomplete (no headers), but still works
   libxaw:
     externals:

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -124,10 +124,6 @@ packages:
     externals:
     - spec: libfuse@2.9.2
       prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.2
-      prefix: /usr
   libxpm:
     externals:
     - spec: libxpm@4.11.0

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -129,10 +129,6 @@ packages:
     externals:
     - spec: libfuse@2.9.2
       prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.2
-      prefix: /usr
   libxpm:
     externals:
     - spec: libxpm@4.11.0


### PR DESCRIPTION
### Summary

Removed libtool form Gaea, Hera and Jet.

### Testing

Installed spack-stack release 1.6.0 on Gaea, Hera and Jet

### Applications affected



### Systems affected



### Dependencies



### Issue(s) addressed

Solves #936 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
