### PR TITLE
global-workflow-env: py-wxflow when +python

### DIFF
--- a/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
@@ -47,6 +47,6 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("metplus")
     depends_on("gsi-ncdiag")
     depends_on("crtm@2.4.0.1")
-    depends_on("py-wxflow")
+    depends_on("py-wxflow", when="+python")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

This PR makes global-workflow-env's dependency on py-wxflow dependent on +python.

### Testing

none

### Applications affected

Global Workflow

### Systems affected

all

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
