### PR TITLE
Fixed path to git-lfs on Orion

### DIFF
--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -86,7 +86,7 @@ packages:
   git-lfs:
     externals:
     - spec: git-lfs@3.1.2
-      prefix: /apps/spack-managed/gcc-11.3.1/git-lfs-3.1.2
+      prefix: /apps/spack-managed/gcc-11.3.1/git-lfs-3.1.2-sjfqfgha27na65g3lrcqamncnryjoa7l
   gmake:
     externals:
     - spec: gmake@4.3


### PR DESCRIPTION
### Summary

This PR, so far, fixes the path to the external git-lfs package for the Orion configuration.

### Testing

I successfully built spack-stack ue-gcc environment using a recent develop branch and found the faulty git-lfs path when trying to run ecbuild for jedi-bundle.

### Applications affected

UFS, JEDI

### Systems affected

Orion

### Dependencies

None

### Issue(s) addressed

Resolves #1235

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
