### PR TITLE
Fix JEDI CI containers after overhaul of common packages.yaml

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -84,7 +84,8 @@
     g2c:
       require: '@1.6.4'
     g2tmpl:
-      require: '@1.10.2'
+      require:
+        - '@1.10.2'
     gfsio:
       require: '@1.4.1'
     #git-lfs:

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -42,7 +42,7 @@ spack:
       require:
         - any_of: ['fflags="-no-pie"']
           when: "@1.10.2: %clang"
-          message: "Extra ESMF compile options for version 1.10.2+ with clang"
+          message: "Extra g2tmpl compile options for version 1.10.2+ with clang"
     gmake:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -60,6 +60,10 @@ spack:
       externals:
       - spec: diffutils@3.7
         prefix: /usr
+    gettext:
+      externals:
+      - spec: gettext@0.19.8.1
+        prefix: /usr
     git:
       buildable: false
       externals:
@@ -133,6 +137,7 @@ spack:
       - cpp
       - g++
       - gcc
+      - gettext
       - gfortran
       - git
       - git-lfs
@@ -149,6 +154,7 @@ spack:
       - cpp
       - g++
       - gcc
+      - gettext
       - gfortran
       - git
       - git-lfs

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -133,6 +133,7 @@ spack:
     ## Additional system packages that are needed at runtime
     os_packages:
       build:
+      - autopoint
       - bc
       - cpp
       - g++
@@ -150,6 +151,7 @@ spack:
       - wget
 
       final:
+      - autopoint
       - bc
       - cpp
       - g++


### PR DESCRIPTION
### Summary

Resolves #1173 with a few minor tweaks to the container recipes:
- need to change `require` syntax for `g2tmpl` so that the `clang-mpich` container can add its additional requirement
- need to use an external `gettext` (with `autopoint`) for Intel, since the latest `gettext` doesn't build with Intel (known from HPCs)

### Testing

I built all three JEDI CI containers manually on the Ubuntu CI node:
```
ubuntu@ip-10-0-1-156:~/spack-stack/manual-testing/spack-stack-fix-jedi-containers-202400701/envs/docker-ubuntu-intel-impi$ docker images
REPOSITORY                               TAG                                IMAGE ID       CREATED          SIZE
docker-ubuntu-intel-impi-jedi-ci         latest                             f0be3e72bf55   15 minutes ago   13.7GB
docker-ubuntu-intel-impi-jedi-ci-debug   latest                             4fe25e5853ef   10 hours ago     9.5GB
docker-ubuntu-gcc-openmpi-jedi-ci        latest                             2c91f8b16473   10 hours ago     5.92GB
049482                                   1742b75e59d548e9af21d2e735774415   0ab1a73e2986   13 hours ago     51MB
049482                                   3a45a007b90f40c2a50477a9d992d8c7   0ab1a73e2986   13 hours ago     51MB
067544                                   05e9ac3784d64946b71767dacd2c8a7d   0ab1a73e2986   13 hours ago     51MB
067544                                   0c221e8ac1b14faf9e6246cf9c88b407   0ab1a73e2986   13 hours ago     51MB
067544                                   1cef92f41df24712bd82727a53e86738   0ab1a73e2986   13 hours ago     51MB
067544                                   427434662b0044b7a5d61b4a00b4b35a   0ab1a73e2986   13 hours ago     51MB
067544                                   6448ad1fd09143f69f677afab2ceb5be   0ab1a73e2986   13 hours ago     51MB
067544                                   963f4b6c6d3d4aa2afb7b67ea97d575b   0ab1a73e2986   13 hours ago     51MB
067544                                   afe9f5f00a1444df800564cb0e8039ef   0ab1a73e2986   13 hours ago     51MB
1dfca0                                   9ba62012f6e74658b49786b79acef8b4   0ab1a73e2986   13 hours ago     51MB
<none>                                   <none>                             7f4cae4f74a2   16 hours ago     5.92GB
docker-ubuntu-clang-mpich-jedi-ci        latest                             76c0436b4713   20 hours ago     6.89GB
....
```

### Applications affected

JEDI CI (not immediately, but next release)

### Systems affected

JEDI CI containers

### Dependencies

n/a

### Issue(s) addressed

Resolves #1173

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
