### PR TITLE
Add 'py-dask +delayed' to gmao-swell-env (so that it is in unified env)

### DIFF
--- a/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
@@ -45,10 +45,13 @@ class GmaoSwellEnv(BundlePackage):
     depends_on("py-urllib3", type="run")
     depends_on("py-wheel", type="run")
     depends_on("py-setuptools", type="run")
-
-    # Different versions than other bundles
-    depends_on("py-pycodestyle@2.10:", type="run")
-    depends_on("py-pyyaml@6:", type="run")
+    depends_on("py-pycodestyle", type="run")
+    depends_on("py-pyyaml", type="run")
+    # Note that the +delayed option is for compatibility
+    # with the py-xnrl package (this restricts py-dask
+    # to certain versions, since the newest versions
+    # don't have that option anymore.
+    depends_on("py-dask +delayed", type="run")
 
     # Future dependencies needed
     # depends_on("py-bokeh", type="run")

--- a/spack-ext/repos/spack-stack/packages/py-xnrl/package.py
+++ b/spack-ext/repos/spack-stack/packages/py-xnrl/package.py
@@ -27,6 +27,8 @@ class PyXnrl(PythonPackage):
     depends_on("py-poetry", type="build")
 
     depends_on("py-metpy", type=("build", "run"))
+    # Note: if the +delayed option is removed, also
+    # need to remove it from gmao-swell-env.
     depends_on("py-dask +delayed", type=("build", "run"))
     depends_on("py-h5netcdf", type=("build", "run"))
     depends_on("py-netcdf4", type=("build", "run"))


### PR DESCRIPTION
### Summary

Add 'py-dask +delayed' to gmao-swell-env (so that it is in the unified environment, as requested by GMAO originally) and add comments in that package and in py-xnrl about the `+delayed` variant. Because this variant affects which versions of `py-dask` can be used, we should modify both packages at the same time. At the moment, we still need the `+delayed` variant in `py-xnrl`.

### Testing

- [x]  CI

### Applications affected

All using unified environment

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

Resolves #1222 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
