### PR TITLE
Bump wgrib2 to 3.1.1 and cdo to 2.3.0

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -258,9 +258,8 @@
       require: '@2.10.0 precision=4,d,8 +extradeps'
     w3nco:
       require: '@2.4.1'
-    # When changing wgrib2, also check Hercules and Nautilus site configs
     wgrib2:
-      require: '@2.0.8'
+      require: '@3.1.1'
     wrf-io:
       require: '@1.2.0'
     zstd:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -27,7 +27,7 @@
     cairo:
       require: '+pic'
     cdo:
-      require: '@2.2.0 ~openmp'
+      require: '@2.3.0 ~openmp'
     cmake:
       version: ['3.27.9']
       require: '+ownlibs'

--- a/configs/sites/tier1/nautilus/packages.yaml
+++ b/configs/sites/tier1/nautilus/packages.yaml
@@ -57,9 +57,6 @@ packages:
       prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.1.2
 
 ### Modifications of common packages
-  # Version 2.0.8 doesn't compile on Nautilus
-  wgrib2:
-    require:: '@3.1.1'
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -40,12 +40,6 @@ General
    This problem is caused by a bad library in the Intel oneAPI installation. The solution is to fix the library using patchelf, which requires write access to the oneAPI installation: First, verify that ``ldd /opt/intel/oneapi/compiler/2024.0/lib/libirc.so`` says it is statically linked (it isn't). Then, run: ``patchelf --add-needed libc.so.6 /opt/intel/oneapi/compiler/2024.0/lib/libirc.so`` and your application should run rightaway (no need to recompile).
 
 ==============================
-MSU Hercules
-==============================
-
-1. ``wgrib2@2.0.8`` doesn't build on Hercules, use ``wgrib2@3.1.1`` instead.
-
-==============================
 NASA Discover
 ==============================
 
@@ -90,14 +84,6 @@ NAVY HPCMP Narwhal
 ==============================
 
 1. On Narwhal (like on any other Cray), the spack build environment depends on the currently loaded modules. It is therefore necessary to build separate environments for different compilers while having the correct modules for that setup loaded.
-
-2. ``mapl@2.35.2`` does not build on Narwhal, see https://github.com/JCSDA/spack-stack/issues/524. When using the ``unified-dev`` template, one has to manually remove ``jedi-ufs-env`` and ``ufs-weather-model-env`` from the environment's ``spack.yaml``.
-
-==============================
-NAVY HPCMP Nautilus
-==============================
-
-1. ``wgrib2@2.0.8`` doesn't build on Nautilus, use ``wgrib2@3.1.1`` instead.
 
 ==============================
 macOS

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -141,9 +141,6 @@ For ``spack-stack-1.7.0`` with GNU, load the following modules after loading min
    module load stack-openmpi/4.1.6
    module load stack-python/3.10.13
 
-.. note::
-   The unified environment on Orion uses ``cdo@2.3.0`` instead of the default ``cdo@2.2.0``. This is a temporary change for release/1.7.0 and no longer needed on develop.
-
 ------------------------------
 MSU Hercules
 ------------------------------

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -358,10 +358,6 @@ With AMD clang/flang (aocc), the following is required for building new spack en
 
    ``spack-stack-1.7.0`` is not yet supported with the Arm clang/flang compilers. Use Intel instead.
 
-.. note::
-
-   `wgrib2@2.0.8` does not build on Nautilus, therefore we are using `wgrib2@3.1.1` on this system.
-
 .. _Preconfigured_Sites_Derecho:
 
 --------------------


### PR DESCRIPTION
### Summary

Both wgrib2@3.1.1 and cdo@2.3.0 have been tested, because some platforms simply refused to build older versions.

Here I am bumping both and also updating the documentation and site configs. I did **not** attempt to update the unmaintained templates - they are very far behind and definitely no longer work since PR #1138 that replaced soft requirements with hard requirements in `configs/common/packages.yaml`.

### Testing

- [x] CI
- Do we need to test the UFS for these changes (neither JEDI nor NEPTUNE nor GEOS use these packages)?

### Applications affected

All using `wgrib2` and `cdo`

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1160
Resolves https://github.com/JCSDA/spack-stack/issues/931

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
