### PR TITLE
two more fixes for ufs wm static template

### DIFF
--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -20,7 +20,7 @@ spack:
   - common
   specs:
   - bacio@2.4.1
-  - crtm@2.4.0~fix
+  - crtm@=2.4.0~fix
   - esmf@8.5.0~shared+external-parallelio
   - fms@2023.02.01 constants=GFS
   - g2@3.4.5

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -6,6 +6,7 @@ spack:
   concretizer:
     unify: when_possible
   config:
+    deprecated: true
     install_tree:
       root: $env/install
   modules:


### PR DESCRIPTION
Forgot to add 'deprecated: true' to ufs wm static template on account of using the old zlib. crtm needs `@=` to distinguish 2.4.0 vs. 2.4.0.1.

With these fixes, `ufswm-env` is successfully installed on Acorn: /lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.6.0/envs/ufswm-env