### PR TITLE
Update flex version to 2.6.4 in the discover scu16 config

### DIFF
--- a/configs/sites/discover-scu16/packages.yaml
+++ b/configs/sites/discover-scu16/packages.yaml
@@ -81,7 +81,7 @@ packages:
     # Must set buildable: false to avoid duplicate packages
     buildable: false
     externals:
-    - spec: flex@2.5.37+lex
+    - spec: flex@2.6.4
       prefix: /usr
   gawk:
     externals:


### PR DESCRIPTION
### Summary

Discover scu16 has flex 2.6.4 in /usr/bin/flex so this updated the config accordingly.

### Testing

Concretize works on Discover scu16, and the build is currently running and appears to be in good shape.

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.
UFS, JEDI

### Systems affected

List all systems intentionally or unintentionally affected by this PR.
Discover scu16

### Dependencies

- [ ] merge after #1138

### Issue(s) addressed

Link the issues addressed or resolved by this PR (use `Fixes #???` for fully resolved issues)
None (this was a quick fix)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
