### PR TITLE
Update to mepo v2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/GMAO-SI-Team/spack
+  branch = add-mepo-package-cherrypick
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/GMAO-SI-Team/spack
-  branch = add-mepo-package-cherrypick
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

This PR updates the submodule pointer for spack for the changes in https://github.com/JCSDA/spack/pull/448: replace our own `mepo` v1 package with the official, GMAO-blessed `mepo` v2 package.

### Testing

- [x] CI (check that it actually builds it)

### Applications affected

GEOS (gmao-swell-env, geos-env, ...)

### Systems affected

n/a

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/448

### Issue(s) addressed

Related to https://github.com/JCSDA/spack-stack/issues/1140

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
