### PR TITLE
Update dask to 2021.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/add_dask_versions_2021pX
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/add_dask_versions_2021pX
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -196,10 +196,13 @@
     # to avoid duplicate packages being built (cylc dependencies soft-want @3:)
     py-cython:
       require: '@0.29.36'
+    # As long as we need the "delayed" variant for py-dask,
+    # we are restricted to version 2021.03.0 (last one that has it)
+    # and newer than 2021.01.0 because of these issues:
     # https://github.com/JCSDA/spack-stack/issues/1216
     # https://github.com/pydata/xarray/issues/8917
     py-dask:
-      require: '@2021.4.1:'
+      require: '@2021.3.0'
     # To avoid duplicate packages
     py-flit-core:
       require: '@3.8.0'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -196,6 +196,10 @@
     # to avoid duplicate packages being built (cylc dependencies soft-want @3:)
     py-cython:
       require: '@0.29.36'
+    # https://github.com/JCSDA/spack-stack/issues/1216
+    # https://github.com/pydata/xarray/issues/8917
+    py-dask:
+      require: '@2021.4.1:'
     # To avoid duplicate packages
     py-flit-core:
       require: '@3.8.0'


### PR DESCRIPTION
### Summary

Update `py-dask` to 2021.3.0 to fix https://github.com/JCSDA/spack-stack/issues/1216. I chose this version because fixing the issue requires at least 2021.1.0, but 2021.3.0 is the last version that has the `delayed` variant that `py-xnrl` needs.

### Testing

- [x] Built environment on my laptop (blackpearl) with `gcc@13`
- [x] Built environment on Nautilus with intel@2021.5.0 and verified it fixes the problem

Note that `py-xnrl` is not built in CI (since it isn't part of the unified environment, just the neptune standalone environment)

### Applications affected

NEPTUNE

### Systems affected

NAVY systems

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/455

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1216
Resolves #1043 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
