### PR TITLE
release/1.7.0: add lowercase jedi_cmake_ROOT and atlas_ROOT env vars in modules for backward compatibility; update authorlist in doc conf

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -100,10 +100,12 @@ modules:
         suffixes:
           +debug: 'debug'
           build_type=Debug:  'debug'
+      # Keep lower-case var for backward compatibility; spack-stack-1.7.0 only
       ecmwf-atlas:
         environment:
           set:
             'atlas_ROOT': '{prefix}'
+            'ATLAS_ROOT': '{prefix}'
       esmf:
         environment:
           set:
@@ -112,6 +114,11 @@ modules:
         environment:
           set:
             'HDF5_DIR': '{prefix}'
+      # For backward compatibility; spack-stack-1.7.0 only
+      jedi-cmake:
+        environment:
+          set:
+            'jedi_cmake_ROOT': '{prefix}'
       libpng:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -102,10 +102,12 @@ modules:
         suffixes:
           +debug: 'debug'
           build_type=Debug:  'debug'
+      # Keep lower-case var for backward compatibility; spack-stack-1.7.0 only
       ecmwf-atlas:
         environment:
           set:
             'atlas_ROOT': '{prefix}'
+            'ATLAS_ROOT': '{prefix}'
       esmf:
         environment:
           set:
@@ -114,6 +116,11 @@ modules:
         environment:
           set:
             'HDF5_DIR': '{prefix}'
+      # For backward compatibility; spack-stack-1.7.0 only
+      jedi-cmake:
+        environment:
+          set:
+            'jedi_cmake_ROOT': '{prefix}'
       libpng:
         environment:
           set:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -143,7 +143,7 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
-    'maketitle': r'\newcommand\sphinxbackoftitlepage{For referencing this document please use: \newline \break Heinzeller, D., A. Richert, C. Book, 2024. spack-stack documentation release v1.7.0. Available at https://spack-stack.readthedocs.io/\textunderscore/downloads/en/v1.7.0/pdf/.}\sphinxmaketitle'
+    'maketitle': r'\newcommand\sphinxbackoftitlepage{For referencing this document please use: \newline \break Heinzeller, D., A. Richert, C. Book, E. Hartnett, H. Lei, N. Perlin, R. Vasic, S. Herbener, 2024. spack-stack documentation release v1.7.0. Available at https://spack-stack.readthedocs.io/\textunderscore/downloads/en/v1.7.0/pdf/.}\sphinxmaketitle'
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
### Summary

1. Provide lowercase `jedi_cmake_ROOT` and `atlas_ROOT` environment variables in auto-generated modulefiles for backward compatibility. Note that this is for release 1.7.0 only to facilitate the transition; this change will not be merged back into develop.

2. Update author list in LaTeX rendering of readthedocs. I took the liberty to remain first author here, everyone else is listed in alphabetical order of first name. Completely open to other suggestions, including first author. This isn't super relevant as literally nobody has ever accessed the LaTeX PDF version.

### Testing

None

### Applications affected

None

### Systems affected

None

### Dependencies

n/a

### Issue(s) addressed

na/

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
