### PR TITLE
Bug fix after merging spack-stack PR 1109 before spack submodule PR https://github.com/JCSDA/spack/pull/432

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/merge_spack_develop_into_spack_stack_dev_20240509
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

@AlexanderRichert-NOAA I made the beginner's mistake and merged #1109 before https://github.com/JCSDA/spack/pull/432. This PR fixes it. Can you check and approve if ok, please?
