### PR TITLE
Remove MPI wrappers for FMS and MAPL builds to enable apple-clang%15.x builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/srherbener/spack
-  branch = feature/apple-clang15x-fms-mapl
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/srherbener/spack
+  branch = feature/apple-clang15x-fms-mapl
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

This PR is simply for syncing up the spack submodule hash for the spack PR (JCSDA/spack/pull/431) that enables builds of FMS and MAPL using apple-clang%15.x. 

### Testing

These changes were tested on my Mac using apple-clang%15.0.0 (Xcode 15.1). 

### Applications affected

FMS and MAPL are impacted. The usage of the MPI wrappers has been removed.

### Systems affected

The MPI wrappers were removed unconditionally so these changes can affect the HPC platforms, plus MacOS, using FMS and MAPL.

### Dependencies

- [x] waiting on JCSDA/spack/pull/431

### Issue(s) addressed

Fixes #1083 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications. (Mac, several NOAA systems, see https://github.com/spack/spack/pull/43726 for details)
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
