### PR TITLE
release/1.6.0: bugfix for mapl with mvapich2, and bug fix for grib-utils modulefile (wgrib env var)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-1.6.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/mapl_mvapich_rel160
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-1.6.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-1.6.0
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-1.6.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/mapl_mvapich_rel160
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -190,7 +190,7 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB2': '{prefix}/bin/wgrib2'
+            'WGRIB': '{prefix}/bin/wgrib2'
       landsfcutil:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -192,7 +192,7 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB2': '{prefix}/bin/wgrib2'
+            'WGRIB': '{prefix}/bin/wgrib2'
       landsfcutil:
         environment:
           set:


### PR DESCRIPTION
### Summary

For release/1.6.0:
- bugfix for `mapl` with `mvapich2` (see https://github.com/JCSDA/spack/pull/449)
- bugfix for `grib-utils` module file (`wgrib` env var) - I don't know why this was never committed to the release branch, instead changes were made locally only :-( 

Corresponding upstream spack develop PR for `mapl`/`mvapich2`: https://github.com/spack/spack/pull/45164

### Testing

Installed successfully on Hercules with `gcc` and `mvapich2`

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

- [x] waiting for https://github.com/JCSDA/spack/pull/449

### Issue(s) addressed

Required for https://github.com/JCSDA/spack-stack/issues/1168

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
