### PR TITLE
release/1.7.0: Update container specs jedi-ci.yaml

### DIFF
--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -2,15 +2,15 @@
   specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.1, ecbuild@3.7.2, eccodes@2.33.0, ecflow@5,
     eckit@1.24.5, ecmwf-atlas@0.36.0 +fckit +trans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
-    eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.5, g2tmpl@1.10.2, gftl-shared@1.6.1,
-    gsibec@1.2.1, hdf@4.2.15, hdf5@1.14.3, ip@4.3.0, jasper@2.0.32, jedi-cmake@1.4.0,
+    eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.9, g2tmpl@1.10.2, gftl-shared@1.6.1,
+    gsibec@1.2.1, hdf@4.2.15, hdf5@1.14.3, ip@5.0.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.1, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
     parallelio@2.6.2, parallel-netcdf@1.12.3, py-eccodes@1.5.0, py-f90nml@1.4.3,
     py-gitpython@3.1.40, py-h5py@3.8.0, py-numpy@1.22.3,
     py-pandas@1.5.3, py-pip, py-pyyaml@6.0, py-scipy@1.11.4, py-shapely@1.8.0, py-xarray@2023.7.0,
     sp@2.5.0, udunits@2.2.28, w3emc@2.10.0, nco@5.1.6, esmf@8.6.0, mapl@2.40.3,
-    zlib@1.2.13, zstd@1.5.2, odc@1.4.6, shumlib@macos_clang_linux_intel_port,
+    zlib-ng@2.1.5, zstd@1.5.2, odc@1.4.6, shumlib@macos_clang_linux_intel_port,
     awscli-v2@2.13.22, py-globus-cli@3.16.0]
     # Notes:
     # 1. Don't build CRTM by default so that it gets built in the JEDI bundles


### PR DESCRIPTION
### Summary

Update container specs for jedi-ci to match what is in `unified-dev` on supported platforms.

### Testing

- [x] docker-ubuntu-clang-mpich container build and CI testing **built, ran jedi-bundle ctests and checked ecflow server**
- [x] docker-ubuntu-gcc-openmpi container build and CI testing **built**
- [x] docker-ubuntu-intel-impi container build and CI testing **built, successfully compiled jedi-bundle**

### Applications affected

JEDI CI

### Systems affected

JEDI CI docker containers

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
