### PR TITLE
Add site config for NRL sandy

### DIFF
--- a/configs/sites/tier1/sandy/compilers.yaml
+++ b/configs/sites/tier1/sandy/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    spec: gcc@=9.3.0
+    paths:
+      cc: /software/depot/gcc-9.3.0/bin/gcc
+      cxx: /software/depot/gcc-9.3.0/bin/g++
+      f77: /software/depot/gcc-9.3.0/bin/gfortran
+      fc: /software/depot/gcc-9.3.0/bin/gfortran
+    flags: {}
+    operating_system: centos7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/configs/sites/tier1/sandy/config.yaml
+++ b/configs/sites/tier1/sandy/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 8

--- a/configs/sites/tier1/sandy/mirrors.yaml
+++ b/configs/sites/tier1/sandy/mirrors.yaml
@@ -1,0 +1,18 @@
+mirrors:
+  local-source:
+    fetch:
+      url: file:///gpfs/fs1/neptune/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null
+    push:
+      url: file:///gpfs/fs1/neptune/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null

--- a/configs/sites/tier1/sandy/modules.yaml
+++ b/configs/sites/tier1/sandy/modules.yaml
@@ -1,0 +1,10 @@
+modules:
+  default:
+    enable::
+    - tcl
+    tcl:
+      include:
+      # List of packages for which we need modules that are blacklisted by default
+      - python
+      exclude:
+      - ecflow

--- a/configs/sites/tier1/sandy/packages.yaml
+++ b/configs/sites/tier1/sandy/packages.yaml
@@ -1,0 +1,113 @@
+packages:
+  all:
+    compiler:: [gcc@9.3.0]
+    providers: 
+      mpi:: [openmpi@4.0.5]
+
+### MPI, Python, MKL
+  mpi:
+    buildable: False
+  openmpi:
+    externals:
+    - spec: openmpi@4.0.5%gcc@9.3.0
+      prefix: /software7/depot/openmpi-4.0.5
+
+### All other external packages listed alphabetically
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.16.1
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.30.117
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.30
+      prefix: /usr
+  curl:
+    externals:
+    - spec: curl@7.61.1
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.39.2+tcltk
+      prefix: /software8/depot/git-2.39.2
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.3.0
+      prefix: /software8/depot/git-2.39.2
+  gmake:
+    externals:
+    - spec: gmake@4.2.1
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.3
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  openssh:
+    externals:
+    - spec: openssh@8.0p1
+      prefix: /usr
+  # Don't use external openssl, too old
+  #openssl:
+  #  externals:
+  #  - spec: openssl@1.1.1k
+  #    prefix: /usr
+  # Can't use with py-xnrl
+  #perl:
+  #  externals:
+  #  - spec: perl@5.26.3~cpanm+shared+threads
+  #    prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.4.2
+      prefix: /usr
+  subversion:
+    externals:
+    - spec: subversion@1.10.2
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.30
+      prefix: /usr
+  texinfo:
+    externals:
+    - spec: texinfo@6.5
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.19.5
+      prefix: /usr


### PR DESCRIPTION
### Summary

Add site config for sandy (tier1). We don't provide more information in the auto-generated documentation on install locations etc, just the site config (same as for atlantis).

### Testing

Built NEPTUNE standalone environment with Python modules with `gcc@9.3.0`.

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
