### PR TITLE
Support multiple esmf versions in unified environment / updates of neptune-dev, unified-dev, skylab-dev templates (add `%oneapi`)

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -91,7 +91,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[openmpi@5.0.3]"
           spack config add "packages:all:compiler:[apple-clang@14.0.3]"
-          sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
+          sed -i '' "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel', '\%oneapi'\]/\['\%apple-clang'\]/g" $ENVDIR/spack.yaml
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
           # DH* 20240513 - avoid hdf-eos2 until https://github.com/spack/spack/issues/44168 is resolved

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -79,7 +79,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[openmpi@5.0.3]"
           spack config add "packages:all:compiler:[gcc@11.4.0]"
-          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%gcc'\]/g" $ENVDIR/spack.yaml
+          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel', '\%oneapi'\]/\['\%gcc'\]/g" $ENVDIR/spack.yaml
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
           spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -118,7 +118,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[intel-oneapi-mpi@2021.10.0]"
           spack config add "packages:all:compiler:[intel@2021.10.0]"
-          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel', '\%oneapi'\]/\['\%gcc'\]/g" $ENVDIR/spack.yaml
+          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel', '\%oneapi'\]/\['\%intel'\]/g" $ENVDIR/spack.yaml
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
           spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -118,7 +118,7 @@ jobs:
           # Set compiler and MPI
           spack config add "packages:all:providers:mpi:[intel-oneapi-mpi@2021.10.0]"
           spack config add "packages:all:compiler:[intel@2021.10.0]"
-          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel'\]/\['\%intel'\]/g" $ENVDIR/spack.yaml
+          sed -i "s/\['\%aocc', '\%apple-clang', '\%gcc', '\%intel', '\%oneapi'\]/\['\%gcc'\]/g" $ENVDIR/spack.yaml
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
           spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -60,13 +60,15 @@
     # Also, check the acorn and derecho site configs which have esmf modifications.
     esmf:
       require:
-        - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio fflags="-fp-model precise" cxxflags="-fp-model precise"']
+        - '~xerces ~pnetcdf +shared +external-parallelio'
+        - any_of: ['@=8.6.1 snapshot=none', '@=8.7.0b04 snapshot=b04']
+        - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"
           message: "Extra ESMF compile options for Intel"
-        - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio']
+        - any_of: ['']
           when: "%gcc"
           message: "Extra ESMF compile options for GCC"
-        - any_of: ['@=8.6.1 ~xerces ~pnetcdf snapshot=none +shared +external-parallelio']
+        - any_of: ['']
           when: "%apple-clang"
           message: "Extra ESMF compile options for GCC"
     fckit:
@@ -246,6 +248,9 @@
       require: ['@1.22.3']
     py-pandas:
       variants: +excel
+    # Pin py-poetry-core to avoid duplicate Python packages
+    py-poetry-core:
+      require: '@1.8.1'
     # Pin the py-setuptools version to avoid duplicate Python packages
     py-setuptools:
       require: ['@63.4.3']

--- a/configs/sites/atlantis/packages.yaml
+++ b/configs/sites/atlantis/packages.yaml
@@ -56,10 +56,11 @@ packages:
     externals:
     - spec: wget@1.19.5
       prefix: /usr
-  perl:
-    externals:
-    - spec: perl@5.26.3~cpanm+shared+threads
-      prefix: /usr
+  # Can't use with py-xnrl
+  #perl:
+  #  externals:
+  #  - spec: perl@5.26.3~cpanm+shared+threads
+  #    prefix: /usr
   gmake:
     externals:
     - spec: gmake@4.2.1

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,13 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env ^esmf@8.7.0b04 snapshot=b04
+      - neptune-env +python ^esmf@8.7.0b04 snapshot=b04
 
   specs:
     - matrix:
       - [$packages]
       - [$compilers]
+
+  packages:
+    esmf:
+      require: '@=8.7.0b04 snapshot=b04'

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -14,7 +14,3 @@ spack:
     - matrix:
       - [$packages]
       - [$compilers]
-
-  packages:
-    esmf:
-      require: '@=8.7.0b04 snapshot=b04'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -6,31 +6,35 @@ spack:
   include: []
 
   definitions:
-  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
+  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - ewok-env +ecflow +cylc
-      - ai-env
-      - geos-gcm-env
-      - jedi-fv3-env
-      - jedi-geos-env
-      - jedi-mpas-env
-      - jedi-neptune-env
-      - jedi-ufs-env
-      - jedi-um-env
-      - soca-env
+    - ewok-env +ecflow +cylc
+    - ai-env
+    - geos-gcm-env          ^esmf@=8.6.1
+    - jedi-fv3-env
+    - jedi-geos-env         ^esmf@=8.6.1
+    - jedi-mpas-env
+    - jedi-neptune-env      ^esmf@=8.7.0b04
+    - jedi-ufs-env          ^esmf@=8.6.1
+    - jedi-um-env
+    - soca-env
 
-      # Various fms tags (list all to avoid duplicate packages)
-      - fms@release-jcsda
-      - fms@2023.04
+    # Various fms tags (list all to avoid duplicate packages)
+    - fms@release-jcsda
+    - fms@2023.04
 
-      # Various crtm tags (list all to avoid duplicate packages)
-      - crtm@2.4.0.1
-      - crtm@v2.4.1-jedi
+    # Various crtm tags (list all to avoid duplicate packages)
+    - crtm@2.4.0.1
+    - crtm@v2.4.1-jedi
+
+    # Various esmf tags (list all to avoid duplicate packages)
+    - esmf@=8.6.1 snapshot=none
+    - esmf@=8.7.0b04 snapshot=b04
 
   specs:
-    - matrix:
-      - [$packages]
-      - [$compilers]
-      exclude:
-        # py-torch in ai-env doesn't build with Intel
-        - ai-env%intel
+  - matrix:
+    - [$packages]
+    - [$compilers]
+    exclude:
+    # py-torch in ai-env doesn't build with Intel
+    - ai-env%intel

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -21,7 +21,7 @@ spack:
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env +python   ^esmf@=8.7.0b04
+    - neptune-env ~python   ^esmf@=8.7.0b04
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.6.1
     - ufs-weather-model-env ^esmf@=8.6.1

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -6,43 +6,47 @@ spack:
   include: []
 
   definitions:
-  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel']
+  - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - ewok-env +ecflow +cylc
-      - ai-env
-      - geos-gcm-env
-      - global-workflow-env
-      - gmao-swell-env
-      - gsi-env
-      - jedi-fv3-env
-      - jedi-geos-env
-      - jedi-mpas-env
-      - jedi-neptune-env
-      - jedi-tools-env
-      - jedi-ufs-env
-      - jedi-um-env
-      - neptune-env
-      - soca-env
-      - ufs-srw-app-env
-      - ufs-weather-model-env
+    - ewok-env +ecflow +cylc
+    - ai-env
+    - geos-gcm-env          ^esmf@=8.6.1
+    - global-workflow-env   ^esmf@=8.6.1
+    - gmao-swell-env
+    - gsi-env               ^esmf@=8.6.1
+    - jedi-fv3-env
+    - jedi-geos-env         ^esmf@=8.6.1
+    - jedi-mpas-env
+    - jedi-neptune-env      ^esmf@=8.7.0b04
+    - jedi-tools-env
+    - jedi-ufs-env          ^esmf@=8.6.1
+    - jedi-um-env
+    - neptune-env +python   ^esmf@=8.7.0b04
+    - soca-env
+    - ufs-srw-app-env       ^esmf@=8.6.1
+    - ufs-weather-model-env ^esmf@=8.6.1
 
-      # Various fms tags (list all to avoid duplicate packages)
-      - fms@release-jcsda
-      - fms@2023.04
+    # Various fms tags (list all to avoid duplicate packages)
+    - fms@release-jcsda
+    - fms@2023.04
 
-      # Various crtm tags (list all to avoid duplicate packages)
-      - crtm@2.4.0.1
-      - crtm@v2.4.1-jedi
+    # Various crtm tags (list all to avoid duplicate packages)
+    - crtm@2.4.0.1
+    - crtm@v2.4.1-jedi
 
-      # MADIS for WCOSS2 decoders.
-      - madis@4.5
+    # Various esmf tags (list all to avoid duplicate packages)
+    - esmf@=8.6.1 snapshot=none
+    - esmf@=8.7.0b04 snapshot=b04
+
+    # MADIS for WCOSS2 decoders.
+    - madis@4.5
 
   specs:
-    - matrix:
-      - [$packages]
-      - [$compilers]
-      exclude:
-        # py-torch in ai-env doesn't build with Intel
-        - ai-env%intel
-        # jedi-tools doesn't build with Intel
-        - jedi-tools-env%intel
+  - matrix:
+    - [$packages]
+    - [$compilers]
+    exclude:
+    # py-torch in ai-env doesn't build with Intel
+    - ai-env%intel
+    # jedi-tools doesn't build with Intel
+    - jedi-tools-env%intel


### PR DESCRIPTION
### Summary

This PR makes it possible to use different ESMF versions for virtual packages within one large environment. NEPTUNE needs `esmf@8.7.0b04` (for now), while the other applications need `esmf@8.6.1`.

There are also cosmetic (indentation) changes for the skylab-dev and unified-dev templates, and an update of the `neptune-dev` template. I've turned off the Python variant for `neptune-env` when built as part of the unified environment due to numerous version conflicts and duplicates. We'll want to look at those later, after #1138 was merged and after the `py-xnrl` package dependencies are updated (ongoing at NRL).

### Testing

- Concretize both the `neptune-dev` (NEPTUNE standalone) template and the `unified-dev` template on my laptop
- Ran CI tests (only builds `unified-dev` at the moment)

### Applications affected

None (no changes from the current status quo)

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1154

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
