### PR TITLE
Update Nautilus site config and common packages/modules to support oneAPI compilers (icx, icpx, ifort)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/oneapi_support_neptune_env
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/oneapi_support_neptune_env
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -31,6 +31,7 @@ modules:
       - fixesproto
       - flex
       - freetype
+      - gcc-runtime
       - gdbm
       - googletest
       - hwloc

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -33,6 +33,7 @@ modules:
       - fixesproto
       - flex
       - freetype
+      - gcc-runtime
       - gdbm
       - googletest
       - hwloc

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -117,6 +117,8 @@
       variants: +external-xdr ~fortran ~netcdf
     hdf5:
       require: '@1.14.3 +hl +fortran +mpi +threadsafe ~szip'
+      # How to fix the annoying concretization errors (add %oneapi?)
+      #require: '@1.14.3%oneapi +hl +fortran +mpi +threadsafe ~szip'
     # Newer versions of hdf-eos2 require manual downloading, avoid
     hdf-eos2:
       require: "@2.20v1.00"

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -117,8 +117,6 @@
       variants: +external-xdr ~fortran ~netcdf
     hdf5:
       require: '@1.14.3 +hl +fortran +mpi +threadsafe ~szip'
-      # How to fix the annoying concretization errors (add %oneapi?)
-      #require: '@1.14.3%oneapi +hl +fortran +mpi +threadsafe ~szip'
     # Newer versions of hdf-eos2 require manual downloading, avoid
     hdf-eos2:
       require: "@2.20v1.00"

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -138,6 +138,9 @@
       variants: +pic
     libyaml:
       version: ['0.2.5']
+    # Newest version of magics needed for oneapi compilers
+    magics:
+      require: "@4.15.3:"
     mapl:
       version: ['2.40.3']
       variants: +shared +pflogger ~f2py

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -49,4 +49,23 @@ compilers:
     - scl/gcc-toolset-12
     environment: {}
     extra_rpaths: []
-
+- compiler:
+    spec: oneapi@2024.1.0
+    paths:
+      cc: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/icx
+      cxx: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/icpx
+      f77: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/ifort
+      fc: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/ifort
+    flags:
+      fflags: -diag-disable=10448
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - intel/compiler/2024.1.0
+    environment:
+      prepend_path:
+        #PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
+        #CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
+        #LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
+        LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm'
+    extra_rpaths: []

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -50,24 +50,22 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: oneapi@2024.1.0
+    spec: oneapi@2024.1.2
     paths:
-      cc: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/icx
-      cxx: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/icpx
-      f77: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/ifort
-      fc: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/ifort
+      cc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2/compiler/2024.1/bin/icx
+      cxx: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2/compiler/2024.1/bin/icpx
+      f77: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2/compiler/2024.1/bin/ifort
+      fc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2/compiler/2024.1/bin/ifort
     flags:
       fflags: -diag-disable=10448
     operating_system: rhel8
     target: x86_64
     modules: []
-    #- intel/compiler/2024.1.0
     environment:
       prepend_path:
         PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
         CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
-        #LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
         LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
       append_path:
-        CPATH: '/p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/opt/compiler/include/intel64'
+        CPATH: '/p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2/compiler/2024.1/opt/compiler/include/intel64'
     extra_rpaths: []

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -52,20 +52,22 @@ compilers:
 - compiler:
     spec: oneapi@2024.1.0
     paths:
-      cc: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/icx
-      cxx: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/icpx
-      f77: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/ifort
-      fc: /p/app/compilers/intel/oneapi-2024.1.0/compiler/2024.1/bin/ifort
+      cc: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/icx
+      cxx: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/icpx
+      f77: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/ifort
+      fc: /p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/bin/ifort
     flags:
       fflags: -diag-disable=10448
     operating_system: rhel8
     target: x86_64
-    modules:
-    - intel/compiler/2024.1.0
+    modules: []
+    #- intel/compiler/2024.1.0
     environment:
       prepend_path:
         PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
         CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
         #LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
         LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
+      append_path:
+        CPATH: '/p/work1/heinzell/oneapi_20240603/oneapi_2024.1.2-new/compiler/2024.1/opt/compiler/include/intel64'
     extra_rpaths: []

--- a/configs/sites/nautilus/compilers.yaml
+++ b/configs/sites/nautilus/compilers.yaml
@@ -64,8 +64,8 @@ compilers:
     - intel/compiler/2024.1.0
     environment:
       prepend_path:
-        #PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
-        #CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
+        PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
+        CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
         #LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
-        LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm'
+        LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
     extra_rpaths: []

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -127,10 +127,11 @@ packages:
       prefix: /p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31
       modules:
       - mysql/8.0.31
-  perl:
-    externals:
-    - spec: perl@5.26.3~cpanm+open+shared+threads
-      prefix: /usr
+  # Needed to remove for xnrl w/intel, hopefully ok with oneapi
+  #perl:
+  #  externals:
+  #  - spec: perl@5.26.3~cpanm+open+shared+threads
+  #    prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.4.2

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -1,8 +1,8 @@
 packages:
   all:
-    compiler:: [intel@2021.5.0, aocc@4.0.0, gcc@12.2.1]
+    compiler:: [intel@2021.5.0, aocc@4.0.0, gcc@12.2.1, oneapi@2024.1.0]
     providers:
-      mpi:: [openmpi@4.1.6, openmpi@5.0.1]
+      mpi:: [openmpi@4.1.6, openmpi@5.0.1, intel-oneapi-mpi@2021.12]
       blas:: [intel-oneapi-mkl]
       fftw-api:: [intel-oneapi-mkl]
       lapack:: [intel-oneapi-mkl]
@@ -14,12 +14,12 @@ packages:
 ### MPI, Python, MKL
   mpi:
     buildable: False
-  #intel-oneapi-mpi:
-  #  externals:
-  #  - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
-  #    modules:
-  #    - intel/mpi/2021.5.1
-  #    prefix: /p/app/compilers/intel/oneapi
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.12%oneapi@2024.1.0
+      modules:
+      - intel/oneapi-2024.1.0-mpi
+      #prefix: /p/app/compilers/intel/oneapi-2024.1.0
   openmpi:
     externals:
     - spec: openmpi@4.1.6%intel@2021.5.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
@@ -39,10 +39,18 @@ packages:
       - slurm
   intel-oneapi-mkl:
     externals:
-    - spec: intel-oneapi-mkl@2022.0.2
+    - spec: intel-oneapi-mkl@2022.0.2%intel@2021.5.0
       prefix: /p/app/compilers/intel/oneapi
       modules:
       - intel-oneapi-mkl@2022.0.2
+    - spec: intel-oneapi-mkl@2022.0.2%gcc@12.2.1
+      prefix: /p/app/compilers/intel/oneapi
+      modules:
+      - intel-oneapi-mkl@2022.0.2
+    - spec: intel-oneapi-mkl@2024.1.0%oneapi@2024.1.0
+      #prefix: /p/app/compilers/intel/oneapi-2024.1.0
+      modules:
+      - intel/oneapi-2024.1.0-mkl
 
 ### Modifications of common packages
   # Version 2.0.8 doesn't compile on Nautilus

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [intel@2021.5.0, aocc@4.0.0, gcc@12.2.1, oneapi@2024.1.0]
+    compiler:: [intel@2021.5.0, aocc@4.0.0, gcc@12.2.1, oneapi@2024.1.2]
     providers:
       mpi:: [openmpi@4.1.6, openmpi@5.0.1, intel-oneapi-mpi@2021.12]
       blas:: [intel-oneapi-mkl]
@@ -14,12 +14,6 @@ packages:
 ### MPI, Python, MKL
   mpi:
     buildable: False
-  intel-oneapi-mpi:
-    externals:
-    - spec: intel-oneapi-mpi@2021.12%oneapi@2024.1.0
-      #modules:
-      #- intel/oneapi-2024.1.0-mpi
-      prefix: /p/app/compilers/intel/oneapi-2024.1.0
   openmpi:
     externals:
     - spec: openmpi@4.1.6%intel@2021.5.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
@@ -37,6 +31,10 @@ packages:
       modules:
       - penguin/openmpi/5.0.1/gcc-8.5.0
       - slurm
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.12%oneapi@2024.1.2
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2
   intel-oneapi-mkl:
     externals:
     - spec: intel-oneapi-mkl@2022.0.2%intel@2021.5.0
@@ -47,14 +45,12 @@ packages:
       prefix: /p/app/compilers/intel/oneapi
       modules:
       - intel-oneapi-mkl@2022.0.2
-    - spec: intel-oneapi-mkl@2024.1%oneapi@2024.1.0
-      prefix: /p/app/compilers/intel/oneapi-2024.1.0
-      #modules:
-      #- intel/oneapi-2024.1.0-mkl
+    - spec: intel-oneapi-mkl@2024.1%oneapi@2024.1.2
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2
   intel-oneapi-runtime:
     externals:
-    - spec: intel-oneapi-runtime@2024.1.0%oneapi@2024.1.0
-      prefix: /p/app/compilers/intel/oneapi-2024.1.0
+    - spec: intel-oneapi-runtime@2024.1.2%oneapi@2024.1.2
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2
 
 ### Modifications of common packages
   # Version 2.0.8 doesn't compile on Nautilus

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -70,7 +70,6 @@ packages:
     externals:
     - spec: binutils@2.30.117
       prefix: /usr
-  # Needed for oneAPI, hopefully also works with other compilers
   bison:
     externals:
     - spec: bison@3.0.4

--- a/configs/sites/nautilus/packages.yaml
+++ b/configs/sites/nautilus/packages.yaml
@@ -17,9 +17,9 @@ packages:
   intel-oneapi-mpi:
     externals:
     - spec: intel-oneapi-mpi@2021.12%oneapi@2024.1.0
-      modules:
-      - intel/oneapi-2024.1.0-mpi
-      #prefix: /p/app/compilers/intel/oneapi-2024.1.0
+      #modules:
+      #- intel/oneapi-2024.1.0-mpi
+      prefix: /p/app/compilers/intel/oneapi-2024.1.0
   openmpi:
     externals:
     - spec: openmpi@4.1.6%intel@2021.5.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
@@ -47,10 +47,14 @@ packages:
       prefix: /p/app/compilers/intel/oneapi
       modules:
       - intel-oneapi-mkl@2022.0.2
-    - spec: intel-oneapi-mkl@2024.1.0%oneapi@2024.1.0
-      #prefix: /p/app/compilers/intel/oneapi-2024.1.0
-      modules:
-      - intel/oneapi-2024.1.0-mkl
+    - spec: intel-oneapi-mkl@2024.1%oneapi@2024.1.0
+      prefix: /p/app/compilers/intel/oneapi-2024.1.0
+      #modules:
+      #- intel/oneapi-2024.1.0-mkl
+  intel-oneapi-runtime:
+    externals:
+    - spec: intel-oneapi-runtime@2024.1.0%oneapi@2024.1.0
+      prefix: /p/app/compilers/intel/oneapi-2024.1.0
 
 ### Modifications of common packages
   # Version 2.0.8 doesn't compile on Nautilus
@@ -69,6 +73,11 @@ packages:
   binutils:
     externals:
     - spec: binutils@2.30.117
+      prefix: /usr
+  # Needed for oneAPI, hopefully also works with other compilers
+  bison:
+    externals:
+    - spec: bison@3.0.4
       prefix: /usr
   coreutils:
     externals:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -6,7 +6,7 @@ spack:
   include: []
 
   definitions:
-  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
+  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
       - neptune-env ^esmf@8.7.0b04 snapshot=b04
 

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -13,9 +13,9 @@ It is also instructive to peruse the GitHub actions scripts in ``.github/workflo
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
 | Compiler                                  | Versions tested/in use in one or more site configs                   | Spack compiler identifier |
 +===========================================+======================================================================+===========================+
-| Intel classic (icc, icpc, ifort)          | 2021.3.0 to the latest available version in oneAPI 2023.2.3 [#fn1]_  | ``intel@``                |
+| Intel classic (icc, icpc, ifort)          | 2021.3.0 to the final version in oneAPI 2023.2.3 [#fn1]_             | ``intel@``                |
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
-| Intel mixed (icx, icpx, ifort)            | all versions up to latest available version in oneAPI 2023.1.0       | ``intel@``                |
+| Intel mixed (icx, icpx, ifort)            | 2024.1.2                                                             | ``oneapi@``               |
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
 | GNU (gcc, g++, gfortran)                  | 9.2.0 to 12.2.0 (note: 13.x.y is **not** yet supported)              | ``gcc@``                  |
 +-------------------------------------------+----------------------------------------------------------------------+---------------------------+
@@ -381,6 +381,7 @@ The following instructions were used to prepare a basic Red Hat 8 system as it i
    # Do *not* install MPI with yum, this will be done with spack-stack
 
    # Misc
+   yum -y install binutils-devel
    yum -y install m4
    yum -y install wget
    # Do not install cmake (it's 3.20.2, which doesn't work with eckit)
@@ -397,6 +398,8 @@ The following instructions were used to prepare a basic Red Hat 8 system as it i
    yum -y install gettext-devel
    yum -y install texlive
    # Do not install qt@5 for now
+   # Only if building with oneapi compilers instead of gcc, intel: install bison
+   yum -y install bison
 
    # Note - only needed for running JCSDA's
    # JEDI-Skylab system (using R2D2 localhost)
@@ -521,6 +524,8 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
        --exclude curl --exclude openssl \
        --exclude openssh --exclude python
    spack external find --scope system wget
+   # Only if building with oneapi compilers instead of gcc, intel: install bison
+   spack external find --scope system bison
 
    # Note - only needed for running JCSDA's
    # JEDI-Skylab system (using R2D2 localhost)

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -398,7 +398,6 @@ The following instructions were used to prepare a basic Red Hat 8 system as it i
    yum -y install gettext-devel
    yum -y install texlive
    # Do not install qt@5 for now
-   # Only if building with oneapi compilers instead of gcc, intel: install bison
    yum -y install bison
 
    # Note - only needed for running JCSDA's
@@ -465,6 +464,7 @@ The following instructions were used to prepare a basic Ubuntu 20.04 or 22.04 LT
    apt install -y libcurl4-openssl-dev
    apt install -y libssl-dev
    apt install -y meson
+   apt install -y bison
 
    # Note - only needed for running JCSDA's
    # JEDI-Skylab system (using R2D2 localhost)
@@ -520,12 +520,10 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 .. code-block:: console
 
    spack external find --scope system \
-       --exclude bison --exclude cmake \
+       --exclude cmake \
        --exclude curl --exclude openssl \
        --exclude openssh --exclude python
    spack external find --scope system wget
-   # Only if building with oneapi compilers instead of gcc, intel: install bison
-   spack external find --scope system bison
 
    # Note - only needed for running JCSDA's
    # JEDI-Skylab system (using R2D2 localhost)

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -626,13 +626,6 @@ def setup_meta_modules():
                             "  ... ... MODULEPREREQS: {}".format(substitutes["MODULEPREREQS"])
                         )
 
-                    # Don't think we need this!
-                    ## Compiler environment variables
-                    #substitutes["CC"] = compiler["compiler"]["paths"]["cc"]
-                    #substitutes["CXX"] = compiler["compiler"]["paths"]["cxx"]
-                    #substitutes["F77"] = compiler["compiler"]["paths"]["f77"]
-                    #substitutes["FC"] = compiler["compiler"]["paths"]["fc"]
-
                     # Compiler wrapper environment variables
                     if "intel" in mpi_name:
                         substitutes["MPICC"] = os.path.join("mpiicc")
@@ -644,7 +637,7 @@ def setup_meta_modules():
                         substitutes["MPICXX"] = os.path.join("mpic++")
                         substitutes["MPIF77"] = os.path.join("mpif77")
                         substitutes["MPIF90"] = os.path.join("mpif90")
-            
+
                     # Spack compiler module hierarchy
                     substitutes["MODULEPATH"] = os.path.join(
                         module_dir, mpi_name, mpi_version, compiler_name, compiler_version

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -626,11 +626,12 @@ def setup_meta_modules():
                             "  ... ... MODULEPREREQS: {}".format(substitutes["MODULEPREREQS"])
                         )
 
-                    # Compiler environment variables
-                    substitutes["CC"] = compiler["compiler"]["paths"]["cc"]
-                    substitutes["CXX"] = compiler["compiler"]["paths"]["cxx"]
-                    substitutes["F77"] = compiler["compiler"]["paths"]["f77"]
-                    substitutes["FC"] = compiler["compiler"]["paths"]["fc"]
+                    # Don't think we need this!
+                    ## Compiler environment variables
+                    #substitutes["CC"] = compiler["compiler"]["paths"]["cc"]
+                    #substitutes["CXX"] = compiler["compiler"]["paths"]["cxx"]
+                    #substitutes["F77"] = compiler["compiler"]["paths"]["f77"]
+                    #substitutes["FC"] = compiler["compiler"]["paths"]["fc"]
 
                     # Compiler wrapper environment variables
                     if "intel" in mpi_name:

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi
@@ -27,6 +27,13 @@ setenv {MPI_CXX} {@MPICXX@}
 setenv {MPI_F77} {@MPIF77@}
 setenv {MPI_F90} {@MPIF90@}
 
+# intel specific mpi wrapper environment variables
+setenv {I_MPI_CC}  {@CC@}
+setenv {I_MPI_CXX} {@CXX@}
+setenv {I_MPI_F77} {@F77@}
+setenv {I_MPI_F90} {@FC@}
+setenv {I_MPI_FC}  {@FC@}
+
 # compiler flags and other environment variables
 @COMPFLAGS@
 @ENVVARS@

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi
@@ -28,11 +28,11 @@ setenv {MPI_F77} {@MPIF77@}
 setenv {MPI_F90} {@MPIF90@}
 
 # intel specific mpi wrapper environment variables
-setenv {I_MPI_CC}  {@CC@}
-setenv {I_MPI_CXX} {@CXX@}
-setenv {I_MPI_F77} {@F77@}
-setenv {I_MPI_F90} {@FC@}
-setenv {I_MPI_FC}  {@FC@}
+setenv {I_MPI_CC}  $env(CC)
+setenv {I_MPI_CXX} $env(CXX)
+setenv {I_MPI_F77} $env(F77)
+setenv {I_MPI_F90} $env(FC)
+setenv {I_MPI_FC}  $env(FC)
 
 # compiler flags and other environment variables
 @COMPFLAGS@

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
@@ -31,6 +31,13 @@ setenv("MPI_CXX", "@MPICXX@")
 setenv("MPI_F77", "@MPIF77@")
 setenv("MPI_F90", "@MPIF90@")
 
+-- intel specific mpi wrapper environment variables
+setenv("I_MPI_CC",  "@CC@")
+setenv("I_MPI_CXX", "@CXX@")
+setenv("I_MPI_F77", "@F77@")
+setenv("I_MPI_F90", "@FC@")
+setenv("I_MPI_FC",  "@FC@")
+
 -- compiler flags and other environment variables
 @COMPFLAGS@
 @ENVVARS@

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
@@ -32,11 +32,11 @@ setenv("MPI_F77", "@MPIF77@")
 setenv("MPI_F90", "@MPIF90@")
 
 -- intel specific mpi wrapper environment variables
-setenv("I_MPI_CC",  "@CC@")
-setenv("I_MPI_CXX", "@CXX@")
-setenv("I_MPI_F77", "@F77@")
-setenv("I_MPI_F90", "@FC@")
-setenv("I_MPI_FC",  "@FC@")
+setenv("I_MPI_CC",  os.getenv("CC"))
+setenv("I_MPI_CXX", os.getenv("CXX"))
+setenv("I_MPI_F77", os.getenv("F77"))
+setenv("I_MPI_F90", os.getenv("FC"))
+setenv("I_MPI_FC",  os.getenv("FC"))
 
 -- compiler flags and other environment variables
 @COMPFLAGS@


### PR DESCRIPTION
### Summary

This PR adds a `oneapi@2024.1.2` option to the nautilus site config. This option currently uses `intel-oneapi-mpi` instead of `openmpi` as MPI provider. If in-depth testing over the next weeks shows that this doesn't perform on Nautilus, we can change it.

The PR further adds the missing `append-path` logic to the `stack-*` meta modules, sets the `I_MPI_*` environment variables in the MPI meta modules (it doesn't hurt if those are always set, other MPI providers ignore them), and updates the documentation for supported compilers.

### Testing

- Built `neptune-env` on Nautilus with `oneapi@2024.1.2` (a heavily patched version, because Intel did a pretty poor job on the 2024.1.0 oneAPI release), ran `neptune_atmos` CI tests - all tests that are exercised in github actions pass. See https://github.nrlmry.navy.mil/NEPTUNE/neptune_atmos/actions/runs/54471 if you have access.

### Applications affected

None

### Systems affected

Nautilus

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/438

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1128

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
