### PR TITLE
Add WGRIB variable to grib-util module

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -194,6 +194,7 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
+            'WGRIB': '{prefix}/bin/wgrib'
       landsfcutil:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -196,6 +196,7 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
+            'WGRIB': '{prefix}/bin/wgrib'
       landsfcutil:
         environment:
           set:


### PR DESCRIPTION
### Summary

This PR adds a variable WGRIB for the wgrib executable in the grib-util module.

### Testing

Tested on personal machine

### Applications affected

UPP, Global Workflow, EMC verif

### Systems affected

all

### Dependencies

none

### Issue(s) addressed

#1097

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
