### PR TITLE
Update Orion's gcc compiler path.

### DIFF
--- a/configs/sites/tier1/orion/compilers.yaml
+++ b/configs/sites/tier1/orion/compilers.yaml
@@ -22,10 +22,10 @@ compilers:
 - compiler:
     spec: gcc@12.2.0
     paths:
-      cc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gcc
-      cxx: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/g++
-      f77: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
-      fc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+      cc: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/gcc
+      cxx: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/g++
+      f77: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/gfortran
+      fc: /work/noaa/epic/role-epic/spack-stack/orion/installs/gcc/12.2.0/bin/gfortran
     flags: {}
     operating_system: rocky9
     target: x86_64


### PR DESCRIPTION
### Summary

Orion's site/compilers.yaml needed update to correct GNU path.

### Testing

User reporting problem couldn't concretize although using correct procedure. Using same procedure, concretize is working OK.

### Applications affected

None

### Systems affected

Orion

### Dependencies

None

### Issue(s) addressed

Fixes #1223 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
