### PR TITLE
Update to esmf@8.6.1 and mapl@2.46.2

### DIFF
--- a/.github/workflows/ubuntu-ci-containers-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-containers-x86_64.yaml
@@ -71,10 +71,6 @@ jobs:
           spack stack create ctr --container ${CONTAINER} --specs ${SPECS}
 
           cd ${ENVDIR}
-          # mapl@:2.41 doesn't build with mpich@4 - https://github.com/JCSDA/spack-stack/issues/608
-          if [[ "${CONTAINER}" == *"mpich"* ]]; then
-              sed -i 's/- mapl@/#- mapl@/g' spack.yaml
-          fi
           spack containerize > Dockerfile
           docker build -t ${CONTAINER}-${SPECS} .
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_mapl_from_spack_dev_20240613
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_mapl_from_spack_dev_20240613
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -59,18 +59,21 @@
     # config and update the projections for lmod/tcl.
     # Also, check the acorn and derecho site configs which have esmf modifications.
     esmf:
-      version: ['8.6.1']
-      variants: ~xerces ~pnetcdf snapshot=none +shared +external-parallelio
+      #version: ['8.6.1']
+      #variants: ~xerces ~pnetcdf snapshot=none +shared +external-parallelio
       #version: ['8.6.1b04']
       #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
       #version: ['8.7.0b04']
       #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
       require:
-        - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
+        - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"
           message: "Extra ESMF compile options for Intel"
-        - any_of: ['']
+        - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio']
           when: "%gcc"
+          message: "Extra ESMF compile options for GCC"
+        - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio']
+          when: "%apple-clang"
           message: "Extra ESMF compile options for GCC"
     fckit:
       version: ['0.11.0']

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -59,7 +59,7 @@
     # config and update the projections for lmod/tcl.
     # Also, check the acorn and derecho site configs which have esmf modifications.
     esmf:
-      version: ['8.6.0']
+      version: ['8.6.1']
       variants: ~xerces ~pnetcdf snapshot=none +shared +external-parallelio
       #version: ['8.6.1b04']
       #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
@@ -139,7 +139,7 @@
     libyaml:
       version: ['0.2.5']
     mapl:
-      version: ['2.40.3']
+      version: ['2.46.2']
       variants: +shared +pflogger ~f2py
     # If making changes here, also check the Discover site configs and the CI workflows
     met:
@@ -195,7 +195,7 @@
     parallel-netcdf:
       version: ['1.12.3']
     pflogger:
-      version: ['1.12.0']
+      #version: ['1.12.0']
       variants: +mpi
     pixman:
       variants: +pic
@@ -291,8 +291,8 @@
       version: ['2.0.8']
     wrf-io:
       version: ['1.2.0']
-    yafyaml:
-      version: ['1.2.0']
+    #yafyaml:
+    #  version: ['1.2.0']
     zstd:
       version: ['1.5.2']
       variants: +programs

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -59,12 +59,6 @@
     # config and update the projections for lmod/tcl.
     # Also, check the acorn and derecho site configs which have esmf modifications.
     esmf:
-      #version: ['8.6.1']
-      #variants: ~xerces ~pnetcdf snapshot=none +shared +external-parallelio
-      #version: ['8.6.1b04']
-      #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
-      #version: ['8.7.0b04']
-      #variants: ~xerces ~pnetcdf snapshot=b04 +shared +external-parallelio
       require:
         - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -9,7 +9,7 @@
     parallelio@2.6.2, parallel-netcdf@1.12.3, py-eccodes@1.5.0, py-f90nml@1.4.3,
     py-gitpython@3.1.40, py-h5py@3.8.0, py-numpy@1.22.3,
     py-pandas@1.5.3, py-pip, py-pyyaml@6.0, py-scipy@1.11.4, py-shapely@1.8.0, py-xarray@2023.7.0,
-    sp@2.5.0, udunits@2.2.28, w3emc@2.10.0, nco@5.1.6, esmf@8.6.0, mapl@2.40.3,
+    sp@2.5.0, udunits@2.2.28, w3emc@2.10.0, nco@5.1.6, esmf@8.6.1, mapl@2.46.2,
     zlib-ng@2.1.5, zstd@1.5.2, odc@1.4.6, shumlib@macos_clang_linux_intel_port,
     awscli-v2@2.13.22, py-globus-cli@3.16.0,
     # Added for new CI system 2024/04/30


### PR DESCRIPTION
### Summary

Update esmf and mapl to @8.6.1 and @2.46.2 in `configs/common/packages.yaml`. We need to use `require` to avoid the concretizer picking another version of esmf (e.g. `8.6.1b04`).

### Testing

@climbfuji's laptop and CI. I verified that the correct esmf and mapl versions are getting built

### Applications affected

all that use esmf / mapl

### Systems affected

none

### Dependencies

spack changed already merged

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1062

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
