### PR TITLE
Update openmpi on Nautilus to 4.1.6

### DIFF
--- a/.github/workflows/ubuntu-rnd-x86_64.yaml
+++ b/.github/workflows/ubuntu-rnd-x86_64.yaml
@@ -188,7 +188,7 @@ jobs:
           ls -l /home/ubuntu/spack-stack/CI/unified-env/${TODAY}/modulefiles/Core
 
           module use /home/ubuntu/spack-stack/CI/unified-env/${TODAY}/modulefiles/Core
-          module load stack-intel/2022.1.0
+          module load stack-intel/2021.6.0
           module load stack-intel-oneapi-mpi/2021.6.0
           module load stack-python/3.10.13
           module available

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
   ##branch = develop
   #url = https://github.com/jcsda/spack
   #branch = jcsda_emc_spack_stack
-  url = https://github.com/rhoneyager-tomorrow/spack
+  url = https://github.com/rhoneyager-tomorrow/spack-1
   branch = bugfix/hdf5_fpe
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
   #branch = jcsda_emc_spack_stack
   url = https://github.com/rhoneyager-tomorrow/spack
   branch = bugfix/hdf5_fpe
-  [submodule "doc/CMakeModules"]
+[submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules
   branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,12 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/spack/spack
-  #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
-[submodule "doc/CMakeModules"]
+  ##url = https://github.com/spack/spack
+  ##branch = develop
+  #url = https://github.com/jcsda/spack
+  #branch = jcsda_emc_spack_stack
+  url = https://github.com/rhoneyager-tomorrow/spack
+  branch = bugfix/hdf5_fpe
+  [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules
   branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = jcsda_emc_spack_stack
-  url = https://github.com/rhoneyager-tomorrow/spack-1
-  branch = bugfix/hdf5_fpe
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -4,8 +4,7 @@ packages:
     providers:
       # For now need to enable one or the other;
       # see https://github.com/JCSDA/spack-stack/issues/659
-      mpi:: [openmpi@4.1.5rc2]
-      #mpi:: [openmpi@4.1.4]
+      mpi:: [openmpi@4.1.6]
       blas:: [intel-oneapi-mkl]
       fftw-api:: [intel-oneapi-mkl]
       lapack:: [intel-oneapi-mkl]
@@ -25,15 +24,10 @@ packages:
   #    prefix: /p/app/compilers/intel/oneapi
   openmpi:
     externals:
-    - spec: openmpi@4.1.5rc2%intel@2021.5.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
-      prefix: /p/app/penguin/openmpi/4.1.5rc2/intel
+    - spec: openmpi@4.1.6%intel@2021.5.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+      prefix: /p/app/penguin/openmpi/4.1.6/intel-classic-2022.0.2
       modules:
-      - penguin/openmpi/4.1.5rc2/intel
-      - slurm
-    - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
-      prefix: /p/app/penguin/openmpi/4.1.4/aoc
-      modules:
-      - penguin/openmpi/4.1.4/aocc
+      - penguin/openmpi/4.1.6/intel-classic-2022.0.2
       - slurm
   intel-oneapi-mkl:
     externals:

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -29,8 +29,7 @@ packages:
       modules:
       - penguin/openmpi/4.1.6/intel-classic-2022.0.2
       - slurm
-    - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
-        fabrics=ucx schedulers=slurm
+    - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
       prefix: /p/app/penguin/openmpi/4.1.4/aoc
       modules:
       - penguin/openmpi/4.1.4/aocc

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -29,6 +29,12 @@ packages:
       modules:
       - penguin/openmpi/4.1.6/intel-classic-2022.0.2
       - slurm
+    - spec: openmpi@4.1.4%aocc@4.0.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
+        fabrics=ucx schedulers=slurm
+      prefix: /p/app/penguin/openmpi/4.1.4/aoc
+      modules:
+      - penguin/openmpi/4.1.4/aocc
+      - slurm
   intel-oneapi-mkl:
     externals:
     - spec: intel-oneapi-mkl@2022.0.2

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -321,9 +321,9 @@ For ``spack-stack-1.6.0`` with Intel, proceed with loading the following modules
 
 .. code-block:: console
 
-   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+   module use /p/app/projects/NEPTUNE/spack-stack/spack-stack-1.6.0/envs/ue-openmpi416/install/modulefiles/Core
    module load stack-intel/2021.5.0
-   module load stack-openmpi/4.1.5rc2
+   module load stack-openmpi/4.1.6
    module load stack-python/3.10.13
 
 With AMD clang/flang (aocc), the following is required for building new spack environments and for using spack to build and run software.

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -312,7 +312,7 @@ With Intel, the following is required for building new spack environments and fo
 
    module load slurm
    module load intel/compiler/2022.0.2
-   module load penguin/openmpi/4.1.5rc2/intel
+   module load penguin/openmpi/4.1.6/intel-classic-2022.0.2
 
    module use /p/app/projects/NEPTUNE/spack-stack/modulefiles
    module load ecflow/5.8.4


### PR DESCRIPTION
### Summary

Use openmpi@4.1.6 instead of 4.1.5rc2 on Nautilus.

I installed an openmpi-4.1.6 environment for the spack-stack-1.6.0 release and made the same modifications as for the existng unified-env environment (https://github.com/JCSDA/spack-stack/issues/941: netlib, fftw, sp link).

Notes.
1. This PR also includes a spack submodule pointer update for hdf5@1.14.3 fpe patches contributed by @rhoneyager-tomorrow (https://github.com/JCSDA/spack/pull/408). I ran the ctests on AWS ParallelCluster Intel with this bug fix included, and the only failures where:
```
	1506 - ufo_test_tier1_test_ufo_qc_historycheck (Failed)
	1507 - ufo_test_tier1_test_ufo_qc_historycheck_mpi (Failed)
	1508 - ufo_test_tier1_test_ufo_qc_historycheck_unittests (Failed)
	2058 - test_soca_parameters_diffusion_hz (Failed)
	2075 - test_soca_dirac_diffusion (Failed)
	2083 - test_soca_3dvar_diffusion (Failed)
	2089 - test_soca_3dhyb_diffusion (Failed)
```
2. This PR also fixes CI tests on the AWS R&D ParallelCluster (which I introduced in my previous PR)

### Testing

Built environment and ran jedi-bundle ctests. Only the "expected failures" occurred.

### Applications affected

All MPI applications on Nautilus

### Systems affected

Nautilus

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/408

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1006

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
