### PR TITLE
Ensure that required tests always run.

### DIFF
--- a/.github/workflows/macos-ci-aarch64-notest.yaml
+++ b/.github/workflows/macos-ci-aarch64-notest.yaml
@@ -1,0 +1,24 @@
+name: macos-ci-aarch64-build
+on:
+  pull_request:
+    paths:
+      - 'configs/sites/**'
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/workflows/macos-ci-aarch64-notest.yaml'
+      - '.gitignore'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  macos-ci-aarch64-build:
+    runs-on: [macos-ci-aarch64]
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ubuntu-ci-x86_64-gnu-notest.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu-notest.yaml
@@ -1,0 +1,24 @@
+name: ubuntu-ci-c6a-x86_64-gnu-build
+on:
+  pull_request:
+    paths:
+      - 'configs/sites/**'
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/workflows/ubuntu-ci-x86_64-gnu-notest.yaml'
+      - '.gitignore'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ubuntu-ci-c6a-x86_64-gnu-build:
+    runs-on: [ubuntu-ci-c6a-x86_64]
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ubuntu-ci-x86_64-intel-notest.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel-notest.yaml
@@ -1,0 +1,24 @@
+name: ubuntu-ci-c6a-x86_64-intel-build
+on:
+  pull_request:
+    paths:
+      - 'configs/sites/**'
+      - 'doc/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/workflows/ubuntu-ci-x86_64-intel-notest.yaml'
+      - '.gitignore'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ubuntu-ci-c6a-x86_64-intel-build:
+    runs-on: [ubuntu-ci-c6a-x86_64]
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
This change adds "notest" variants of existing required tests. The purpose of this change is to ensure that required tests always run without forcing them to consume resources with a full build when this would be unnecessary. While the main tests use the `pull_request: ↳ paths-ignore:` directive to trigger the workflow, this abbreviated test uses the same file patterns but applies the inclusive `paths` directive.