### PR TITLE
Fix Hera Intel MPI config

### DIFF
--- a/configs/sites/tier1/hera/packages.yaml
+++ b/configs/sites/tier1/hera/packages.yaml
@@ -49,17 +49,9 @@ packages:
     externals:
     - spec: findutils@4.5.11
       prefix: /usr
-  flex:
-    externals:
-    - spec: flex@2.5.37+lex
-      prefix: /usr
   gawk:
     externals:
     - spec: gawk@4.0.2
-      prefix: /usr
-  gettext:
-    externals:
-    - spec: gettext@0.19.8.1
       prefix: /usr
   ghostscript:
     externals:

--- a/configs/sites/tier1/hera/packages_intel.yaml
+++ b/configs/sites/tier1/hera/packages_intel.yaml
@@ -14,6 +14,7 @@ packages:
     - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
       modules:
       - impi/2022.1.2
+      prefix: /apps/oneapi
   intel-oneapi-mkl:
     # Remove buildable: False and uncomment externals section below to use intel-oneapi-mkl
     buildable: False


### PR DESCRIPTION
### Summary

The `prefix: /apps/oneapi` config for intel-oneapi-mpi for Hera got lost in the Intel MKL PR. This PR brings it back. Without it: `==> Error: RuntimeError: /apps/oneapi/mpi/2021.5.1/mpi/2021.5.1/include does not exist`

Also, flex doesn't build with external gettext, so this PR removes external gettext and flex for Hera.

### Testing

Tested on Hera.

### Applications affected

all

### Systems affected

Hera

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
