### PR TITLE
Fix bug in .github/workflows/ubuntu-rnd-x86_64.yaml

### DIFF
--- a/.github/workflows/ubuntu-rnd-x86_64.yaml
+++ b/.github/workflows/ubuntu-rnd-x86_64.yaml
@@ -72,10 +72,10 @@ jobs:
           spack config add "config:misc_cache:/home/ubuntu/spack-stack/CI/tmp/misc_cache"
 
           # Loop over compilers
-          compilers=(gcc intel)
+          declare -a compilers=("gcc" "intel")
           cp ${ENVDIR}/spack.yaml ${ENVDIR}/spack.yaml.original
 
-          for compiler in "${!compilers[@]}"
+          for compiler in "${compilers[@]}"
           do
             # Set compiler and MPI
             cp ${ENVDIR}/spack.yaml.original ${ENVDIR}/spack.yaml
@@ -138,10 +138,10 @@ jobs:
           spack config add "config:misc_cache:/home/ubuntu/spack-stack/CI/tmp/misc_cache"
 
           # Loop over compilers
-          compilers=(gcc intel)
+          declare -a compilers=("gcc" "intel")
           cp ${ENVDIR}/spack.yaml ${ENVDIR}/spack.yaml.original
 
-          for compiler in "${!compilers[@]}"
+          for compiler in "${compilers[@]}"
           do
             # Set compiler and MPI
             cp ${ENVDIR}/spack.yaml.original ${ENVDIR}/spack.yaml

--- a/.github/workflows/ubuntu-rnd-x86_64.yaml
+++ b/.github/workflows/ubuntu-rnd-x86_64.yaml
@@ -80,7 +80,7 @@ jobs:
             # Set compiler and MPI
             cp ${ENVDIR}/spack.yaml.original ${ENVDIR}/spack.yaml
             sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%${compiler}'\]/g" ${ENVDIR}/spack.yaml
-            cat spack.yaml
+            cat ${ENVDIR}/spack.yaml
 
             # Concretize and check for duplicates
             spack concretize --force --fresh 2>&1 | tee log.concretize.${ENVNAME}.${compiler}
@@ -146,7 +146,7 @@ jobs:
             # Set compiler and MPI
             cp ${ENVDIR}/spack.yaml.original ${ENVDIR}/spack.yaml
             sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%${compiler}'\]/g" ${ENVDIR}/spack.yaml
-            cat spack.yaml
+            cat ${ENVDIR}/spack.yaml
 
             # Concretize and check for duplicates
             spack concretize --force --fresh 2>&1 | tee log.concretize.${ENVNAME}.${compiler}


### PR DESCRIPTION
### Summary

This is take 2 of fixing the R&D CI runs. I introduced two bugs in the last PR that this PR fixes. But I decided to stay away from implementing a more complicates matrix-strategy in Github actions because of the reasons outlined in https://github.com/JCSDA/spack-stack/issues/950#issuecomment-1894867153.

### Testing

- [x] workflow_dispatch run on R&D cluster - see https://github.com/JCSDA/spack-stack/actions/runs/7550652613

### Applications affected

n/a

### Systems affected

JCSDA R&D AWS ParallelCluster used for CI runs

### Dependencies

none

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/950

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
