### PR TITLE
remove wgrib2 entry for grib-util module

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -189,7 +189,6 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB2': '{prefix}/bin/wgrib2'
       landsfcutil:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -191,7 +191,6 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB2': '{prefix}/bin/wgrib2'
       landsfcutil:
         environment:
           set:


### PR DESCRIPTION
### Summary

grib-util has a module config entry that adds a (non-existent) wgrib2 executable. This should not be defined there.

### Testing

none (no such executable exists)

### Applications affected

none

### Systems affected

none

### Dependencies

none

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/NCEPLIBS-grib_util/issues/312

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
