### PR TITLE
Add gcc stack for Nautilus

### DIFF
--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -35,3 +35,18 @@ compilers:
         CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
         LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
     extra_rpaths: []
+- compiler:
+    spec: gcc@12.2.1
+    paths:
+      cc: /opt/rh/gcc-toolset-12/root/usr/bin/gcc
+      cxx: /opt/rh/gcc-toolset-12/root/usr/bin/g++
+      f77: /opt/rh/gcc-toolset-12/root/usr/bin/gfortran
+      fc: /opt/rh/gcc-toolset-12/root/usr/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - scl/gcc-toolset-12
+    environment: {}
+    extra_rpaths: []
+

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -34,7 +34,6 @@ packages:
       modules:
       - penguin/openmpi/4.1.4/aocc
       - slurm
-    #- spec: openmpi@5.0.1%gcc@12.2.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
     - spec: openmpi@5.0.1%gcc@12.2.1~cuda~java~memchecker~static~wrapper-rpath fabrics=ucx schedulers=slurm
       prefix: /p/app/penguin/openmpi/5.0.1/gcc-8.5.0
       modules:

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -34,6 +34,12 @@ packages:
       modules:
       - penguin/openmpi/4.1.4/aocc
       - slurm
+    #- spec: openmpi@5.0.1%gcc@12.2.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+    - spec: openmpi@5.0.1%gcc@12.2.1~cuda~java~memchecker~static~wrapper-rpath fabrics=ucx schedulers=slurm
+      prefix: /p/app/penguin/openmpi/5.0.1/gcc-8.5.0
+      modules:
+      - penguin/openmpi/5.0.1/gcc-8.5.0
+      - slurm
   intel-oneapi-mkl:
     externals:
     - spec: intel-oneapi-mkl@2022.0.2

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -1,10 +1,8 @@
 packages:
   all:
-    compiler:: [intel@2021.5.0, aocc@4.0.0]
+    compiler:: [intel@2021.5.0, aocc@4.0.0, gcc@12.2.1]
     providers:
-      # For now need to enable one or the other;
-      # see https://github.com/JCSDA/spack-stack/issues/659
-      mpi:: [openmpi@4.1.6]
+      mpi:: [openmpi@4.1.6, openmpi@5.0.1]
       blas:: [intel-oneapi-mkl]
       fftw-api:: [intel-oneapi-mkl]
       lapack:: [intel-oneapi-mkl]


### PR DESCRIPTION
### Summary

This PR adds a gcc stack config for Nautilus (`gcc@12.2.1` + `openmpi@5.0.1`).

### Testing

- [x] Build unified-dev environment on Nautilus with this compiler/OpenMPI combination
- [x]  Build jedi-bundle with all options turned on and run ctest - all passed:
```
100% tests passed, 0 tests failed out of 2571

Label Time Summary:
CRTM_Tests            = 310.61 sec*proc (162 tests)
GEOS                  =  12.03 sec*proc (3 tests)
HofX                  =  30.17 sec*proc (10 tests)
QC                    =  63.53 sec*proc (16 tests)
UV                    =   7.97 sec*proc (2 tests)
actions               =  16.16 sec*proc (4 tests)
aircraft              =  11.61 sec*proc (3 tests)
compo                 =   6.38 sec*proc (2 tests)
coupling              =  39.99 sec*proc (9 tests)
crtm                  = 250.20 sec*proc (57 tests)
errors                =  27.57 sec*proc (8 tests)
executable            = 596.98 sec*proc (239 tests)
femps                 =   9.48 sec*proc (1 test)
filters               = 715.05 sec*proc (187 tests)
fortran               =   8.03 sec*proc (3 tests)
fov                   =   8.73 sec*proc (3 tests)
fv3-jedi              = 706.42 sec*proc (127 tests)
fv3jedi               = 714.20 sec*proc (128 tests)
gnssro                =   4.01 sec*proc (1 test)
gsw                   =  13.33 sec*proc (6 tests)
instrument            = 100.08 sec*proc (28 tests)
ioda                  = 639.88 sec*proc (364 tests)
iodaconv              = 864.74 sec*proc (333 tests)
iodaconv_validate     = 230.96 sec*proc (174 tests)
metoffice             =   5.85 sec*proc (2 tests)
mpasjedi              = 422.25 sec*proc (54 tests)
mpi                   = 4545.84 sec*proc (1039 tests)
obsfunctions          = 276.14 sec*proc (83 tests)
oops                  = 718.71 sec*proc (305 tests)
openmp                = 1103.45 sec*proc (323 tests)
operators             = 573.41 sec*proc (153 tests)
ozone                 =   3.88 sec*proc (2 tests)
pibal                 =   3.92 sec*proc (1 test)
predictors            =  72.15 sec*proc (22 tests)
profile               = 148.47 sec*proc (41 tests)
radarVAD              =   7.00 sec*proc (2 tests)
rass                  =   6.81 sec*proc (2 tests)
saber                 = 1025.90 sec*proc (274 tests)
satwinds              =  11.21 sec*proc (3 tests)
scatwinds             =  10.77 sec*proc (3 tests)
script                = 6361.34 sec*proc (2061 tests)
sfcLand               =  12.13 sec*proc (3 tests)
sfcMarine             =  11.06 sec*proc (3 tests)
soca                  = 286.20 sec*proc (57 tests)
sonde                 =  11.30 sec*proc (3 tests)
ufo                   = 1879.93 sec*proc (507 tests)
ufo_data              = 431.71 sec*proc (328 tests)
ufo_data_validate     = 431.71 sec*proc (328 tests)
unit_tests            = 339.38 sec*proc (94 tests)
utils                 =   5.74 sec*proc (2 tests)
vader                 =  76.12 sec*proc (47 tests)
variablenamemap       =   2.92 sec*proc (1 test)
variabletransforms    = 110.02 sec*proc (28 tests)

Total Test time (real) = 7427.58 sec
```

### Applications affected

n/a

### Systems affected

No existing system/config affected

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1110

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
