### PR TITLE
Move from zlib to zlib-ng

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/jcsda/spack
-  branch = jcsda_emc_spack_stack
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = zlibng
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
   path = spack
   #url = https://github.com/spack/spack
   #branch = develop
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = zlibng
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -10,7 +10,7 @@
         jpeg: [libjpeg-turbo]
         lapack: [openblas]
         yacc: [bison]
-        zlib-api: [zlib]
+        zlib-api: [zlib-ng]
     #
     # This version of awscli goes with py-pyyaml@5.4.1
     awscli:
@@ -275,8 +275,6 @@
       version: ['1.2.0']
     yafyaml:
       version: ['1.2.0']
-    zlib:
-      version: ['1.2.13']
     zstd:
       version: ['1.5.2']
       variants: +programs

--- a/spack-ext/repos/spack-stack/packages/base-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/base-env/package.py
@@ -27,7 +27,7 @@ class BaseEnv(BundlePackage):
     depends_on("curl", type="run")
 
     # I/O
-    depends_on("zlib", type="run")
+    depends_on("zlib-api", type="run")
     depends_on("hdf5", type="run")
     depends_on("netcdf-c", type="run")
     depends_on("netcdf-fortran", type="run")

--- a/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
@@ -30,7 +30,7 @@ class UfsUtilsEnv(BundlePackage):
     depends_on("w3emc")
     depends_on("sigio")
     depends_on("sfcio")
-    depends_on("zlib")
+    depends_on("zlib-ng")
     depends_on("hdf5")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")

--- a/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
@@ -30,7 +30,7 @@ class UfsUtilsEnv(BundlePackage):
     depends_on("w3emc")
     depends_on("sigio")
     depends_on("sfcio")
-    depends_on("zlib-ng")
+    depends_on("zlib-api")
     depends_on("hdf5")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")


### PR DESCRIPTION
### Summary

This PR moves from zlib to zlib-ng. Time to get with the times.

For now I'm not touching any of the templates.

### Testing

Tested on Hera & personal machine. Successfully concretizes without zlib, and on Hera, the UFS WM deps build and RTs run successfully.

### Applications affected

All

### Systems affected

All

### Dependencies

https://github.com/JCSDA/spack/pull/409

### Issue(s) addressed

#902

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
