### PR TITLE
Add esmf@8.6.1b04 and esmf@8.7.0b04

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/esmf_861b04_870b04
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/esmf_861b04_870b04
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -137,6 +137,10 @@ modules:
           ^esmf@8.5.0+debug snapshot=none: 'esmf-8.5.0-debug'
           ^esmf@8.6.0~debug snapshot=none: 'esmf-8.6.0'
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
+          ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
+          ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
+          ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -139,6 +139,10 @@ modules:
           ^esmf@8.5.0+debug snapshot=none: 'esmf-8.5.0-debug'
           ^esmf@8.6.0~debug snapshot=none: 'esmf-8.6.0'
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
+          ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
+          ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
+          ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -60,6 +60,10 @@
     esmf:
       version: ['8.6.0']
       variants: ~xerces ~pnetcdf snapshot=none +shared +external-parallelio
+      #version: ['8.6.1b04']
+      #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
+      #version: ['8.7.0b04']
+      #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
       require:
         - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"


### PR DESCRIPTION
### Summary

See title. As mentioned in https://github.com/JCSDA/spack/pull/423, we will not be sending these changes back to spack develop, but rather replace them with the official tags once they are ready.

### Testing

- [x] Installed on my macOS alongside with esmf@8.6.0, also generated the modules
- [x] CI

### Applications affected

none (since the new version are not the defaults)

### Systems affected

none

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/423

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1079 and https://github.com/JCSDA/spack-stack/issues/1062

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
