### PR TITLE
CI workflow ensures directories are writable before environment cleanup.

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pwd
           ls -lart
+          find ./* -type d -exec chmod u+xw {} \;
           rm -fr *
 
       - name: checkout

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pwd
           ls -lart
+          find ./* -type d -exec chmod u+xw {} \;
           rm -fr *
 
       - name: checkout

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pwd
           ls -lart
+          find ./* -type d -exec chmod u+xw {} \;
           rm -fr *
 
       - name: checkout

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pwd
           ls -lart
+          find ./* -type d -exec chmod u+xw {} \;
           rm -fr *
 
       - name: checkout


### PR DESCRIPTION
A change in https://github.com/JCSDA/spack-stack/pull/1270 uncovered a behavior where `go mod` derived package install modules cannot be removed from our scratch directory due to undesirable folder permissions. This has been observed before and golang maintainers marked the [behavior as WAI](https://github.com/golang/go/issues/35615) suggesting that people maintain these directory trees with go-language tools. In our case this is not highly feasible due to spack's intervention in the project structure meaning we must find a workaround.

The workaround here uses `find` to update directory permissions to ensure that write/execute is set on all directories in the tree. This has been tested locally but due to environment carryover we cannot ensure it has the desired effect for go packages in our CI system until it is submitted. (Ie; testing would require re-running an affected workflow and all other pull requests would still be subject to the issue and would break).

## Testing

CI tests here will exercise the code and ensure it doesn't break our existing environment.

## Issues addressed.

Bugfix for regression noted in #1270 