### PR TITLE
Add gaea c6 config

### DIFF
--- a/configs/sites/gaea-c6/compilers.yaml
+++ b/configs/sites/gaea-c6/compilers.yaml
@@ -18,7 +18,7 @@ compilers:
       fflags: "-gcc-name=/usr/bin/gcc-12"
     environment:
       set:
-        # OpenSUSE on Gaea C5 sets CONFIG_SITE so
+        # OpenSUSE on Gaea C6 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
         # which confuses some packages.
         CONFIG_SITE: ''

--- a/configs/sites/gaea-c6/compilers.yaml
+++ b/configs/sites/gaea-c6/compilers.yaml
@@ -1,0 +1,25 @@
+compilers:
+- compiler:
+    spec: intel@2023.2.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-intel/8.5.0
+    - intel-classic/2023.2.0
+    - craype/2.7.30
+    - libfabric/1.20.1
+    flags:
+      cflags: "-gcc-name=/usr/bin/gcc-12"
+      cxxflags: "-gxx-name=/usr/bin/g++-12 -gcc-name=/usr/bin/gcc-12 -static-libstdc++"
+      fflags: "-gcc-name=/usr/bin/gcc-12"
+    environment:
+      set:
+        # OpenSUSE on Gaea C5 sets CONFIG_SITE so
+        # Automake-based builds are installed in lib64
+        # which confuses some packages.
+        CONFIG_SITE: ''
+    extra_rpaths: []

--- a/configs/sites/gaea-c6/config.yaml
+++ b/configs/sites/gaea-c6/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 6

--- a/configs/sites/gaea-c6/mirrors.yaml
+++ b/configs/sites/gaea-c6/mirrors.yaml
@@ -1,0 +1,18 @@
+mirrors:
+  local-source:
+    fetch:
+      url: file:///lustre/f2/dev/wpo/role.epic/contrib/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null
+    push:
+      url: file:///lustre/f2/dev/wpo/role.epic/contrib/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null

--- a/configs/sites/gaea-c6/modules.yaml
+++ b/configs/sites/gaea-c6/modules.yaml
@@ -1,0 +1,7 @@
+modules:
+  default:
+    enable::
+    - lmod
+    lmod:
+      include:
+      - python

--- a/configs/sites/gaea-c6/packages.yaml
+++ b/configs/sites/gaea-c6/packages.yaml
@@ -1,0 +1,206 @@
+packages:
+  all:
+    compiler:: [intel@2023.2.0]
+    providers:
+      mpi:: [cray-mpich@8.1.29]
+
+### MPI
+  cray-mpich:
+    externals:
+    - spec: cray-mpich@8.1.29%intel@2023.2.0~wrappers
+      modules:
+      - craype-network-ofi
+      - cray-mpich/8.1.29
+
+### All other external packages listed alphabetically
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.15.1
+      prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.23
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.41
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.32
+      prefix: /usr
+  cpio:
+    externals:
+    - spec: cpio@2.13
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  dos2unix:
+    externals:
+    - spec: dos2unix@7.4.0
+      prefix: /usr
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.8.4+ui+static_boost
+      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/ecflow-5.8.4
+  file:
+    externals:
+    - spec: file@5.32
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.8.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.4+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.20.2
+      prefix: /usr
+  ghostscript:
+    externals:
+    - spec: ghostscript@9.52
+      prefix: /usr
+  git:
+    buildable: false
+    externals:
+    - spec: git@2.42.0
+      modules: [git/2.42.0]
+  git-lfs:
+    buildable: false
+    externals:
+    - spec: git-lfs@2.11.0
+      modules: [git-lfs/2.11.0]
+  gmake:
+    externals:
+    - spec: gmake@4.2.1
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.4
+      prefix: /usr
+  hwloc:
+    externals:
+    - spec: hwloc@2.9.0
+      prefix: /usr
+  # This package is currently incomplete (no headers), but still works
+  krb5:
+    externals:
+    - spec: krb5@1.20.1
+      #prefix: /usr/lib/mit
+      prefix: /usr
+  libfuse:
+    externals:
+    - spec: libfuse@2.9.7
+      prefix: /usr
+    - spec: libfuse@3.10.5
+      prefix: /usr
+  libtirpc:
+    variants: ~gssapi
+  # This package is currently incomplete (no headers), but still works
+  libxaw:
+    externals:
+    - spec: libxaw@1.10.13
+      prefix: /usr
+  libxml2:
+    externals:
+    - spec: libxml2@2.10.3
+      prefix: /usr
+  # This package is currently incomplete (no headers) and doesn't work
+  # for us. But it's only needed to build libxaw, for which we can use
+  # the existing (incomplete) installation in /usr, see above
+  #libxpm:
+  #  externals:
+  #  - spec: libxpm@4.11.0
+  #    prefix: /usr
+  lustre:
+    externals:
+    - spec: lustre@2.15.0.2_rc2_cray_113_g62287d0
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  mysql:
+    buildable: False
+    externals:
+    - spec: mysql@8.0.36
+      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/mysql-8.0.36
+  ncurses:
+    externals:
+    - spec: ncurses@6.1.20180317+termlib abi=6
+      prefix: /usr
+  openjdk:
+    externals:
+    - spec: openjdk@11.0.22
+      prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.26.1~cpanm+shared+threads
+      prefix: /usr
+  pkg-config:
+    buildable: false
+    externals:
+    - spec: pkg-config@0.29.2
+      prefix: /usr
+  qt:
+    externals:
+    - spec: qt@5.15.2
+      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
+  rdma-core:
+    externals:
+    - spec: rdma-core@42.0
+      prefix: /usr
+  rsync:
+    externals:
+    - spec: rsync@3.2.3
+      prefix: /usr
+  ruby:
+    externals:
+    - spec: ruby@2.5.9
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.4
+      prefix: /usr
+  slurm:
+    externals:
+    - spec: slurm@24.05.0
+      prefix: /usr
+  subversion:
+    externals:
+    - spec: subversion@1.14.1
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.34
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.20.3
+      prefix: /usr
+  which:
+    externals:
+    - spec: which@2.21
+      prefix: /usr
+  xz:
+    externals:
+    - spec: xz@5.2.3
+      prefix: /usr
+  zip:
+    externals:
+    - spec: zip@3.0
+      prefix: /usr


### PR DESCRIPTION
### Summary

Adding a gaea-c6 site config.

Note the interesting compiler flags. We want the Intel compilers to be aware of a recent-ish version of GCC for the usual reasons. On C6, GCC 12 and 13 are installed as 'gcc-12' 'gcc-13 'gfortran-12' etc., and using `-gcc-name` and `-gxx-name` appear to be the preferred ways of pointing to non-standard GCC executable names. That said, when I do that, ecmwf-atlas won't compile unless I also add `-static-libstdc++`, so I've added that. The alternatives would be to install our own GCC (my least favorite option), try a different version (not clear that this would work, like if we had the admins install GCC 11), or create aliases for the compilers so they use the regular names, then add that path to $PATH. For the last option, it would avoid the need for the `-static-libstdc++` flag, but it's kind of an ugly solution.

### Testing

Tested building 1.6.0 unified env, as well as concretizing and installing some packages based on develop.

### Applications affected

all

### Systems affected

gaea-c6

### Dependencies

none

### Issue(s) addressed

Related to #1130

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
