### PR TITLE
Replace "|&" syntax with "2>& |" syntax

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ msg1="Added repo with namespace"
 msg2="Repository is already registered with Spack"
 for repo in spack-stack; do
   repodir=${SPACK_STACK_DIR}/spack-ext/repos/$repo
-  othererrors=$( ( spack repo add $repodir --scope defaults |& grep -v -e "$msg1" -e "$msg2" ) || true )
+  othererrors=$( ( spack repo add $repodir --scope defaults 2>&1 | grep -v -e "$msg1" -e "$msg2" ) || true )
   if [ $(echo "$othererrors" | grep -c .) -ne 0 ]; then
     echo "$othererrors"
     return 2


### PR DESCRIPTION
### Summary

Fixes #973.  Older versions of bash (< 4.1?) do not recognize the `|&` syntax for some reason.  So this PR replaces the use of `|&` with the more verbose, but equivalent, `2>&1 |` syntax.

### Testing

Sourcing of `./setup.sh` was tested on Mac laptop having old version of bash (` 3.2.57`) and on Hercules having a newer version of bash (`5.1.8`).

### Applications affected

Impacts only the installation of spack-stack

### Systems affected

Impacts anyone installing spack-stack on a system with an old version of bash that doesn't support the `|&` syntax.

### Dependencies

N/A

### Issue(s) addressed

Fixes #973 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
