### PR TITLE
Bugfix for NewSiteConfigs.rst

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -262,6 +262,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 8. If the environment will be used to run JCSDA's JEDI-Skylab experiments using R2D2 with a local MySQL server, run the following command:
 
 .. code-block:: console
+
    spack config add "packages:ewok-env:variants:+mysql"
 
 9. If applicable (depends on the environment), edit the main config file for the environment and adjust the compiler matrix to match the compilers for macOS, as above:


### PR DESCRIPTION
### Summary
This PR fixes a markdown bug in the `code-block` environment by adding an empty line inside the 6.1.4.8 subsection (instructions to use local `MySQL`).

@ericlingerfelt noticed recently that the command mentioned is not being presented on the website. Please see the image below:

<img width="759" alt="Screenshot 2024-02-27 at 11 25 52 AM" src="https://github.com/JCSDA/spack-stack/assets/45880035/0557881c-442d-401e-9914-1baaa53d87af">

A closer look revealed that the piece of code necessary to show the command is there but with a missing line after opening the `code-block` environment.

### Testing
Not needed.

### Applications affected
None.

### Systems affected
None.

### Dependencies
None.

### Issue(s) addressed
None.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
