### PR TITLE
Remove fms release-jcsda versions from config templates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/srherbener/spack
-  branch = feature/remove-jcsda-fms-version
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/srherbener/spack
+  branch = feature/remove-jcsda-fms-version
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -74,6 +74,7 @@
       # Pin version to avoid duplicates
       require: '@2.6.4'
     fms:
+      require: '@2023.04'
       variants: 'precision=32,64 +quad_precision +gfs_phys +openmp +pic constants=GFS build_type=Release +deprecated_io'
     fontconfig:
       require: '+pic'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -19,9 +19,6 @@ spack:
     - jedi-um-env
     - soca-env
 
-    # Various fms tags (list all to avoid duplicate packages)
-    - fms@2023.04
-
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -20,7 +20,6 @@ spack:
     - soca-env
 
     # Various fms tags (list all to avoid duplicate packages)
-    - fms@release-jcsda
     - fms@2023.04
 
     # Various crtm tags (list all to avoid duplicate packages)

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -27,7 +27,6 @@ spack:
     - ufs-weather-model-env ^esmf@=8.6.1
 
     # Various fms tags (list all to avoid duplicate packages)
-    - fms@release-jcsda
     - fms@2023.04
 
     # Various crtm tags (list all to avoid duplicate packages)

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -26,9 +26,6 @@ spack:
     - ufs-srw-app-env       ^esmf@=8.6.1
     - ufs-weather-model-env ^esmf@=8.6.1
 
-    # Various fms tags (list all to avoid duplicate packages)
-    - fms@2023.04
-
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi

--- a/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
@@ -24,7 +24,7 @@ class GmaoSwellEnv(BundlePackage):
     depends_on("crtm@v2.4-jedi.2", type="run")
 
     # Additional dependencies for JEDI used by swell
-    depends_on("fms@2023.04+pic", type="run")
+    depends_on("fms", type="run")
     depends_on("nco", type="run")
 
     # GEOS

--- a/spack-ext/repos/spack-stack/packages/jedi-fv3-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/jedi-fv3-env/package.py
@@ -17,6 +17,6 @@ class JediFv3Env(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@2023.04+pic", type="run")
+    depends_on("fms", type="run")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/jedi-ufs-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/jedi-ufs-env/package.py
@@ -17,7 +17,7 @@ class JediUfsEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@2023.04+pic", type="run")
+    depends_on("fms", type="run")
 
     depends_on("bacio", type="run")
     depends_on("g2", type="run")

--- a/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
@@ -25,7 +25,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("netcdf-fortran")
     depends_on("parallelio")
     depends_on("esmf")
-    depends_on("fms@2023.04")
+    depends_on("fms")
     depends_on("bacio")
     depends_on("crtm@2.4.0.1")
     depends_on("g2")

--- a/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
@@ -26,7 +26,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("base-env", type="run")
     depends_on("ufs-pyenv", type="run", when="+python")
 
-    depends_on("fms@2023.04", type="run")
+    depends_on("fms", type="run")
     depends_on("bacio", type="run")
     depends_on("crtm@2.4.0.1", type="run")
     depends_on("g2", type="run")


### PR DESCRIPTION
### Summary

This PR removes the fms `release-jcsda` versions from the unified-dev and skylab-dev config templates. These versions are no longer needed given the recent switch to the fms 2023.04 version.

This PR is in response to the request made here: https://github.com/JCSDA/spack-stack/issues/548#issuecomment-2217821312

### Testing



### Applications affected

Skylab, fv3 model variants

### Systems affected

HPC, Linux and Mac platforms

### Dependencies

None

### Issue(s) addressed

Partially addresses #548

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
