### PR TITLE
grib-util module fix

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -196,7 +196,6 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB2': '{prefix}/bin/wgrib2'
       landsfcutil:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -198,7 +198,6 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB2': '{prefix}/bin/wgrib2'
       landsfcutil:
         environment:
           set:


### PR DESCRIPTION
### Summary

This PR removes the unwanted and unneeded WGRIB2 entry from the grib-util module config.

### Testing

no testing to do

### Applications affected

none

### Systems affected

none

### Dependencies

none

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/NCEPLIBS-grib_util/issues/312

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
