### PR TITLE
No szip for WCOSS2 hdf5 & netcdf

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -114,7 +114,7 @@
       variants: +external-xdr ~fortran ~netcdf
     hdf5:
       version: ['1.14.0']
-      variants: +hl +fortran +mpi ~threadsafe +szip
+      variants: +hl +fortran +mpi ~threadsafe ~szip
     ip:
       version: ['4.3.0']
       variants: precision=4,d,8
@@ -166,7 +166,7 @@
     netcdf-c:
       version: ['4.9.2']
       # If using 4.9.1, turn off byterange variant to fix compile error: ~byterange
-      variants: +dap +mpi ~parallel-netcdf
+      variants: +dap +mpi ~parallel-netcdf ~szip
     netcdf-cxx4:
       version: ['4.3.1']
     netcdf-fortran:

--- a/configs/templates/ufs-weather-model-static/spack.yaml
+++ b/configs/templates/ufs-weather-model-static/spack.yaml
@@ -26,13 +26,13 @@ spack:
   - g2@3.4.5
   - g2tmpl@1.10.2
   - gftl-shared@1.6.1
-  - hdf5@1.14.0+hl+mpi~shared~tools
+  - hdf5@1.14.0+hl+mpi~shared~tools~szip
   - ip@3.3.3
   - jasper@2.0.25~shared
   - libjpeg-turbo~shared
   - libpng@1.6.37 libs=static
   - mapl@2.40.3~shared~pflogger~fargparse~extdata2g
-  - netcdf-c@4.9.2~parallel-netcdf+mpi~shared~dap
+  - netcdf-c@4.9.2~parallel-netcdf+mpi~shared~dap~szip
   - netcdf-fortran@4.6.0~shared
   - parallel-netcdf@1.12.2~shared
   - parallelio@2.5.10+fortran~pnetcdf~shared


### PR DESCRIPTION
No szip for WCOSS2 hdf5 & netcdf.