### PR TITLE
Add jedi-geos-env to unified-dev and skylab-dev templates, set additional env variable for Derecho

### DIFF
--- a/configs/sites/derecho/compilers.yaml
+++ b/configs/sites/derecho/compilers.yaml
@@ -17,6 +17,9 @@ compilers::
           PATH: '/opt/cray/pe/gcc/12.2.0/bin'
           CPATH: '/opt/cray/pe/gcc/12.2.0/snos/include'
           LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2023.2.1/compiler/2023.2.1/linux/compiler/lib/intel64_lin:/opt/cray/pe/gcc/12.2.0/snos/lib:/opt/cray/pe/gcc/12.2.0/lib64'
+        set:
+          # https://github.com/JCSDA/spack-stack/issues/957
+          FI_CXI_RX_MATCH_MODE: 'hybrid'
       extra_rpaths: []
   - compiler:
       spec: gcc@12.2.0
@@ -33,6 +36,7 @@ compilers::
       - gcc/12.2.0
       environment:
         set:
-          CRAYPE_LINK_TYPE: 'dynamic'
+          # https://github.com/JCSDA/spack-stack/issues/957
+          FI_CXI_RX_MATCH_MODE: 'hybrid'
       extra_rpaths: []
 

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -11,6 +11,7 @@ spack:
       - ewok-env +ecflow +cylc
       - geos-gcm-env
       - jedi-fv3-env
+      - jedi-geos-env
       - jedi-mpas-env
       - jedi-neptune-env
       - jedi-ufs-env

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -14,6 +14,7 @@ spack:
       - gmao-swell-env
       - gsi-env
       - jedi-fv3-env
+      - jedi-geos-env
       - jedi-mpas-env
       - jedi-neptune-env
       - jedi-tools-env


### PR DESCRIPTION
### Summary

1. Derecho needs an additional environment variable - set in `compilers.yaml` (see https://github.com/JCSDA/spack-stack/issues/957 for more information)
2. Add previously created `jedi-geos-env` virtual package to `unified-dev` and `skylab-dev` templates

### Testing

- [x] CI

### Applications affected

None

### Systems affected

Derecho (but see https://github.com/JCSDA/spack-stack/issues/957 for feedback from the sysadmins that the flag can be set in any case).

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/957
Working towards https://github.com/JCSDA-internal/AOP23/issues/33

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
