### PR TITLE
Fix for mapl

### DIFF
--- a/configs/sites/acorn/packages.yaml
+++ b/configs/sites/acorn/packages.yaml
@@ -25,6 +25,8 @@
       externals:
       - spec: perl@5.26.1~cpanm+shared+threads
         prefix: /usr
+    mapl:
+      require: '@2.40.3 ~pflogger ~extdata2g'
     mysql:
       buildable: false
       externals:

--- a/configs/sites/derecho/packages.yaml
+++ b/configs/sites/derecho/packages.yaml
@@ -32,6 +32,8 @@ packages:
   # Newer versions of patchelf (tested 0.18.0) don't build with Intel on Derecho
   patchelf:
     version:: ['0.17.2']
+  mapl:
+    require: '@2.40.3 ~pflogger ~extdata2g'
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/gaea-c5/packages.yaml
+++ b/configs/sites/gaea-c5/packages.yaml
@@ -13,6 +13,10 @@ packages:
       - craype-network-ofi
       - cray-mpich/8.1.25
 
+### Modifications of common packages
+  mapl:
+    require: '@2.40.3 ~pflogger ~extdata2g'
+
 ### All other external packages listed alphabetically
   autoconf:
     externals:

--- a/configs/sites/hercules/packages.yaml
+++ b/configs/sites/hercules/packages.yaml
@@ -23,6 +23,8 @@ packages:
       - openmpi/4.1.6-gcc-12.2.0-spack
 
 ### Modifications of common packages
+  mapl:
+      require: '@2.40.3 ~pflogger ~extdata2g'
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -25,6 +25,8 @@ packages:
   # Temporary - see https://github.com/spack/spack/issues/41947
   cdo:
     require: '@2.0.5'
+  mapl:
+    require: '@2.40.3 ~pflogger ~extdata2g'
 
 ### All other external packages listed alphabetically
   autoconf:


### PR DESCRIPTION
### Summary

With Intel compiler newer than 2021.7 mapl was having problems with pflogger and extdata2g
Added lines in packages.yaml for machines: Orion, Hercules, Gaea and Derecho:
  mapl:
    require: '@2.40.3 ~pflogger ~extdata2g'

### Testing

Tested on  Orion, Hercules, Gaea and Derecho machines.

### Systems affected

Orion, Hercules, Gaea and Derecho

### Issue(s) addressed
This solves issue #1070 


### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
