### PR TITLE
Update ufs-weather-model-static template

### DIFF
--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -1,3 +1,7 @@
+# The intent of this template is to "clone" the stack available on WCOSS2
+# insofar as needed to support the UFS Weather Model.
+# Version numbers are taken from ufs-weather-model/modulefiles/ufs_wcoss2.lua
+# Updated Jan 2024 by Alex Richert
 spack:
   concretizer:
     unify: when_possible
@@ -16,22 +20,27 @@ spack:
   specs:
   - bacio@2.4.1
   - crtm@2.4.0~fix
-  - esmf@8.4.2~shared+external-parallelio
-  - fms@2023.01 constants=GFS
+  - esmf@8.5.0~shared+external-parallelio
+  - fms@2023.02.01 constants=GFS
   - g2@3.4.5
   - g2tmpl@1.10.2
-  - gftl-shared@1.5.0
-  - hdf5@1.14.0+hl+mpi~shared~szip
+  - gftl-shared@1.6.1
+  - hdf5@1.14.0+hl+mpi~shared~tools
   - ip@3.3.3
-  - jasper@2.0.32~shared
+  - jasper@2.0.25~shared
   - libjpeg-turbo~shared
   - libpng@1.6.37 libs=static
-  - mapl@2.35.2~pnetcdf~shared
+  - mapl@2.40.3~shared~pflogger~fargparse~extdata2g
   - netcdf-c@4.9.2~parallel-netcdf+mpi~shared~dap
   - netcdf-fortran@4.6.0~shared
   - parallel-netcdf@1.12.2~shared
   - parallelio@2.5.10+fortran~pnetcdf~shared
-  - scotch@7.0.3
+  - scotch@7.0.4
   - sp@2.3.3
   - w3emc@2.9.2
-  - zlib@1.2.13~shared
+  - zlib@1.2.11~shared
+  packages:
+    all:
+      require: ["%intel@19.1.3.304"]
+    cmake:
+      require: ["@3.20.2"]

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -41,6 +41,6 @@ spack:
   - zlib@1.2.11~shared
   packages:
     all:
-      require: ["%intel@19.1.3.304"]
+      require: ["%intel@19.1.3.304"] # Change if not on Acorn
     cmake:
       require: ["@3.20.2"]


### PR DESCRIPTION
### Summary

This PR updates the ufs-weather-model-static template in anticipation of deploying on Acorn and possibly a few other systems in order to have a stack that resembles WCOSS2.

### Testing

Tested installation on Acorn.

### Applications affected

None immediately impacted (will support UFS WM)

### Systems affected

I plan to install on Acorn under the existing 1.6.0 installation. Other systems may come later.

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
