### PR TITLE
Upgrade ecmwf-atlas to 0.38.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/srherbener/spack
-  branch = feature/upgrade-atlas-0.38.1
-  # url = https://github.com/jcsda/spack
-  # branch = spack-stack-dev
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  url = https://github.com/ericlingerfelt/spack
+  branch = feature/upgrade-atlas-0.38
+  # url = https://github.com/jcsda/spack
+  # branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/ericlingerfelt/spack
-  branch = feature/upgrade-atlas-0.38
+  url = https://github.com/srherbener/spack
+  branch = feature/upgrade-atlas-0.38.1
   # url = https://github.com/jcsda/spack
   # branch = spack-stack-dev
 [submodule "doc/CMakeModules"]

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -43,7 +43,7 @@
     eckit:
       require: '@1.24.5 linalg=eigen,lapack compression=lz4,bzip2'
     ecmwf-atlas:
-      require: '@0.36.0 +fckit +trans +tesselation +fftw'
+      require: '@0.38.1 +fckit +trans +tesselation +fftw'
     ectrans:
       require: '@1.2.0 ~mkl +fftw'
     eigen:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,7 +1,7 @@
   ### spack-stack-1.6.0 / skylab-7.x.y containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
   specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.1, ecbuild@3.7.2, eccodes@2.33.0, ecflow@5,
-    eckit@1.24.5, ecmwf-atlas@0.36.0 +fckit +trans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
+    eckit@1.24.5, ecmwf-atlas@0.38.1 +fckit +trans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@2023.04, g2@3.4.9, g2tmpl@1.10.2,
     gsibec@1.2.1, hdf@4.2.15, hdf5@1.14.3, ip@5.0.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1, netcdf-fortran@4.6.1,


### PR DESCRIPTION
### Summary

Ecmwf-atlas 0.38.0 and 0.38.1 has been added. 

### Testing

Harvesting this information now
- [x] CI spack-stack build

JCSDA testing
- [x] Orion, GNU (@srherbener)
- [x] Discover, Intel (@srherbener)

### Applications affected

JEDI, UFS

### Systems affected

S4, Discover, Hera, Jet, Acorn

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/459

### Issue(s) addressed

Resolves #1155 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
