### PR TITLE
Add missing packages for building spack-stack locally with Ubuntu

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -409,6 +409,8 @@ The following instructions were used to prepare a basic Ubuntu 20.04 or 22.04 LT
    apt install -y bzip2
    apt install -y unzip
    apt install -y automake
+   apt install -y autopoint
+   apt install -y gettext
    apt install -y xterm
    apt install -y texlive
    apt install -y libcurl4-openssl-dev


### PR DESCRIPTION
### Summary

This PR fixes the documentation, section "6.2.2. Prerequisites: Ubuntu (one-off)(https://spack-stack.readthedocs.io/en/1.6.0/NewSiteConfigs.html#prerequisites-ubuntu-one-off)", Step "Install basic OS packages as root", bullet "#Misc": 
- It adds two missing packages , `autopint` and `gettext` to the bullet "#Misc", without which otherwise caused failure of building spack-stack.

### Testing

None. This PR fixes the doc, instead of the code.

### Applications affected

None.

### Systems affected

Local installation of spack-stack with Ubuntu 22.04LTS

### Dependencies

None.

### Issue(s) addressed

This PR resolves #1023

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~ (not applicable)
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
