### PR TITLE
Update BUFR to 12.1.0

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -19,7 +19,7 @@ packages:
   boost:
     require: '@1.84 ~atomic +chrono +date_time +exception +filesystem ~graph ~iostreams ~locale ~log ~math ~mpi ~numpy +pic +program_options +python ~random +regex +serialization ~signals +system +test +thread +timer ~wave cxxstd=17 visibility=hidden'
   bufr:
-    require: '@12.0.1 +python'
+    require: '@12.1.0 +python'
   cairo:
     require: '+pic'
   cdo:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -1,6 +1,6 @@
   ### spack-stack-1.6.0 / skylab-7.x.y containers for fv3-jedi and mpas-jedi (but not for ufs-jedi)
   specs: [base-env@1.0.0, jedi-base-env@1.0.0, ewok-env@1.0.0, jedi-fv3-env@1.0.0,
-    jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.0.1, ecbuild@3.7.2, eccodes@2.33.0, ecflow@5,
+    jedi-mpas-env@1.0.0, bacio@2.4.1, bison@3.8.2, bufr@12.1.0, ecbuild@3.7.2, eccodes@2.33.0, ecflow@5,
     eckit@1.24.5, ecmwf-atlas@0.38.1 +fckit +trans +tesselation +fftw, fiat@1.2.0, ectrans@1.2.0 +fftw,
     eigen@3.4.0, fckit@0.11.0, fms@2024.02, g2@3.4.9, g2tmpl@1.10.2,
     gsibec@1.2.1, hdf@4.2.15, hdf5@1.14.3, ip@5.0.0, jasper@2.0.32, jedi-cmake@1.4.0,

--- a/configs/templates/gsi-addon-dev/spack.yaml
+++ b/configs/templates/gsi-addon-dev/spack.yaml
@@ -15,7 +15,7 @@ spack:
   # Note: Set 'compilers' manually; must match upstream list
   - compilers: []
   - packages:
-    - global-workflow-env ^bufr@11.7.0 ^metplus@3.1.1 ^met@9.1.3
+    - global-workflow-env ^metplus@3.1.1 ^met@9.1.3
     - ufs-weather-model-env
     - gsi-env
 


### PR DESCRIPTION
### Summary

Describe the changes made in this PR and why they are needed.

### Testing

Concretized on Hera, currently building in `/scratch1/NCEPDEV/global/David.Huber/SPACK/ss_bufr_12.1/envs/unified_bufr12.1`.

### Applications affected

JEDI, global-workflow, GSI, GDASApp

### Systems affected

All

### Dependencies

None
### Issue(s) addressed

#1060 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.