### PR TITLE
Switch orion site config to zlib instead of zlib-ng

### DIFF
--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -3,6 +3,8 @@ packages:
     compiler:: [intel@2022.0.2, gcc@10.2.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.0.4]
+      # https://github.com/JCSDA/spack-stack/issues/1055
+      zlib-api:: [zlib]
 
 ### MPI, Python, MKL
   mpi:


### PR DESCRIPTION
### Summary

This is similar to what was done for the release/spack-stack-1.7.0 branch on S4. With intel@2021.5.0 (will be used on Orion until May 22nd, 2024), `zlib-ng` wrecks havoc: cannot run `git clone`, cannot run `pip install`, etc.

### Testing

Used on Orion to rebuild the spack-stack-1.7.0 installs of `ue` and `gsi-addon-env` with Intel (left GNU alone).

### Applications affected

n/a

### Systems affected

Orion until it's rebuilt in May

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
