### PR TITLE
Bump g2 to 3.5.1 and g2tmpl to 1.13.0 in `configs/containers/specs/jedi-ci.yaml`

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -78,7 +78,8 @@ packages:
   freetype:
     require: '+pic'
   g2:
-    require: '@3.5.1'
+    require:
+    - '@3.5.1'
   g2c:
     require: '@1.6.4'
   g2tmpl:

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -37,6 +37,12 @@ spack:
       externals:
       - spec: gcc@9.4.0
         prefix: /usr
+    g2:
+      # https://github.com/NOAA-EMC/NCEPLIBS-g2/issues/745
+      require:
+        - any_of: ['fflags="-fno-range-check"']
+          when: "@3.5.1 %clang"
+          message: "Extra g2 compile options for version 3.5.1 with clang"
     g2tmpl:
       # https://github.com/JCSDA/spack-stack/issues/525
       require:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -2,7 +2,7 @@
   specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.1, ecbuild@3.7.2, eccodes@2.33.0, ecflow@5,
     eckit@1.24.5, ecmwf-atlas@0.38.1 +fckit +trans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
-    eigen@3.4.0, fckit@0.11.0, fms@2024.02, g2@3.4.9, g2tmpl@1.10.2,
+    eigen@3.4.0, fckit@0.11.0, fms@2024.02, g2@3.5.1, g2tmpl@1.13.0,
     gsibec@1.2.1, hdf@4.2.15, hdf5@1.14.3, ip@5.0.0, jasper@2.0.32, jedi-cmake@1.4.0,
     libpng@1.6.37, nccmp@1.9.0.1, netcdf-c@4.9.2, netcdf-cxx4@4.3.1, netcdf-fortran@4.6.1,
     parallelio@2.6.2, parallel-netcdf@1.12.3, py-eccodes@1.5.0, py-f90nml@1.4.3,


### PR DESCRIPTION
### Summary

Yesterday's update of `g2` and `g2tmpl` in `configs/common/packages.yaml` didn't make it into `configs/containers/specs/jedi-ci.yaml`. This PR fixes it.

### Testing

- No CI testing needed
- Manual testing of containers using `workflow_dispatch` or nightly testing deferred to PR #1239, which overhauls the container builds for JEDI CI

### Applications affected

JEDI CI

### Systems affected

JEDI CI containers

### Dependencies

n/a

### Issue(s) addressed

Resolves #1260 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
