### PR TITLE
spack-stack-1.8.0 config for Discover

### DIFF
--- a/configs/sites/tier1/discover-scu16/modules.yaml
+++ b/configs/sites/tier1/discover-scu16/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/discover-scu16/packages.yaml
+++ b/configs/sites/tier1/discover-scu16/packages.yaml
@@ -38,13 +38,6 @@ packages:
     externals:
     - spec: diffutils@3.3
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /discover/swdev/jcsda/spack-stack/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.22
@@ -129,6 +122,7 @@ packages:
     - spec: pkg-config@0.28
       prefix: /usr
   qt:
+    buildable: False
     externals:
     - spec: qt@5.15.2
       prefix: /discover/swdev/jcsda/spack-stack/qt-5.15.2/5.15.2/gcc_64

--- a/configs/sites/tier1/discover-scu17/modules.yaml
+++ b/configs/sites/tier1/discover-scu17/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/discover-scu17/packages.yaml
+++ b/configs/sites/tier1/discover-scu17/packages.yaml
@@ -46,13 +46,6 @@ packages:
     externals:
     - spec: diffutils@3.6
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.11.4+ui+static_boost
-      prefix: /discover/swdev/jcsda/spack-stack/scu17/ecflow-5.11.4
-      modules:
-      - ecflow/5.11.4
   findutils:
     externals:
     - spec: findutils@4.8.0
@@ -119,6 +112,7 @@ packages:
     - spec: pkg-config@0.29.2
       prefix: /usr
   qt:
+    buildable: False
     externals:
     - spec: qt@5.15.10
       prefix: /usr/local/other/xpdf/4.04/Deps


### PR DESCRIPTION
### Summary

This PR provides configuration for 1.8.0 on Discover. Both SCU16 and SCU17 configurations are included.

### Testing

I've tested with SCU16, gcc and intel compilers and successfully built the gcc environment, and the intel build is still in progress (spack concretize completed successfully and spack install is still running).

### Applications affected

All applications

### Systems affected

Discover

### Dependencies

None

### Issue(s) addressed

Partially addresses #1278

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
