### PR TITLE
Update KnownIssues.rst with solution for bad oneAPI `libirc.so`

### DIFF
--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -35,6 +35,10 @@ General
 
    This error usually indicates that the wrong module type is used in the ``spack module ... refresh`` command. For example, the system is configured for ``lmod``, but the command used is ``spack module tcl refresh``.
 
+8. Runtime segmentation faults for applications with ``intel@2021.10.0``: ``Relink `/opt/intel/oneapi/compiler/2024.0/lib/libirc.so' with `/lib/x86_64-linux-gnu/libc.so.6' for IFUNC symbol `memmove' - Segmentation fault (core dumped)``.
+
+   This problem is caused by a bad library in the Intel oneAPI installation. The solution is to fix the library using patchelf, which requires write access to the oneAPI installation: First, verify that ``ldd /opt/intel/oneapi/compiler/2024.0/lib/libirc.so`` says it is statically linked (it isn't). Then, run: ``patchelf --add-needed libc.so.6 /opt/intel/oneapi/compiler/2024.0/lib/libirc.so`` and your application should run rightaway (no need to recompile).
+
 ==============================
 MSU Hercules
 ==============================


### PR DESCRIPTION
### Summary

All in the title. This resolves https://github.com/JCSDA/spack-stack/issues/988

### Testing

Tested on MSU Hercules with oneAPI 2023.2.1

Rendering of the updated documentation: https://spack-stack--1108.org.readthedocs.build/en/1108/KnownIssues.html#general

### Applications affected

Potentially all (known: GEOSgcm)

### Systems affected

Potentially all (known: Discover SCU17, AWS ParallelCluster, Hercules)

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/988

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
