### PR TITLE
TACC Frontera support

### DIFF
--- a/configs/sites/frontera/compilers.yaml
+++ b/configs/sites/frontera/compilers.yaml
@@ -19,26 +19,6 @@ compilers::
           PATH: '/opt/apps/gcc/9.1.0/bin'
           CPATH: '/opt/apps/gcc/9.1.0/include'
           LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin:/opt/apps/gcc/9.1.0/lib64:/opt/apps/gcc/9.1.0/lib'
-        set:
-          # https://github.com/JCSDA/spack-stack/issues/1012
-          I_MPI_EXTRA_FILESYSTEM: 'ON'
-          # https://github.com/JCSDA/spack-stack/issues/1011
-          I_MPI_SHM_HEAP_VSIZE: '512'
-          PSM2_MEMORY: 'large'
-          I_MPI_EXTRA_FILESYSTEM_FORCE: 'gpfs'
-          I_MPI_FABRICS: 'ofi'
-          I_MPI_OFI_PROVIDER: 'psm3'
-          I_MPI_ADJUST_SCATTER: '2'
-          I_MPI_ADJUST_SCATTERV: '2'
-          I_MPI_ADJUST_GATHER: '2'
-          I_MPI_ADJUST_GATHERV: '3'
-          I_MPI_ADJUST_ALLGATHER: '3'
-          I_MPI_ADJUST_ALLGATHERV: '3'
-          I_MPI_ADJUST_ALLREDUCE: '12'
-          I_MPI_ADJUST_REDUCE: '10'
-          I_MPI_ADJUST_BCAST: '11'
-          I_MPI_ADJUST_REDUCE_SCATTER: '4'
-          I_MPI_ADJUST_BARRIER: '9'
       extra_rpaths: []
   - compiler:
       spec: gcc@=9.1.0

--- a/configs/sites/frontera/compilers.yaml
+++ b/configs/sites/frontera/compilers.yaml
@@ -1,0 +1,56 @@
+compilers::
+  - compiler:
+      spec: intel@=23.1.0
+      paths:
+        cc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/icc
+        cxx: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/icpc
+        f77: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/ifort
+        fc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/ifort
+      flags:
+        cflags: -diag-disable=10441
+        cxxflags: -diag-disable=10441
+        fflags: -diag-disable=10448
+      operating_system: centos7
+      target: x86_64
+      modules:
+      - intel/23.1.0
+      environment:
+        prepend_path:
+          PATH: '/opt/apps/gcc/9.1.0/bin'
+          CPATH: '/opt/apps/gcc/9.1.0/include'
+          LD_LIBRARY_PATH: '/opt/intel/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin:/opt/apps/gcc/9.1.0/lib64:/opt/apps/gcc/9.1.0/lib'
+        set:
+          # https://github.com/JCSDA/spack-stack/issues/1012
+          I_MPI_EXTRA_FILESYSTEM: 'ON'
+          # https://github.com/JCSDA/spack-stack/issues/1011
+          I_MPI_SHM_HEAP_VSIZE: '512'
+          PSM2_MEMORY: 'large'
+          I_MPI_EXTRA_FILESYSTEM_FORCE: 'gpfs'
+          I_MPI_FABRICS: 'ofi'
+          I_MPI_OFI_PROVIDER: 'psm3'
+          I_MPI_ADJUST_SCATTER: '2'
+          I_MPI_ADJUST_SCATTERV: '2'
+          I_MPI_ADJUST_GATHER: '2'
+          I_MPI_ADJUST_GATHERV: '3'
+          I_MPI_ADJUST_ALLGATHER: '3'
+          I_MPI_ADJUST_ALLGATHERV: '3'
+          I_MPI_ADJUST_ALLREDUCE: '12'
+          I_MPI_ADJUST_REDUCE: '10'
+          I_MPI_ADJUST_BCAST: '11'
+          I_MPI_ADJUST_REDUCE_SCATTER: '4'
+          I_MPI_ADJUST_BARRIER: '9'
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@=9.1.0
+      paths:
+        cc: /opt/apps/gcc/9.1.0/bin/gcc
+        cxx: /opt/apps/gcc/9.1.0/bin/g++
+        f77: /opt/apps/gcc/9.1.0/bin/gfortran
+        fc: /opt/apps/gcc/9.1.0/bin/gfortran
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules:
+      - gcc/9.1.0
+      environment: {}
+      extra_rpaths: []

--- a/configs/sites/frontera/config.yaml
+++ b/configs/sites/frontera/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 4

--- a/configs/sites/frontera/modules.yaml
+++ b/configs/sites/frontera/modules.yaml
@@ -1,0 +1,7 @@
+modules:
+  default:
+    enable::
+    - lmod
+    lmod:
+      exclude:
+      - ecflow

--- a/configs/sites/frontera/packages.yaml
+++ b/configs/sites/frontera/packages.yaml
@@ -1,0 +1,256 @@
+packages:
+  all:
+    compiler:: [intel@23.1.0]
+    #compiler:: [gcc@12.2.0]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.9.0]
+      #mpi:: [mvapich2@2.3]
+
+### MPI, Python, MKL
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.9.0%intel@23.1.0
+      modules:
+      - impi/21.9.0
+      prefix: /opt/intel/oneapi
+  #mvapich2:
+  #  externals:
+  #  - spec: mvapich2@2.3%gcc@9.1.0
+  #    modules:
+  #    - mvapich2-x/2.3
+  #    prefix: /opt/apps/gcc9_1/mvapich2-x/2.3
+  python:
+    require: "+ssl"
+
+### All other external packages listed alphabetically
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /opt/apps/autotools/1.2
+  automake:
+    externals:
+    - spec: automake@1.15
+      prefix: /opt/apps/autotools/1.2
+    - spec: automake@1.13.4
+      prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.2.46
+      prefix: /usr
+  berkeley-db:
+    externals:
+    - spec: berkeley-db@5.3.21
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.32
+      prefix: /opt/apps/gcc/9.1.0
+    - spec: binutils@2.27.44
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4
+      prefix: /usr
+  bzip2:
+    externals:
+    - spec: bzip2@1.0.6
+      prefix: /usr
+  cmake:
+    externals:
+    - spec: cmake@3.24.2
+      prefix: /opt/apps/cmake/3.24.2
+      modules:
+      - cmake/3.24.2
+  cpio:
+    externals:
+    - spec: cpio@2.11
+      prefix: /usr
+  curl:
+    externals:
+    - spec: curl@7.29.0+ldap
+      prefix: /usr
+  cvs:
+    externals:
+    - spec: cvs@1.11.23
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.3
+      prefix: /usr
+  dos2unix:
+    externals:
+    - spec: dos2unix@6.0.3
+      prefix: /usr
+  doxygen:
+    externals:
+    - spec: doxygen@1.8.5+graphviz~mscgen
+      prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost
+      prefix: /work2/06146/tg854455/frontera/spack-stack/ecflow-5.8.4
+      modules:
+      - ecflow/5.8.4
+  file:
+    externals:
+    - spec: file@5.11
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.5.11
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.5.37+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@4.0.2
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.19.8.1
+      prefix: /usr
+  ghostscript:
+    externals:
+    - spec: ghostscript@9.25
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.24.1+tcltk
+      prefix: /opt/apps/git/2.24.1
+  git-lfs:
+    externals:
+    - spec: git-lfs@2.10.0
+      modules:
+      - git-lfs/2.10.0
+      prefix: /work2/06146/tg854455/frontera/spack-stack/git-lfs/2.10.0
+  gmake:
+    externals:
+    - spec: gmake@3.82
+      prefix: /usr
+  go:
+    externals:
+    - spec: go@1.15.14
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.2
+      prefix: /usr
+  hwloc:
+    externals:
+    - spec: hwloc@1.11.8
+      prefix: /usr
+  krb5:
+    externals:
+    - spec: krb5@1.15.1
+      prefix: /usr
+  libfuse:
+    externals:
+    - spec: libfuse@2.9.2
+      prefix: /usr
+    - spec: libfuse@3.6.1
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /opt/apps/autotools/1.2
+    - spec: libtool@2.4.2
+      prefix: /usr
+  lustre:
+    externals:
+    - spec: lustre@2.12.8_ddn7
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /opt/apps/autotools/1.2
+    - spec: m4@1.4.16
+      prefix: /usr
+  meson:
+    externals:
+    - spec: meson@0.55.1
+      prefix: /usr
+  ncurses:
+    externals:
+    - spec: ncurses@5.9.20130511+termlib abi=5
+      prefix: /usr
+    - spec: ncurses@6.3.20211021+termlib abi=6
+      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
+  ninja:
+    externals:
+    - spec: ninja@1.10.2
+      prefix: /usr
+  openssh:
+    externals:
+    - spec: openssh@8.5p1-hpn15v2
+      prefix: /usr
+#  openssl:
+#    externals:
+#    - spec: openssl@1.0.2k-fips
+#      prefix: /usr
+#    - spec: openssl@1.1.1q
+#      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
+#  perl:
+#    externals:
+#    - spec: perl@5.16.3~cpanm+shared+threads
+#      prefix: /usr
+  pkg-config:
+    externals:
+    - spec: pkg-config@0.27.1
+      prefix: /usr
+  qt:
+    externals:
+    - spec: qt@5.14.2
+      prefix: /opt/apps/qt5/5.14.2
+  rsync:
+    externals:
+    - spec: rsync@3.1.2
+      prefix: /usr
+  ruby:
+    externals:
+    - spec: ruby@2.0.0
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.2.2
+      prefix: /usr
+  slurm:
+    externals:
+    - spec: slurm@20.11.9
+      prefix: /usr
+  sqlite:
+    externals:
+    - spec: sqlite@3.38.2+fts~functions+rtree
+      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
+  subversion:
+    externals:
+    - spec: subversion@1.7.14
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.26
+      prefix: /usr
+  texinfo:
+    externals:
+    - spec: texinfo@5.1
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.14
+      prefix: /usr
+  which:
+    externals:
+    - spec: which@2.20
+      prefix: /usr
+  xz:
+    externals:
+    - spec: xz@5.2.5
+      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
+  zip:
+    externals:
+    - spec: zip@3.0
+      prefix: /usr

--- a/configs/sites/frontera/packages.yaml
+++ b/configs/sites/frontera/packages.yaml
@@ -1,10 +1,8 @@
 packages:
   all:
     compiler:: [intel@23.1.0]
-    #compiler:: [gcc@12.2.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.9.0]
-      #mpi:: [mvapich2@2.3]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,14 +13,6 @@ packages:
       modules:
       - impi/21.9.0
       prefix: /opt/intel/oneapi
-  #mvapich2:
-  #  externals:
-  #  - spec: mvapich2@2.3%gcc@9.1.0
-  #    modules:
-  #    - mvapich2-x/2.3
-  #    prefix: /opt/apps/gcc9_1/mvapich2-x/2.3
-  python:
-    require: "+ssl"
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -178,8 +168,6 @@ packages:
     externals:
     - spec: ncurses@5.9.20130511+termlib abi=5
       prefix: /usr
-    - spec: ncurses@6.3.20211021+termlib abi=6
-      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
   ninja:
     externals:
     - spec: ninja@1.10.2
@@ -188,16 +176,6 @@ packages:
     externals:
     - spec: openssh@8.5p1-hpn15v2
       prefix: /usr
-#  openssl:
-#    externals:
-#    - spec: openssl@1.0.2k-fips
-#      prefix: /usr
-#    - spec: openssl@1.1.1q
-#      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
-#  perl:
-#    externals:
-#    - spec: perl@5.16.3~cpanm+shared+threads
-#      prefix: /usr
   pkg-config:
     externals:
     - spec: pkg-config@0.27.1
@@ -222,10 +200,6 @@ packages:
     externals:
     - spec: slurm@20.11.9
       prefix: /usr
-  sqlite:
-    externals:
-    - spec: sqlite@3.38.2+fts~functions+rtree
-      prefix: /work2/06146/tg854455/frontera/spack-stack/miniconda-3.9.12
   subversion:
     externals:
     - spec: subversion@1.7.14
@@ -241,10 +215,6 @@ packages:
   wget:
     externals:
     - spec: wget@1.14
-      prefix: /usr
-  which:
-    externals:
-    - spec: which@2.20
       prefix: /usr
   xz:
     externals:


### PR DESCRIPTION
### Summary
This PR aims to bring TACC Frontera support to spack-stack. The PR based on initial implementation which was available on 1.5.1 and modified to use more recent version of the Intel Compiler (`intel/23.1.0` using `gcc/9.1.0` backend) and MPI (impi/21.9.0).

### Testing

`ufs-weather-model` template is tested in the installation.

### Applications affected

None

### Systems affected

None. Adds TACC Frontera support.

### Dependencies

None

### Issue(s) addressed

Link the issues addressed or resolved by this PR (use `Fixes #???` for fully resolved issues)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
