### PR TITLE
Remove intel 2018 from compilers.yaml and packages.yaml on Orion

### DIFF
--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -18,24 +18,6 @@ compilers:
         CPATH: '/apps/gcc-10.2.0/gcc-10.2.0/include'
     extra_rpaths: []
 - compiler:
-    spec: intel@18.0.5
-    paths:
-      cc: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/icc
-      cxx: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/icpc
-      f77: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/ifort
-      fc: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - intel/2018.4
-    environment:
-      prepend_path:
-        PATH: '/apps/gcc-8/gcc-8.3.0/bin'
-        LD_LIBRARY_PATH: '/apps/gcc-8/gcc-8.3.0/lib64:/apps/gcc-8/gcc-8.3.0//lib:/apps/gcc-8/gcc-8.3.0/mpfr-4.0.2/lib:/apps/gcc-8/gcc-8.3.0/mpc-1.1.0/lib:/apps/gcc-8/gcc-8.3.0/gmp-6.1.2/lib'
-        CPATH: '/apps/gcc-8/gcc-8.3.0/include'
-    extra_rpaths: []
-- compiler:
     spec: gcc@10.2.0
     paths:
       cc: /apps/gcc-10.2.0/gcc-10.2.0/bin/gcc

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -1,10 +1,8 @@
 packages:
   all:
     compiler:: [intel@2022.0.2, gcc@10.2.0]
-    #compiler:: [intel@18.0.5]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.0.4]
-      #mpi:: [intel-mpi@2018.5.274]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,12 +13,6 @@ packages:
       prefix: /apps/intel-2022.1.2/intel-2022.1.2
       modules:
       - impi/2022.1.2
-  intel-mpi:
-    externals:
-    - spec: intel-mpi@2018.5.274%intel@18.0.5
-      prefix: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/mpi
-      modules:
-      - impi/2018.4
   openmpi:
     externals:
     - spec: openmpi@4.0.4%gcc@10.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath


### PR DESCRIPTION
### Summary

Intel installation was failing for version 2018.4. It is removed and 2022.0 was used.

### Testing

Installation on Orion was successful. 

### Applications affected

N/A

### Systems affected

N/A

### Dependencies

N/A

### Issue(s) addressed

Fixes #1063 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
