### PR TITLE
Bug fix: Configure neptune-env variants in three templates: neptune-dev, skylab-dev, unified-dev

### DIFF
--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,7 +8,7 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +python ^esmf@8.7.0b11 snapshot=b11
+      - neptune-env +espc +python +xnrl ^esmf@8.7.0b11 snapshot=b11
 
   specs:
     - matrix:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -17,6 +17,7 @@ spack:
     - jedi-neptune-env      ^esmf@=8.7.0b11 snapshot=b11
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
+    - neptune-env ~espc +python ~xnrl ^esmf@=8.7.0b11 snapshot=b11
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -21,7 +21,7 @@ spack:
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env ~python   ^esmf@=8.7.0b11 snapshot=b11
+    - neptune-env ~espc +python ~xnrl ^esmf@=8.7.0b11 snapshot=b11
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.6.1
     - ufs-weather-model-env ^esmf@=8.6.1


### PR DESCRIPTION
### Summary

This is a bug fix PR: Configure neptune-env variants in three templates: neptune-dev, skylab-dev, unified-dev. This commit must have gotten lost yesterday in https://github.com/JCSDA/spack-stack/pull/1265 - not sure how. Either way, this is how I tested it, so let's see if CI is happy with it as well.

### Testing

@climbfuji's laptop (concretized neptune standalone and unified environments)

### Applications affected

All

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

None (bug fix for #1265)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
