### PR TITLE
release/1.7.0: revert uppercase PACKAGE_ROOT env vars

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -114,11 +114,6 @@ modules:
         environment:
           set:
             'HDF5_DIR': '{prefix}'
-      # For backward compatibility; spack-stack-1.7.0 only
-      jedi-cmake:
-        environment:
-          set:
-            'jedi_cmake_ROOT': '{prefix}'
       libpng:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -116,11 +116,6 @@ modules:
         environment:
           set:
             'HDF5_DIR': '{prefix}'
-      # For backward compatibility; spack-stack-1.7.0 only
-      jedi-cmake:
-        environment:
-          set:
-            'jedi_cmake_ROOT': '{prefix}'
       libpng:
         environment:
           set:


### PR DESCRIPTION
### Summary

Update submodule pointer for the changes described in https://github.com/JCSDA/spack/pull/421 and remove the previously added `jedi_cmake_ROOT env vars in configs/common/modules_*.yaml`.

This is for the release branch. After this is merged, we will need to retag the spack submodule, update spack-stack (remove the extra JEDI_CMAKE_ROOT env settings in `configs/common/modules.*yaml`), tag, go back to all supported platforms, check out the final tagged code, and rerun the `spack module ??? refresh && spack stack setup-meta-modules` commands.

List of platforms:

- [x] Hercules (@RatkoVasic-NOAA)
- [x] Orion (@RatkoVasic-NOAA) 
- [x] Discover (@climbfuji)
- [x] Casper (@climbfuji)
- [x] Derecho (@RatkoVasic-NOAA) 
- [ ] Acorn (@AlexanderRichert-NOAA)
- [x] Gaea C5 (@RatkoVasic-NOAA)
- [x] Hera (@AlexanderRichert-NOAA)
- [x] Jet (@AlexanderRichert-NOAA)
- [x] Narwhal (@climbfuji)
- [x] Nautilus (@climbfuji)
- [x] S4 (@climbfuji)
- [x] AWS AMI RH 8 (@climbfuji)
- [x] AWS CI cluster (existing, c6i; @climbfuji)
- [ ] ~~AWS ParallelCluster~~ (decommissioned - if resurrected, then @climbfuji)
- [x] NOAA ParallelWorks EPIC (@natalie-perlin)
- [x] NOAA ParallelWorks JCSDA (@climbfuji)

### Testing

- CI

### Applications affected

All = none (because our applications still expect the lowercase/case-preserving version)

### Systems affected

All

### Dependencies

- [x] https://github.com/JCSDA/spack/pull/421

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1066

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
