### PR TITLE
Add py-fortranformat to neptune-env

### DIFF
--- a/spack-ext/repos/spack-stack/packages/neptune-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-env/package.py
@@ -55,5 +55,6 @@ class NeptuneEnv(BundlePackage):
         depends_on("py-xarray", type="run")
         depends_on("py-xnrl", type="run")
         depends_on("py-pytest", type="run")
+        depends_on("py-fortranformat", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
Add the package py-fortranformat to neptune-env. Note that neptune-env as loaded by the unified environment template is the ~python variant so this package had to be modified manually.

### Testing

This was tested un a Ubuntu system. Testing is ongoing and I'll update this PR from a draft to a full PR when testing is done.

### Issue(s) addressed

Fixes #1229
Note the container update will be made in a separate PR.

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
