### PR TITLE
Update NewSiteConfigs.rst for macOS: exclude homebrew gettext

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -225,7 +225,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
    spack external find --scope system \
        --exclude bison --exclude openssl \
-       --exclude python
+       --exclude python --exclude gettext
    spack external find --scope system libiconv
    spack external find --scope system perl
    spack external find --scope system wget


### PR DESCRIPTION
### Summary

`gettext` builds easily on macOS, and finding it without specifying the path means that many homebrew packages find their way into the default built environment (because `/usr/local/bin` etc. get added to the build environment whenever `gettext` is needed).

### Testing

Locally on Dom's Intel macOS.

### Applications affected

n/a

### Systems affected

macOS user systems

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
