### PR TITLE
Update path to find qt@5

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -232,6 +232,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
    PATH="$HOMEBREW_ROOT/opt/curl/bin:$PATH" \
         spack external find --scope system curl
 
+   # Note - Path to qt can differ by homebrew version. Check path if qt is not found.
    PATH="$HOMEBREW_ROOT/opt/qt@5/bin:$PATH" \
        spack external find --scope system qt
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -232,7 +232,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
    PATH="$HOMEBREW_ROOT/opt/curl/bin:$PATH" \
         spack external find --scope system curl
 
-   PATH="$HOMEBREW_ROOT/opt/qt5/bin:$PATH" \
+   PATH="$HOMEBREW_ROOT/opt/qt@5/bin:$PATH" \
        spack external find --scope system qt
 
    # Optional, only if planning to build jedi-tools environment with LaTeX support


### PR DESCRIPTION
### Summary

The homebrew path to qt version 5 that is currently in the instructions was not found on a new system, resulting in qt not being found by the `find` command. Updating the path.

### Testing

Instructions tested on new M2 Mac with fresh homebrew install.
