### PR TITLE
Update esmf from 8.7.0b04 to 8.7.0b11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/esmf_870b11
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/esmf_870b11
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -147,6 +147,8 @@ modules:
           ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
           ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
+          ^esmf@8.7.0b11~debug snapshot=b04: 'esmf-8.7.0b11'
+          ^esmf@8.7.0b11+debug snapshot=b04: 'esmf-8.7.0b11-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -149,6 +149,8 @@ modules:
           ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0b04~debug snapshot=b04: 'esmf-8.7.0b04'
           ^esmf@8.7.0b04+debug snapshot=b04: 'esmf-8.7.0b04-debug'
+          ^esmf@8.7.0b11~debug snapshot=b04: 'esmf-8.7.0b11'
+          ^esmf@8.7.0b11+debug snapshot=b04: 'esmf-8.7.0b11-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,7 +54,7 @@
     esmf:
       require:
         - '~xerces ~pnetcdf +shared +external-parallelio'
-        - any_of: ['@=8.6.1 snapshot=none', '@=8.7.0b04 snapshot=b04']
+        - any_of: ['@=8.6.1 snapshot=none', '@=8.7.0b11 snapshot=b11']
         - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
           when: "%intel"
           message: "Extra ESMF compile options for Intel"

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,7 +14,7 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.7.0b04
+    - jedi-neptune-env      ^esmf@=8.7.0b11
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
     - soca-env
@@ -25,7 +25,7 @@ spack:
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
-    - esmf@=8.7.0b04 snapshot=b04
+    - esmf@=8.7.0b11 snapshot=b11
 
   specs:
   - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -17,11 +17,11 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.7.0b04
+    - jedi-neptune-env      ^esmf@=8.7.0b11
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env ~python   ^esmf@=8.7.0b04
+    - neptune-env ~python   ^esmf@=8.7.0b11
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.6.1
     - ufs-weather-model-env ^esmf@=8.6.1
@@ -32,7 +32,7 @@ spack:
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
-    - esmf@=8.7.0b04 snapshot=b04
+    - esmf@=8.7.0b11 snapshot=b11
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5


### PR DESCRIPTION
### Summary

This PR replaces esmf@8.7.0b04 (where currently in use) with 8.7.0b11 - this is the freeze tag for the soon-to-be-created official 8.7.0 release.

### Testing

- [x]  CI
- [x] Manual testing of NEPTUNE with esmf@8.7.0b11

### Applications affected

NEPTUNE, JEDI-NEPTUNE

### Systems affected

NRL systems

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/458

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1232

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
