### PR TITLE
release/1.7.0: update Orion site config after Rocky9 update

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -26,7 +26,7 @@
     cairo:
       variants: +pic
     cdo:
-      version: ['2.2.0']
+      version: ['2.3.0']
       variants: ~openmp
     cmake:
       version: ['3.23.1']
@@ -277,7 +277,7 @@
       version: ['1.21.2']
     # When changing wgrib2, also check Hercules and Nautilus site configs
     wgrib2:
-      version: ['2.0.8']
+      version: ['3.1.1']
     wrf-io:
       version: ['1.2.0']
     yafyaml:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -26,7 +26,7 @@
     cairo:
       variants: +pic
     cdo:
-      version: ['2.3.0']
+      version: ['2.2.0']
       variants: ~openmp
     cmake:
       version: ['3.23.1']
@@ -277,7 +277,7 @@
       version: ['1.21.2']
     # When changing wgrib2, also check Hercules and Nautilus site configs
     wgrib2:
-      version: ['3.1.1']
+      version: ['2.0.8']
     wrf-io:
       version: ['1.2.0']
     yafyaml:

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -19,7 +19,7 @@ compilers:
         # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
         I_MPI_EXTRA_FILESYSTEM: 'ON'
     extra_rpaths: []
-compilers:
+
 - compiler:
     spec: gcc@12.2.0
     paths:

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -1,33 +1,36 @@
 compilers:
 - compiler:
-    spec: intel@2022.0.2
+    spec: intel@2023.1.0
     paths:
-      cc: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/icc
-      cxx: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/icpc
-      f77: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/ifort
-      fc: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
+      cc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/icx
+      cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/icpx
+      f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/ifx
+      fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/ifx
+    flags:
+      cflags: -diag-disable=10441
+      cxxflags: -diag-disable=10441
+      fflags: -diag-disable=10448
+    operating_system: rocky9
     target: x86_64
     modules:
-    - intel/2022.1.2
+    - intel-oneapi-compilers/2023.1.0
     environment:
-      prepend_path:
-        PATH: '/apps/gcc-10.2.0/gcc-10.2.0/bin'
-        LD_LIBRARY_PATH: '/apps/gcc-10.2.0/gcc-10.2.0/lib64:/apps/gcc-10.2.0/gcc-10.2.0/contrib/lib'
-        CPATH: '/apps/gcc-10.2.0/gcc-10.2.0/include'
+      set:
+        # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
+        I_MPI_EXTRA_FILESYSTEM: 'ON'
     extra_rpaths: []
+compilers:
 - compiler:
-    spec: gcc@10.2.0
+    spec: gcc@12.2.0
     paths:
-      cc: /apps/gcc-10.2.0/gcc-10.2.0/bin/gcc
-      cxx: /apps/gcc-10.2.0/gcc-10.2.0/bin/g++
-      f77: /apps/gcc-10.2.0/gcc-10.2.0/bin/gfortran
-      fc: /apps/gcc-10.2.0/gcc-10.2.0/bin/gfortran
+      cc: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/gcc
+      cxx: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/g++
+      f77: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/gfortran
+      fc: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/gfortran
     flags: {}
-    operating_system: centos7
+    operating_system: rocky9
     target: x86_64
     modules:
-    - gcc/10.2.0
+    - gcc/12.2.0
     environment: {}
     extra_rpaths: []

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -1,11 +1,11 @@
 compilers:
 - compiler:
-    spec: intel@2023.1.0
+    spec: intel@2021.9.0
     paths:
-      cc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/icx
-      cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/icpx
-      f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/ifx
-      fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/ifx
+      cc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icc
+      cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icpc
+      f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
+      fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
     flags:
       cflags: -diag-disable=10441
       cxxflags: -diag-disable=10441

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -1,30 +1,31 @@
 packages:
   all:
-    compiler:: [intel@2022.0.2, gcc@10.2.0]
+    compiler:: [intel@2023.1.0, gcc@12.2.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.0.4]
+      mpi:: [intel-oneapi-mpi/2021.7.1, openmpi@4.1.6]
+      zlib-api:: [zlib]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.5.1%intel@2022.0.2
-      prefix: /apps/intel-2022.1.2/intel-2022.1.2
+    - spec: intel-oneapi-mpi@2021.7.1%intel@2023.1.0
+      prefix: /apps/spack-managed/oneapi-2023.1.0/intel-oneapi-mpi-2021.9.0-a66eaipzsnyrdgaqzxmqmqz64qzvhkse
       modules:
-      - impi/2022.1.2
+      - intel-oneapi-mpi/2021.7.1
   openmpi:
     externals:
-    - spec: openmpi@4.0.4%gcc@10.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
-        fabrics=ucx schedulers=slurm +internal-hwloc +two_level_namespace
-      prefix: /apps/gcc-10.2.0/openmpi-4.0.4/openmpi-4.0.4
+    - spec: openmpi@4.1.6%gcc@12.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath schedulers=slurm
+      prefix: /work/noaa/epic/role-epic/spack-stack/orion/installs/openmpi/4.1.6
       modules:
-      - openmpi/4.0.4
+      - gnu/12.2.0
+      - openmpi/4.1.6
 
 ### Modifications of common packages
   # Temporary - see https://github.com/spack/spack/issues/41947
   cdo:
-    require: '@2.0.5'
+    require: '@2.3.0'
   mapl:
     require: '@2.40.3 ~pflogger ~extdata2g'
 

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -2,7 +2,7 @@ packages:
   all:
     compiler:: [intel@2023.1.0, gcc@12.2.0]
     providers:
-      mpi:: [intel-oneapi-mpi/2021.7.1, openmpi@4.1.6]
+      mpi:: [intel-oneapi-mpi@2021.7.1, openmpi@4.1.6]
       zlib-api:: [zlib]
 
 ### MPI, Python, MKL

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -20,7 +20,7 @@ packages:
       # Shouldn't set prefix if we want to use modules
       prefix: /work/noaa/epic/role-epic/spack-stack/orion/installs/openmpi/4.1.6
       modules:
-      - gnu/12.2.0
+      - gcc/12.2.0
       - openmpi/4.1.6
 
 ### Modifications of common packages

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -1,8 +1,8 @@
 packages:
   all:
-    compiler:: [intel@2023.1.0, gcc@12.2.0]
+    compiler:: [intel@2021.9.0, gcc@12.2.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.7.1, openmpi@4.1.6]
+      mpi:: [intel-oneapi-mpi@2021.9.0, openmpi@4.1.6]
       zlib-api:: [zlib]
 
 ### MPI, Python, MKL
@@ -10,13 +10,14 @@ packages:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.7.1%intel@2023.1.0
-      prefix: /apps/spack-managed/oneapi-2023.1.0/intel-oneapi-mpi-2021.9.0-a66eaipzsnyrdgaqzxmqmqz64qzvhkse
+    - spec: intel-oneapi-mpi@2021.9.0%intel@2021.9.0
+      #prefix: /apps/spack-managed/oneapi-2023.1.0/intel-oneapi-mpi-2021.9.0-a66eaipzsnyrdgaqzxmqmqz64qzvhkse
       modules:
-      - intel-oneapi-mpi/2021.7.1
+      - intel-oneapi-mpi/2021.9.0
   openmpi:
     externals:
     - spec: openmpi@4.1.6%gcc@12.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath schedulers=slurm
+      # Shouldn't set prefix if we want to use modules
       prefix: /work/noaa/epic/role-epic/spack-stack/orion/installs/openmpi/4.1.6
       modules:
       - gnu/12.2.0

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -100,22 +100,22 @@ For ``spack-stack-1.7.0`` with Intel, load the following modules after loading m
 
 .. code-block:: console
 
-   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.7.0/envs/ue-intel-centos/install/modulefiles/Core
-   module load stack-intel/2022.0.2
-   module load stack-intel-oneapi-mpi/2021.5.1
+   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.7.0/envs/ue-intel/install/modulefiles/Core
+   module load stack-intel/2021.9.0
+   module load stack-intel-oneapi-mpi/2021.9.0
    module load stack-python/3.10.13
 
 For ``spack-stack-1.7.0`` with GNU, load the following modules after loading miniconda and ecflow:
 
 .. code-block:: console
 
-   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.7.0/envs/ue-gcc-centos/install/modulefiles/Core
-   module load stack-gcc/10.2.0
-   module load stack-openmpi/4.0.4
+   module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.7.0/envs/ue-gcc/install/modulefiles/Core
+   module load stack-gcc/12.2.0
+   module load stack-openmpi/4.1.6
    module load stack-python/3.10.13
 
 .. note::
-   The unified environment on Orion uses ``cdo@2.0.5`` instead of the default ``cdo@2.2.0`` because of a bug in the ``cdo`` package recipe that affects systems that don't have a ``python3`` interpreter in the default search paths (see https://github.com/spack/spack/issues/41947) for more information. This is a temporary change on Orion for the spack-stack-1.7.0 release and will be reverted once the ``cdo`` package is updated in the upstream spack develop code.
+   The unified environment on Orion uses ``cdo@2.3.0`` instead of the default ``cdo@2.2.0``. This is a temporary change on Orion after the Rocky9 OS upgrade.
 
 .. note::
    spack-stack-1.7.0 on Orion provides a chained environment `gsi-addon-env` for GSI with Intel and GNU. To use this environment, replace `ue` in the above `module use` statements with `gsi-addon`, and load module `stack-python/3.11.6` instead of `stack-python/3.10.13`.

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -93,7 +93,6 @@ The following is required for building new spack environments and for using spac
 
    module purge
    module use /work/noaa/epic/role-epic/spack-stack/orion/modulefiles
-   module load python/3.9.2
    module load ecflow/5.8.4
 
 For ``spack-stack-1.7.0`` with Intel, load the following modules after loading miniconda and ecflow:


### PR DESCRIPTION
### Summary

Update site config and documentation for Orion for Rocky9 OS upgrade. This was used to reinstall the unified environments and gsi-addon-environments for both Intel and GNU. The following steps were taken for each of the compilers:

- fixed local site config
- install basic unified environment, then added esmf@8.6.1
- updated site config and readthedocs for release/1.7.0 - this PR
- updated site config and readthedocs for develop - separate follow-up PR
- install gsi-addon
- grib-util: wgrib module entry for both ue and gsi-addon
- removed centos environments

### Testing

See above

### Applications affected

n/a

### Systems affected

Orion

### Dependencies

n/a

### Issue(s) addressed

Working towards #981

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
