### PR TITLE
Backporting to release/1.7.0: add esmf tags 8.6.1b04, 8.6.1, 8.7.0b04

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-1.7.0
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_esmf_tags_to_rel_170
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-1.7.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-1.7.0
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-1.7.0
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_esmf_tags_to_rel_170
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -141,6 +141,8 @@ modules:
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
           ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
           ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.6.1~debug snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
           ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -139,6 +139,10 @@ modules:
           ^esmf@8.5.0+debug snapshot=none: 'esmf-8.5.0-debug'
           ^esmf@8.6.0~debug snapshot=none: 'esmf-8.6.0'
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
+          ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
+          ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
+          ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -143,6 +143,8 @@ modules:
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
           ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
           ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.6.1~debug snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
           ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -141,6 +141,10 @@ modules:
           ^esmf@8.5.0+debug snapshot=none: 'esmf-8.5.0-debug'
           ^esmf@8.6.0~debug snapshot=none: 'esmf-8.6.0'
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
+          ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
+          ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
+          ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -60,6 +60,10 @@
     esmf:
       version: ['8.6.0']
       variants: ~xerces ~pnetcdf snapshot=none +shared +external-parallelio
+      #version: ['8.6.1b04']
+      #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
+      #version: ['8.7.0b04']
+      #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
       require:
         - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"


### PR DESCRIPTION
### Summary

This PR makes the necessary changes to release/1.7.0 in `configs/common/modules*.yaml` for adding esmf tags 8.6.1b04, 8.6.1, 8.7.0b04 - see PR https://github.com/JCSDA/spack/pull/433

### Testing

- Locally on @climbfuji's macOS
- On Nautilus and Narwhal

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

- [x]  waiting on https://github.com/JCSDA/spack/pull/433

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1117.

(in order to close the issue, we need to also add those commits to spack-stack develop)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
