### PR TITLE
No more bootstrap/cache in ~/.spack

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 
 source ${SPACK_STACK_DIR:?}/spack/share/spack/setup-env.sh
 echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
-export SPACK_DISABLE_LOCAL_CONFIG=true
+#export SPACK_DISABLE_LOCAL_CONFIG=true
 export SPACK_USER_CACHE_PATH=$SPACK_ROOT/user_cache
 
 # Get the current hash of the spack-stack code

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,6 @@ echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 
 source ${SPACK_STACK_DIR:?}/spack/share/spack/setup-env.sh
 echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
-#export SPACK_DISABLE_LOCAL_CONFIG=true
 export SPACK_USER_CACHE_PATH=$SPACK_ROOT/user_cache
 
 # Get the current hash of the spack-stack code

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,8 @@ echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 
 source ${SPACK_STACK_DIR:?}/spack/share/spack/setup-env.sh
 echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
+export SPACK_DISABLE_LOCAL_CONFIG=true
+export SPACK_USER_CACHE_PATH=$SPACK_ROOT/user_cache
 
 # Get the current hash of the spack-stack code
 export SPACK_STACK_HASH=`git rev-parse --short HEAD`


### PR DESCRIPTION
### Summary

I've gotten annoyed with our various installations clobbering the contents of ~/.spack, having to periodically delete ~/.spack as we work across multiple Spack versions, etc. This PR makes our installations self contained by putting the bootstrap and cache directories that would normally go under ~/.spack in $SPACK_ROOT.

### Testing

Tested on personal machine. Needs further testing on HPC systems etc.

### Applications affected

n/a

### Systems affected

All

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
