### PR TITLE
Add esmf@8.6.1 to develop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,8 @@
   path = spack
   url = https://github.com/jcsda/spack
   branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_esmf861_spack_stack_dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,6 @@
   path = spack
   url = https://github.com/jcsda/spack
   branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_esmf861_spack_stack_dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -140,6 +140,8 @@ modules:
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
           ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
           ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.6.1~debug snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
           ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -142,6 +142,8 @@ modules:
           ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
           ^esmf@8.6.1b04~debug snapshot=b04: 'esmf-8.6.1b04'
           ^esmf@8.6.1b04+debug snapshot=b04: 'esmf-8.6.1b04-debug'
+          ^esmf@8.6.1~debug snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
           ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
       openmpi:


### PR DESCRIPTION
### Summary

This PR is the same as https://github.com/JCSDA/spack-stack/pull/1118, but for develop / spack-stack-dev

### Testing

Verified checksum and ran install of esmf@8.6.1 on macOS.

### Applications affected

None unless the default ESMF version is changed

### Systems affected

None unless the default ESMF version is changed

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/434

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
