### PR TITLE
Add site config for blackpearl

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -58,12 +58,12 @@
         - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"
           message: "Extra ESMF compile options for Intel"
-        - any_of: ['']
-          when: "%gcc"
-          message: "Extra ESMF compile options for GCC"
-        - any_of: ['']
-          when: "%apple-clang"
-          message: "Extra ESMF compile options for GCC"
+        #- any_of: ['']
+        #  when: "%gcc"
+        #  message: "Extra ESMF compile options for GCC"
+        #- any_of: ['']
+        #  when: "%apple-clang"
+        #  message: "Extra ESMF compile options for GCC"
     fckit:
       require: '@0.11.0 +eckit'
     fftw:
@@ -86,6 +86,8 @@
     g2tmpl:
       require:
         - '@1.10.2'
+    gcc-runtime:
+      require: '%gcc'
     gfsio:
       require: '@1.4.1'
     #git-lfs:
@@ -214,7 +216,8 @@
     # py-numpy@1.26 causes many build problems with older Python packages
     # also check Nautilus site config when making changes here
     py-numpy:
-      require: '@:1.25'
+      require:
+      - '@:1.25'
     py-pandas:
       require: '+excel'
     py-pybind11:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -253,8 +253,9 @@
     # Note - we can remove upp from stack at some point?
     upp:
       require: '@10.0.10'
+    # Need extradeps for grib-utils, enable by default to avoid duplicate packages
     w3emc:
-      require: '@2.10.0 precision=4,d,8'
+      require: '@2.10.0 precision=4,d,8 +extradeps'
     w3nco:
       require: '@2.4.1'
     # When changing wgrib2, also check Hercules and Nautilus site configs

--- a/configs/sites/tier2/blackpearl/README.md
+++ b/configs/sites/tier2/blackpearl/README.md
@@ -1,0 +1,3 @@
+Blackpearl is @climbfuji's development system (Dell Laptop running Oracle Linux 9.1 under Windows WSL2).
+
+The site config currently requires a manual copy of the correct packages_COMPILER.yaml to the environment site directory. This will be improved later.

--- a/configs/sites/tier2/blackpearl/compilers.yaml
+++ b/configs/sites/tier2/blackpearl/compilers.yaml
@@ -1,0 +1,61 @@
+compilers:
+- compiler:
+    spec: clang@=14.0.6
+    paths:
+      cc: /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: null
+      fc: null
+    flags: {}
+    operating_system: oracle9
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@=11.4.1
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: oracle9
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@=13.3.0
+    paths:
+      cc: /home/dom/prod/gcc-13.3.0-manual/bin/gcc
+      cxx: /home/dom/prod/gcc-13.3.0-manual/bin/g++
+      f77: /home/dom/prod/gcc-13.3.0-manual/bin/gfortran
+      fc: /home/dom/prod/gcc-13.3.0-manual/bin/gfortran
+    flags: {}
+    operating_system: oracle9
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2024.1.2
+    paths:
+      cc: /opt/intel/oneapi/compiler/2024.1/bin/icx
+      cxx: /opt/intel/oneapi/compiler/2024.1/bin/icpx
+      f77: /opt/intel/oneapi/compiler/2024.1/bin/ifort
+      fc: /opt/intel/oneapi/compiler/2024.1/bin/ifort
+      #f77: /opt/intel/oneapi/compiler/2024.1/bin/ifx
+      #fc: /opt/intel/oneapi/compiler/2024.1/bin/ifx
+    flags:
+      cflags: -diag-disable=10441
+      cxxflags: -diag-disable=10441
+      fflags: -diag-disable=10448
+    operating_system: oracle9
+    target: x86_64
+    modules: []
+    environment:
+      # change to append_path once relevant PR is merged
+      append_path:
+        CPATH: /opt/intel/oneapi/compiler/2024.1/opt/compiler/include/intel64
+    extra_rpaths: []

--- a/configs/sites/tier2/blackpearl/config.yaml
+++ b/configs/sites/tier2/blackpearl/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 2

--- a/configs/sites/tier2/blackpearl/modules.yaml
+++ b/configs/sites/tier2/blackpearl/modules.yaml
@@ -1,0 +1,10 @@
+modules:
+  default:
+    enable::
+    - tcl
+    tcl:
+      include:
+      # List of packages for which we need modules that are blacklisted by default
+      - openmpi
+      - mpich
+      - python

--- a/configs/sites/tier2/blackpearl/packages_gcc.yaml
+++ b/configs/sites/tier2/blackpearl/packages_gcc.yaml
@@ -1,0 +1,87 @@
+packages:
+
+  all:
+    compiler:: [gcc@=13.3.0]
+    providers:
+      mpi:: [openmpi@=5.0.3]
+
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.16.2
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.35.2
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.7.4
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.32
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.7
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.8.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.4+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@5.1.0
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.21
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.43.0~tcltk
+      prefix: /usr
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.4.1
+      prefix: /usr
+  #gmake:
+  #  externals:
+  #  - spec: gmake@4.3
+  #    prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.4
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.19
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.7.3
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.8
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.34
+      prefix: /usr
+  texlive:
+    externals:
+    - spec: texlive@20200406
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.21.1
+      prefix: /usr

--- a/configs/sites/tier2/blackpearl/packages_oneapi.yaml
+++ b/configs/sites/tier2/blackpearl/packages_oneapi.yaml
@@ -1,0 +1,114 @@
+packages:
+
+  all:
+    compiler:: [oneapi@=2024.1.2]
+    providers:
+      mpi:: [intel-oneapi-mpi@=2021.12]
+      blas:: [intel-oneapi-mkl]
+      fftw-api:: [intel-oneapi-mkl]
+      lapack:: [intel-oneapi-mkl]
+  ectrans:
+    require:: '+mkl ~fftw'
+  gsibec:
+    require:: '+mkl'
+  py-numpy:
+    require:
+    - '^intel-oneapi-mkl'
+  gmake:
+    require: '@:4.2'
+
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.12%oneapi@2024.1.2
+      prefix: /opt/intel/oneapi
+  intel-oneapi-mkl:
+    externals:
+    - spec: intel-oneapi-mkl@2024.1%oneapi@2024.1.2
+      prefix: /opt/intel/oneapi
+  intel-oneapi-runtime:
+    externals:
+    - spec: intel-oneapi-runtime@2024.1.2%oneapi@2024.1.2
+      prefix: /opt/intel/oneapi
+
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.16.2
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.35.2
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.7.4
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.32
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.7
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.8.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.4+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@5.1.0
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.21
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.43.0~tcltk
+      prefix: /usr
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.4.1
+      prefix: /usr
+  #gmake:
+  #  externals:
+  #  - spec: gmake@4.3
+  #    prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.4
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.19
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.7.3
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.8
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.34
+      prefix: /usr
+  texlive:
+    externals:
+    - spec: texlive@20200406
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.21.1
+      prefix: /usr


### PR DESCRIPTION
### Summary

Adding the site config for @climbfuji's development system that's gotten too complicated (because of multiple compilers etc) to generate it from `linux.default` every time.

There are minor modifications to `configs/common/packages.yaml` that are needed to avoid duplicate packages, and I believe those will be necessary for other systems moving to the `oneapi` (Intel LLVM) compilers (at least `icx`, `icpx`) in the future. (Otherwise, I'd not bother you reviewing this PR).

### Testing

Tested locally

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
