### PR TITLE
Doc updates

### DIFF
--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -432,8 +432,6 @@ NOAA Acorn (WCOSS2 test system)
 
 For spack-stack-1.7.0, the meta modules are in ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.7.0/envs/ue-intel{19,2022}/modulefiles/Core``.
 
-Acorn has a spack-stack environment installed to reflect the versions and build options used on WCOSS2 for the operational configurations of the UFS Weather Model. The path to that environment is ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.6.0/envs/ufswm-env``.
-
 On WCOSS2 OpenSUSE sets ``CONFIG_SITE`` which causes libraries to be installed in ``lib64``, breaking the ``lib`` assumption made by some packages. Therefore, ``CONFIG_SITE`` should be set to empty in ``compilers.yaml``. Also, don't use ``module purge`` on Acorn!
 
 When installing an official ``spack-stack`` on Acorn, be mindful of umask and group ownership, as these can be finicky. The umask value should be 002, otherwise various files can be assigned to the wrong group. In any case, running something to the effect of ``chgrp nceplibs <spack-stack dir> -R`` and ``chmod o+rX <spack-stack dir> -R`` after the whole installation is done is a good idea.

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -90,7 +90,7 @@ For questions or problems, please consult the known issues in :numref:`Section %
 Supplemental environments
 =========================
  
-The following is a list of supplemental or "add-on" environments are maintained through spack-stack. Note that not all are included with every release; see the third column to determine release location and look under ``envs/`` subdirectory (i.e., same parent directory as ``ue-*`` directories per the above table). Check the installation directories to verify which package versions are available before using them.
+The following is a list of supplemental or "add-on" environments that are maintained through spack-stack. Note that not all are included with every release; see the third column to determine release location and look under ``envs/`` subdirectory (i.e., same parent directory as ``ue-*`` directories per the above table). Check the installation directories to verify which package versions are available before using them.
 
 +------------------+---------------------------------------------------------+------------------------+-------------------------------------------+
 | Environment name | Description                                             | spack-stack release(s) | Platforms                                 |

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -11,7 +11,7 @@ Pre-configured sites are split into two categories: Tier 1 with officially suppo
 Officially supported spack-stack 1.6.0 installations (tier 1)
 =============================================================
 
-Ready-to-use spack-stack 1.6.0 installations are available on the following, fully supported platforms. This version supports JEDI-Skylab and various UFS Applications (UFS Weather Model, EMC Global Workflow, GSI, UFS Short Range Weather Application). Amazon Web Services AMI are available in the US East 1 or 2 regions.
+Ready-to-use spack-stack 1.6.0 installations are available on the following fully supported platforms. This version supports JEDI-Skylab and various UFS and related applications (UFS Weather Model, EMC Global Workflow, GSI, UFS Short Range Weather Application). Amazon Web Services AMI are available in the US East 1 or 2 regions.
 
 On selected systems, developmental versions / release candidates are installed that are newer than spack-stack 1.6.0 (see following table). For information on the spack-stack 1.6.0 releases on this platforms, please revert to version 1.6.0 of the documentation (https://spack-stack.readthedocs.io/en/1.6.0/PreConfiguredSites.html#pre-configured-sites-tier-1).
 
@@ -36,7 +36,7 @@ On selected systems, developmental versions / release candidates are installed t
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (NCEP)         | Acorn                            | Intel           | ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.6.0/envs/unified-env-intel{19,2022}``          | NOAA-EMC                      |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
-|                     | Gaea C5                          | Intel           | ``/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env``                                      | EPIC / NOAA-EMC               |
+|                     | Gaea                             | Intel           | ``/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env``                                      | EPIC / NOAA-EMC               |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 | NOAA (RDHPCS)       | Hera                             | GCC, Intel      | ``/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env``                     | EPIC / NOAA-EMC               |
 |                     +----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
@@ -61,9 +61,32 @@ On selected systems, developmental versions / release candidates are installed t
 | NOAA (RDHPCS)       | RDHPCS Cloud (Parallel Works)    | Intel           | ``/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env``                                             | EPIC / JCSDA                  |
 +---------------------+----------------------------------+-----------------+---------------------------------------------------------------------------------------------------------+-------------------------------+
 
+**To use one of the above installations** via the system default environment module system, add ``/install/modulefiles/Core`` to the path from the above table and prepend that path to $MODULEPATH, e.g.,
+
+.. code-block:: console
+
+  # On Gaea:
+  module use /ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+  module load stack-intel
+  module load bacio netcdf-c ...
+
 For more information about a specific platform, please see the individual sections below.
 
 For questions or problems, please consult the known issues in :numref:`Section %s <KnownIssues>`, the currently open GitHub `issues <https://github.com/jcsda/spack-stack/issues>`_ and `discussions <https://github.com/jcsda/spack-stack/discussions>`_ first.
+
+=========================
+Supplemental environments
+=========================
+ 
+The following is a list of supplemental or "add-on" environments are maintained through spack-stack. Note that not all are included with every release; see the third column to determine release location and look under ``envs/`` subdirectory (i.e., same parent directory as ``unified-env`` directory per the above table). Check the installation directories to verify which package versions are available before using them.
+
++------------------+---------------------------------------------------------+------------------------+-------------------------------------------+
+| Environment name | Description                                             | spack-stack release(s) | Platforms                                 |
++==================+=========================================================+========================+===========================================+
+| gsi-addon-env    | Supports GSI and related applications                   | 1.6.0, 1.7.0           | Hera, Hercules, Gaea, Jet, S4             |
++------------------+---------------------------------------------------------+------------------------+-------------------------------------------+
+| ufswm-env        | Supports UFS Weather Model with WCOSS2 package versions | 1.6.0                  | Acorn, Hera, Hercules, Jet, Orion         |
++------------------+---------------------------------------------------------+------------------------+-------------------------------------------+
 
 .. _Preconfigured_Sites_Tier1:
 
@@ -109,9 +132,6 @@ For ``spack-stack-1.6.0`` with GNU, load the following modules after loading min
 .. note::
    The unified environment on Orion uses ``cdo@2.0.5`` instead of the default ``cdo@2.2.0`` because of a bug in the ``cdo`` package recipe that affects systems that don't have a ``python3`` interpreter in the default search paths (see https://github.com/spack/spack/issues/41947) for more information. This is a temporary change on Orion for the spack-stack-1.6.0 release and will be reverted once the ``cdo`` package is updated in the upstream spack develop code.
 
-.. note::
-   spack-stack-1.6.0 on Orion provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
-
 ------------------------------
 MSU Hercules
 ------------------------------
@@ -154,9 +174,6 @@ For ``spack-stack-1.6.0`` with GNU+OpenMPI, an alternative and recommended versi
    module load stack-openmpi/4.1.6
    module load stack-python/3.10.13
    module available
-
-.. note::
-   spack-stack-1.6.0 on Hercules provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
 
 .. note::
    spack-stack-1.6.0 on Hercules has additional packages `fms@2023.02.01`, `sp@2.3.0`, and `crtm@2.4.0` installed in the unified environment, in addition to the two default versions `fms@2023.04` and `fms@release-jcsda`.
@@ -432,6 +449,8 @@ NOAA Acorn (WCOSS2 test system)
 
 For spack-stack-1.6.0, the meta modules are in ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core``.
 
+Acorn has a spack-stack environment installed to reflect the versions and build options used on WCOSS2 for the operational configurations of the UFS Weather Model. The path to that environment is ``/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.6.0/envs/ufswm-env``.
+
 On WCOSS2 OpenSUSE sets ``CONFIG_SITE`` which causes libraries to be installed in ``lib64``, breaking the ``lib`` assumption made by some packages. Therefore, ``CONFIG_SITE`` should be set to empty in ``compilers.yaml``. Also, don't use ``module purge`` on Acorn!
 
 When installing an official ``spack-stack`` on Acorn, be mindful of umask and group ownership, as these can be finicky. The umask value should be 002, otherwise various files can be assigned to the wrong group. In any case, running something to the effect of ``chgrp nceplibs <spack-stack dir> -R`` and ``chmod o+rX <spack-stack dir> -R`` after the whole installation is done is a good idea.
@@ -443,7 +462,7 @@ As of spring 2023, there is an inconsistency in ``libstdc++`` versions on Acorn 
 Note that certain packages, such as recent versions of `py-scipy`, cannot be compiled on compute nodes because their build systems require internet access.
 
 .. note::
-   System-wide ``spack`` software installations are maintained by NCO on this platform. The spack-stack official installations use those installations for some dependencies.
+   System-wide ``spack`` software installations are maintained by NCO on this platform which are not associated with spack-stack. The spack-stack official installations use those installations for one dependency (git-lfs).
 
 .. _Preconfigured_Sites_Parallel_Works:
 
@@ -473,13 +492,13 @@ For ``spack-stack-1.6.0`` with Intel, proceed with loading the following modules
    module load stack-python/3.10.13
    module available
 
-.. _Preconfigured_Sites_Gaea_C5:
+.. _Preconfigured_Sites_Gaea:
 
 ------------------------------
-NOAA RDHPCS Gaea C5
+NOAA RDHPCS Gaea
 ------------------------------
 
-The following is required for building new spack environments and for using spack to build and run software. Make sure to log into a C5 head node, and don't use ``module purge`` on Gaea!
+The following is required for building new spack environments and for using spack to build and run software. Log into a head node, and don't use ``module purge`` on Gaea!
 
 .. code-block:: console
 
@@ -502,10 +521,10 @@ For ``spack-stack-1.6.0`` with Intel, proceed with loading the following modules
    module -t available
 
 .. note::
-   On Gaea C5, running ``module available`` without the option ``-t`` leads to an error: ``/usr/bin/lua5.3: /opt/cray/pe/lmod/lmod/libexec/Spider.lua:568: stack overflow``
+   On Gaea, running ``module available`` without the option ``-t`` leads to an error: ``/usr/bin/lua5.3: /opt/cray/pe/lmod/lmod/libexec/Spider.lua:568: stack overflow``
 
 .. note::
-   On Gaea C5, a current limitation is that any executable that is linked against the MPI library (``cray-mpich``) must be run through ``srun`` on a compute node, even if it is run serially (one process). This is in particular a problem when using ``ctest`` for unit testing created by the ``ecbuild add_test`` macro. A workaround is to use the `cmake` cross-compiling emulator for this:
+   On Gaea, a current limitation is that any executable that is linked against the MPI library (``cray-mpich``) must be run through ``srun`` on a compute node, even if it is run serially (one process). This is in particular a problem when using ``ctest`` for unit testing created by the ``ecbuild add_test`` macro. A workaround is to use the `cmake` cross-compiling emulator for this:
 
 .. code-block:: console
 
@@ -548,10 +567,6 @@ For ``spack-stack-1.6.0`` with GNU, proceed with loading the following modules:
 
 Note that on Hera, a dedicated node exists for ``ecflow`` server jobs (``hecflow01``). Users starting ``ecflow_server`` on the regular login nodes will see their servers being killed every few minutes, and may be barred from accessing the system.
 
-.. note::
-
-   spack-stack-1.6.0 on Hera provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
-
 .. _Preconfigured_Sites_Jet:
 
 ------------------------------
@@ -588,10 +603,6 @@ For ``spack-stack-1.6.0`` with GNU, proceed with loading the following modules:
    module load stack-python/3.10.8
    module available
 
-.. note::
-
-   spack-stack-1.6.0 on Jet provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
-
 ------------------------------
 UW (Univ. of Wisconsin) S4
 ------------------------------
@@ -618,10 +629,6 @@ For ``spack-stack-1.6.0`` with Intel, proceed with loading the following modules
    module available
 
 Note the two `module unuse` commands, that need to be run after the stack metamodules are loaded. Loading the Intel compiler meta module loads the Intel compiler module provided by the sysadmins, which adds those two directories to the module path. These contain duplicate libraries that are not compatible with our stack, such as ``hdf4``.
-
-.. note::
-
-   spack-stack-1.6.0 on S4 provides a chained environment `gsi-addon-env` for GSI with Intel. To use this environment, replace `unified-env` in the above `module use` statements with `gsi-addon-env`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.
 
 .. note::
 

--- a/doc/source/Utilities.rst
+++ b/doc/source/Utilities.rst
@@ -29,6 +29,7 @@ check_package_config.py
 The utility at util/check_package_config.py is run after concretization in an active spack-stack environment (i.e., `$SPACK_ENV` is set) to confirm that the packages versions and variants in common/packages.yaml are respected in the concretization, as well as that any externals specified in site/packages.yaml are not being omitted. It does this by reading common/packages.yaml (for the version and variant settings), site/packages.yaml (for the external settings), and spack.lock. Usage is as follows:
 
 .. code-block:: console
+
    spack env active envs/unified-env/
    # To verify versions, variants, and externals:
    ${SPACK_STACK_DIR}/util/check_package_config.py


### PR DESCRIPTION
### Summary

This PR updates readthedocs:
- Create table to track add-on envs and make them easy to find.
- Clarify how to use the pre-configured sites table.
- Change 'Gaea C5' -> 'Gaea'

### Testing

Tested doc build on personal machine.

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

none

### Issue(s) addressed

Fixes #1056

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
