### PR TITLE
fix a couple bugs in util/check_package_config.py

### DIFF
--- a/util/check_package_config.py
+++ b/util/check_package_config.py
@@ -34,8 +34,9 @@ with open(packages_versions_path, "r") as f:
     packages_versions = yaml.safe_load(f)
 
 packages_externals_path = os.path.join(SPACK_ENV, "site", "packages.yaml")
-with open(packages_externals_path, "r") as f:
-    packages_externals = yaml.safe_load(f)
+if os.path.isdir(packages_externals_path):
+    with open(packages_externals_path, "r") as f:
+        packages_externals = yaml.safe_load(f)
 
 # Load spack.lock
 spack_lock_path = os.path.join(SPACK_ENV, "spack.lock")
@@ -72,13 +73,13 @@ for concrete_spec in spack_lock["concrete_specs"].values():
                 )
         # Check whether concretized variants match settings from common/packages.yaml
         if "variants" in packages_versions["packages"][concrete_name].keys():
-            config_variants = packages_versions["packages"][concrete_name]["variants"].split()
+            config_variants = packages_versions["packages"][concrete_name]["variants"].replace("+"," +").replace("~"," ~").split()
             for config_variant in config_variants:
                 variant_mismatch = False
                 # Boolean variant
                 if config_variant[0] in ("+", "~"):
                     config_value = config_variant[0] == "+"
-                    if not 'config_variant[1:]' in concrete_spec["parameters"].keys():
+                    if not config_variant[1:] in concrete_spec["parameters"].keys():
                         variant_mismatch = True
                     elif concrete_spec["parameters"][config_variant[1:]] != config_value:
                         variant_mismatch = True
@@ -99,16 +100,17 @@ for concrete_spec in spack_lock["concrete_specs"].values():
                         f"WARNING: '{concrete_name}' concretized variant '{config_variant}' does not match configured value in $SPACK_ENV/common/packages.yaml"
                     )
     # Check whether concretized package is an external based on site/packages.yaml
-    if concrete_name in packages_externals["packages"].keys():
-        is_external_config = "externals" in packages_externals["packages"][concrete_name].keys()
-    else:
-        is_external_config = False
-    is_external_concrete = "external" in concrete_spec.keys()
-    if is_external_config != is_external_concrete:
-        iret = 1
-        print(
-            f"WARNING: '{concrete_name}' is %sconfigured as external in $SPACK_ENV/site/packages.yaml but was %sconcretized as external"
-            % ((not is_external_config) * "not ", (not is_external_concrete) * "not ")
-        )
+    if os.path.isdir(packages_externals_path):
+        if concrete_name in packages_externals["packages"].keys():
+            is_external_config = "externals" in packages_externals["packages"][concrete_name].keys()
+        else:
+            is_external_config = False
+        is_external_concrete = "external" in concrete_spec.keys()
+        if is_external_config != is_external_concrete:
+            iret = 1
+            print(
+                f"WARNING: '{concrete_name}' is %sconfigured as external in $SPACK_ENV/site/packages.yaml but was %sconcretized as external"
+                % ((not is_external_config) * "not ", (not is_external_concrete) * "not ")
+            )
 
 sys.exit(iret)

--- a/util/check_package_config.py
+++ b/util/check_package_config.py
@@ -34,7 +34,7 @@ with open(packages_versions_path, "r") as f:
     packages_versions = yaml.safe_load(f)
 
 packages_externals_path = os.path.join(SPACK_ENV, "site", "packages.yaml")
-if os.path.isdir(packages_externals_path):
+if os.path.isfile(packages_externals_path):
     with open(packages_externals_path, "r") as f:
         packages_externals = yaml.safe_load(f)
 
@@ -100,7 +100,7 @@ for concrete_spec in spack_lock["concrete_specs"].values():
                         f"WARNING: '{concrete_name}' concretized variant '{config_variant}' does not match configured value in $SPACK_ENV/common/packages.yaml"
                     )
     # Check whether concretized package is an external based on site/packages.yaml
-    if os.path.isdir(packages_externals_path):
+    if os.path.isfile(packages_externals_path):
         if concrete_name in packages_externals["packages"].keys():
             is_external_config = "externals" in packages_externals["packages"][concrete_name].keys()
         else:


### PR DESCRIPTION
### Summary

This PR fixes a couple bugs in util/check_package_config.py. Right now it's flagging false positives, borks when site/packages.yaml doesn't exist (like if using site={macos,linux}.default), and can't handle non-space delimited variants in packages.yaml. This can be merged after #1109.

### Testing

Tested on personal machine.

### Applications affected

none

### Systems affected

all

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
