### PR TITLE
Update documentation with links to the spack-stack wiki for latest updates on current and previous releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ and the [Spack documentation](https://spack.readthedocs.io/en/latest/).
 installation on a [supported platform](https://spack-stack.readthedocs.io/en/latest/PreConfiguredSites.html)
 or by [creating a new installation](https://spack-stack.readthedocs.io/en/latest/CreatingEnvironments.html), see the
 [Getting Started](https://spack-stack.readthedocs.io/en/latest/Overview.html#getting-started) documentation page.
-Full documentation with table of contents can be found at https://spack-stack.readthedocs.io/en/latest/.
+Full documentation with table of contents can be found at https://spack-stack.readthedocs.io/en/latest/. The spack-stack
+[Wiki](https://github.com/JCSDA/spack-stack/wiki) also provides latest updates for current and previous spack-stack releases.
 
 Spack-stack is a collaborative effort between:
 * [NOAA Environmental Modeling Center (EMC)](https://www.emc.ncep.noaa.gov)

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -3,6 +3,9 @@
 Pre-configured sites
 *************************
 
+.. note::
+  The information on this page usually refers to the latest stable release of spack-stack. There are usually no updates for the latest developmental code for preconfigured sites. Further, current and previous releases of spack-stack are often updated with new packages, and sometimes it is necessary to rebuild spack-stack environments, for example in case an HPC receives a major software update. Also in this case, the documentation available on readthedocs is not updated. Be sure to check the spack-stack Wiki <https://github.com/JCSDA/spack-stack/wiki> for updates to current and previous releases before using the information below!
+
 Directory ``configs/sites`` contains site configurations for several HPC systems, as well as minimal configurations for macOS and Linux. The macOS and Linux configurations are **not** meant to be used as is, as user setups and package versions vary considerably. Instructions for adding this information can be found in :numref:`Section %s <NewSiteConfigs>`.
 
 Pre-configured sites are split into two categories: Tier 1 with officially supported spack-stack installations (see :numref:`Section %s <Preconfigured_Sites_Tier1>`), and Tier 2 (sites with configuration files that were tested or contributed by others in the past, but that are not officially supported by the spack-stack team; see :numref:`Section %s <Preconfigured_Sites_Tier2>`).


### PR DESCRIPTION
### Summary

This PR updates `README.md` and `doc/source/PreConfiguredSites.rst` with links to the spack-stack wiki for latest updates on current and previous releases. I started populating the wiki pages with the relevant information for spack-stack-1.7.0:

https://github.com/JCSDA/spack-stack/wiki

This is needed so that we can make updates more easily and faster as we modify existing spack-stack releases.

We could also add information to that page with when a release was published/installed and when it will be removed.

### Testing

Rendered documentation (only preconfigured sites has changed): https://spack-stack--1178.org.readthedocs.build/en/1178/

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1161

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
