### PR TITLE
Document workaround for apple-clang@15.0.0 linker/loader issues.

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -268,7 +268,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
       extra_rpaths: []
 
 .. note::
-  Apple is aware of this issue and working on a solution, so this is a temparary workaround that will be removed once the linker/loader issues are repaired.
+  Apple is aware of this issue (Apple ticket number FB13208302) and working on a solution, so this is a temporary workaround that will be removed once the linker/loader issues are repaired.
 
 6. Do **not** forget to unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable!
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -244,6 +244,32 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
    spack compiler find --scope system
 
+.. note::
+  When using apple-clang@15.0.0 (or newer) compilers, you need to manually add the following ldflags spec in the `site/compilers.yaml` file.
+  There are known issues with new features in the Apple linker/loader that comes with the 15.0.0 compiler set, and this change tells the linker/loader to use its legacy features which work fine.
+
+.. code-block:: yaml
+  :emphasize-lines: 9,10
+
+  compilers:
+  - compiler:
+      spec: apple-clang@=15.0.0
+      paths:
+        cc: /usr/bin/clang
+        cxx: /usr/bin/clang++
+        f77: /opt/homebrew/bin/gfortran-12
+        fc: /opt/homebrew/bin/gfortran-12
+      flags:
+        ldflags: '-Wl,-ld_classic'         # Add this ldflags spec
+      operating_system: sonoma
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+.. note::
+  Apple is aware of this issue and working on a solution, so this is a temparary workaround that will be removed once the linker/loader issues are repaired.
+
 6. Do **not** forget to unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable!
 
 .. code-block:: console
@@ -521,6 +547,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    If the environment will be used to run JCSDA's JEDI-Skylab experiments using R2D2 with a local MySQL server, run the following command:
 
 .. code-block:: console
+
    spack config add "packages:ewok-env:variants:+mysql"
 
 9. If you have manually installed lmod, you will need to update the site module configuration to use lmod instead of tcl. Skip this step if you followed the Ubuntu or Red Hat instructions above.


### PR DESCRIPTION
### Summary

Until Apple fixes their new linker/loader associated with apple-clang@15.0.0 compilers, we need to use a manual workaround to get the spack-stack build to complete on MacOS platforms. See #971 for details. This PR adds documentation showing the user how to manually insert the workaround.

### Testing

I tested this on my Mac using Sphinx to build the modified documentation. It appears to be rendering the new instructions properly, but we'll see for sure with the CI testing.

### Applications affected

This primarily impacts UFS and JEDI applications, however the impact is very limited. This is documentation only change for a workaround that is only necessary on apple-clang%15.0.0 or newer compilers.

### Systems affected

MacOS platforms when using apple-clang@15.0.0 or newer compilers

### Dependencies

None

### Issue(s) addressed

Resolves #971

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
