### PR TITLE
JEDI CI container specs update and FMS update for JEDI-FV3

### DIFF
--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -75,6 +75,11 @@ spack:
       externals:
       - spec: mysql@8.0.32
         prefix: /usr
+    py-pynacl:
+      buildable: false
+      externals:
+      - spec: py-pynacl@1.5.0
+        prefix: /usr/lib/python3/dist-packages/nacl
     # Turn off crypt, because libxcrypt doesn't
     # build with Intel.
     python:
@@ -180,7 +185,8 @@ spack:
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
         apt update && \
-        apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 intel-oneapi-mpi-devel-2021.6.0 -y
+        apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 intel-oneapi-mpi-devel-2021.6.0 python3-nacl -y && \
+        rm -rf /var/lib/apt/lists/*
       pre_final: |
         # Set environment variables for installing tzdata
         ENV DEBIAN_FRONTEND=noninteractive
@@ -199,7 +205,8 @@ spack:
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
         apt update && \
-        apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 intel-oneapi-mpi-devel-2021.6.0 -y
+        apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 intel-oneapi-mpi-devel-2021.6.0 -y && \
+        rm -rf /var/lib/apt/lists/*
         # Copy spack find output from builder
         COPY --from=builder /root/spack_find.out /root/spack_find.out
         # Make a non-root user:nonroot / group:nonroot for running MPI

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -2,7 +2,7 @@
   specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.1, ecbuild@3.7.2, eccodes@2.33.0, ecflow@5,
     eckit@1.24.5, ecmwf-atlas@0.36.0 +fckit +trans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
-    eigen@3.4.0, fckit@0.11.0, fms@release-jcsda, g2@3.4.9, g2tmpl@1.10.2, gftl-shared@1.6.1,
+    eigen@3.4.0, fckit@0.11.0, fms@2023.04, g2@3.4.9, g2tmpl@1.10.2, gftl-shared@1.6.1,
     gsibec@1.2.1, hdf@4.2.15, hdf5@1.14.3, ip@5.0.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1,
     netcdf-fortran@4.6.1, nlohmann-json@3.10.5, nlohmann-json-schema-validator@2.1.0,
@@ -11,7 +11,9 @@
     py-pandas@1.5.3, py-pip, py-pyyaml@6.0, py-scipy@1.11.4, py-shapely@1.8.0, py-xarray@2023.7.0,
     sp@2.5.0, udunits@2.2.28, w3emc@2.10.0, nco@5.1.6, esmf@8.6.0, mapl@2.40.3,
     zlib-ng@2.1.5, zstd@1.5.2, odc@1.4.6, shumlib@macos_clang_linux_intel_port,
-    awscli-v2@2.13.22, py-globus-cli@3.16.0]
+    awscli-v2@2.13.22, py-globus-cli@3.16.0,
+    # Added for new CI system 2024/04/30
+    py-ansi2html@1.6.0, py-pygithub@2.1.1, jq@1.6 ]
     # Notes:
     # 1. Don't build CRTM by default so that it gets built in the JEDI bundles
     # 2. Comment out for now until build problems are solved

--- a/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
@@ -24,7 +24,7 @@ class GmaoSwellEnv(BundlePackage):
     depends_on("crtm@v2.4-jedi.2", type="run")
 
     # Additional dependencies for JEDI used by swell
-    depends_on("fms@release-jcsda", type="run")
+    depends_on("fms@2023.04+pic", type="run")
     depends_on("nco", type="run")
 
     # GEOS

--- a/spack-ext/repos/spack-stack/packages/jedi-fv3-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/jedi-fv3-env/package.py
@@ -17,6 +17,6 @@ class JediFv3Env(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@release-jcsda", type="run")
+    depends_on("fms@2023.04+pic", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

1. Add missing packages to JEDI-CI specs for container builds (needed by JEDI CI system)
2. Update FMS from `release-jcsda` to `2023.04` for jedi-fv3-env and `gmao-swell-env` (the latter to be confirmed by GMAO). This is needed for the FMS + FV3-DYCORE updates in fv3-jedi etc.

### Testing

1. [x] Built gcc-openmpi container manually on EC2
2. [x] Needs testing in JEDI-CI framework after test containers have been built
3. [ ] ~~Needs testing with gmao-swell-env on Discover (if change is ok for GMAO)~~

### Applications affected

JEDI CI (JEDI-FV3)

### Systems affected

Container builds

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
