### PR TITLE
Add fftw and netlib-lapack as passive dependencies for jedi-neptune-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_fftw_lapack_jedi_neptune_env_passive
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_fftw_lapack_jedi_neptune_env_passive
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

See https://github.com/JCSDA/spack/pull/391 for a description of what the submodule pointer update does.

### Testing

- [x] tested locally on macOS with spack-stack develop
- [x] tested on Nautilus in spack-stack-1.6.0 (I added the two packages manually to the release so that they are available now)
- [x] CI

### Applications affected

n/a

### Systems affected

Nautilus, Narwhal

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/391

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/941

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
