### PR TITLE
Redefine variants in neptune-env virtual package

### DIFF
--- a/spack-ext/repos/spack-stack/packages/neptune-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-env/package.py
@@ -19,7 +19,9 @@ class NeptuneEnv(BundlePackage):
 
     version("1.4.0")
 
-    variant("python", default=True, description="Build Python libraries")
+    variant("python", default=True, description="Build Python dependencies")
+    variant("espc", default=True, description="Build ESPC dependencies")
+    variant("xnrl", default=True, description="Build XNRL and its extra Python dependencies")
 
     depends_on("base-env", type="run")
 
@@ -37,9 +39,11 @@ class NeptuneEnv(BundlePackage):
     depends_on("nco", type="run")
     depends_on("mct", type="run")
 
-    # Required by ESPC
-    depends_on("fftw", type="build")
-    depends_on("netlib-lapack", type="build")
+    conflicts("+xnrl", when="~python", msg="Variant xnrl requires variant python")
+
+    with when("+espc"):
+        depends_on("fftw", type="build")
+        depends_on("netlib-lapack", type="build")
 
     with when("+python"):
         depends_on("py-f90nml", type="run")
@@ -53,8 +57,10 @@ class NeptuneEnv(BundlePackage):
         depends_on("py-pyyaml", type="run")
         depends_on("py-scipy", type="run")
         depends_on("py-xarray", type="run")
-        depends_on("py-xnrl", type="run")
         depends_on("py-pytest", type="run")
         depends_on("py-fortranformat", type="run")
+
+    with when("+xnrl"):
+        depends_on("py-xnrl", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

This PR defines three variants in the `neptune-env` virtual package: `espc`, `python`, `xnrl`. In the unified environment and in the skylab environment, the variants `espc` and `xnrl` are off, the `python` variant is on. This is so that `py-fortranformat` is available in those environments (required by `pyiri-jedi`). In the neptune standalone environment, all three variants are on. Note that the `xnrl` variant requires the `python` variant.

We can debate if we should move some of the Python packages from the `python` variant to the `xnrl` variant, but since these are in the unified environment anyway (because some other package needs them), it doesn't really matter.

### Testing

I concretize the neptune standalone environment and the unified environment on my laptop and verified that there are no duplicate packages or conflicts. I also tested that specifying `+xnrl ~python` throws an error. Further testing will be done in CI (see below).

### Applications affected

There are no changes to the neptune standalone environment, only to the unified environment and the skylab environment (if that is still used).

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

Need `py-fortranformat` in unified environment.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
