### PR TITLE
Move to ip@5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/AlexanderRichert-NOAA/spack
+  url = https://github.com/jcsda/spack
   branch = release/1.7.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
+  url = https://github.com/AlexanderRichert-NOAA/spack
   branch = release/1.7.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -82,7 +82,7 @@
     freetype:
       variants: +pic
     g2:
-      version: ['3.4.5']
+      version: ['3.4.9']
     g2c:
       version: ['1.6.4']
     g2tmpl:
@@ -100,7 +100,7 @@
       # the container builds.
       #version: ['2.11.0']
     grib-util:
-      version: ['1.3.0']
+      version: ['1.4.0']
     gsibec:
       version: ['1.2.1']
     gsi-ncdiag:
@@ -259,6 +259,8 @@
       variants: precision=4,d,8
     udunits:
       version: ['2.2.28']
+    ufs-utils:
+      version: ['1.13.0']
     # Note - we can remove upp from stack at some point?
     upp:
       version: ['10.0.10']

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -114,7 +114,7 @@
       version: ['1.14.3']
       variants: +hl +fortran +mpi ~threadsafe ~szip
     ip:
-      version: ['4.3.0']
+      version: ['5.0.0']
       variants: precision=4,d,8
     ip2:
       version: ['1.1.2']

--- a/spack-ext/repos/spack-stack/packages/emc-gfs-wafs-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/emc-gfs-wafs-env/package.py
@@ -21,7 +21,7 @@ class EmcGfsWafsEnv(BundlePackage):
     depends_on("bacio")
     depends_on("w3emc")
     depends_on("w3nco")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("ip")
     depends_on("g2")
     depends_on("bufr")

--- a/spack-ext/repos/spack-stack/packages/gldas-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gldas-env/package.py
@@ -23,6 +23,6 @@ class GldasEnv(BundlePackage):
     depends_on("w3emc")
     depends_on("nemsio")
     depends_on("bacio")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
@@ -30,7 +30,7 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("g2tmpl")
     depends_on("w3nco")
     depends_on("w3emc")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("ip")
     depends_on("nemsio")
     depends_on("nemsiogfs")

--- a/spack-ext/repos/spack-stack/packages/gsi-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gsi-env/package.py
@@ -23,7 +23,7 @@ class GsiEnv(BundlePackage):
     depends_on("bufr")
     depends_on("bacio")
     depends_on("w3emc")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("ip")
     depends_on("sigio")
     depends_on("sfcio")

--- a/spack-ext/repos/spack-stack/packages/jedi-base-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/jedi-base-env/package.py
@@ -46,7 +46,7 @@ class JediBaseEnv(BundlePackage):
     depends_on("nlohmann-json", type="run")
     depends_on("nlohmann-json-schema-validator", type="run")
     depends_on("odc", type="run")
-    depends_on("sp", type="run")
+    depends_on("sp", type="run", when="^ip@:4")
     depends_on("udunits", type="run")
 
     # Python packages

--- a/spack-ext/repos/spack-stack/packages/nceplibs-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/nceplibs-env/package.py
@@ -32,7 +32,7 @@ class NceplibsEnv(BundlePackage):
     depends_on("nemsio")
     depends_on("sfcio")
     depends_on("sigio")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("w3emc")
     depends_on("w3nco")
     depends_on("wrf-io")

--- a/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
@@ -31,7 +31,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("g2")
     depends_on("g2tmpl")
     depends_on("ip")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("w3nco")
     depends_on("gfsio")
     depends_on("landsfcutil")

--- a/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
@@ -26,7 +26,7 @@ class UfsUtilsEnv(BundlePackage):
     depends_on("ip2")
     depends_on("nemsio")
     depends_on("nemsiogfs")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("w3emc")
     depends_on("sigio")
     depends_on("sfcio")

--- a/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
@@ -32,7 +32,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("g2", type="run")
     depends_on("g2tmpl", type="run")
     depends_on("ip", type="run")
-    depends_on("sp", type="run")
+    depends_on("sp", type="run", when="^ip@:4")
     depends_on("w3emc", type="run")
     depends_on("scotch", type="run")
     depends_on("cprnc", type="run")

--- a/spack-ext/repos/spack-stack/packages/upp-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/upp-env/package.py
@@ -24,7 +24,7 @@ class UppEnv(BundlePackage):
     depends_on("nemsio")
     depends_on("sfcio")
     depends_on("sigio")
-    depends_on("sp")
+    depends_on("sp", when="^ip@:4")
     depends_on("w3nco")
     depends_on("w3emc")
     depends_on("wrf-io")


### PR DESCRIPTION
### Summary

This PR changes the default ip version to ip@5, making sp no longer needed.

### Testing

Tested with UFS WM

### Applications affected

UFSWM, SRW, various JEDI

### Systems affected

all

### Dependencies

https://github.com/JCSDA/spack/pull/418

### Issue(s) addressed

Fixes #1020

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
