### PR TITLE
Pin matplotlib and numpy to 3.7.4 and 1.23.5

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -214,6 +214,8 @@ packages:
   ## To avoid duplicate packages
   #py-jinja2:
   #  require: '@3.1.2'
+  py-matplotlib:
+     require: '@3.7.4'
   py-meson-python:
      require: '@0.15.0'
   # Comment out for now until build problems are solved
@@ -228,7 +230,7 @@ packages:
   # also check Nautilus site config when making changes here
   py-numpy:
     require:
-    - '@:1.25'
+    - '@:1.23.5'
   py-pandas:
     require: '+excel'
   py-pybind11:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -214,6 +214,7 @@ packages:
   ## To avoid duplicate packages
   #py-jinja2:
   #  require: '@3.1.2'
+  # https://github.com/JCSDA/spack-stack/issues/1276
   py-matplotlib:
      require: '@3.7.4'
   py-meson-python:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -229,6 +229,7 @@ packages:
     require: '@1.5.8 ~mpi'
   # py-numpy@1.26 causes many build problems with older Python packages
   # also check Nautilus site config when making changes here
+  # https://github.com/JCSDA/spack-stack/issues/1276
   py-numpy:
     require:
     - '@:1.23.5'

--- a/configs/sites/tier1/acorn/packages_intel.yaml
+++ b/configs/sites/tier1/acorn/packages_intel.yaml
@@ -31,7 +31,7 @@
       - '@1.2.1 ~mkl'
     py-numpy:
       require::
-      - '@:1.25 ^openblas'
+      - '@:1.23 ^openblas'
     # *DH
     eckit:
       require:

--- a/configs/sites/tier1/aws-pcluster/packages_intel.yaml
+++ b/configs/sites/tier1/aws-pcluster/packages_intel.yaml
@@ -31,5 +31,5 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH

--- a/configs/sites/tier1/derecho/packages_intel.yaml
+++ b/configs/sites/tier1/derecho/packages_intel.yaml
@@ -37,6 +37,6 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH
 

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -35,7 +35,7 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH
 
 ### All other external packages listed alphabetically

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -34,7 +34,7 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH
 
 ### All other external packages listed alphabetically

--- a/configs/sites/tier1/hera/packages_intel.yaml
+++ b/configs/sites/tier1/hera/packages_intel.yaml
@@ -30,7 +30,7 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH
   zlib-ng:
     require:

--- a/configs/sites/tier1/hercules/packages_intel.yaml
+++ b/configs/sites/tier1/hercules/packages_intel.yaml
@@ -30,4 +30,4 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'

--- a/configs/sites/tier1/nautilus/packages_gcc.yaml
+++ b/configs/sites/tier1/nautilus/packages_gcc.yaml
@@ -31,4 +31,4 @@ packages:
     - '@1.2.1 +mkl'
   py-numpy:
     require::
-    - '@:1.25 ^intel-oneapi-mkl'
+    - '@:1.23 ^intel-oneapi-mkl'

--- a/configs/sites/tier1/noaa-aws/packages_intel.yaml
+++ b/configs/sites/tier1/noaa-aws/packages_intel.yaml
@@ -30,5 +30,5 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH

--- a/configs/sites/tier1/noaa-azure/packages_intel.yaml
+++ b/configs/sites/tier1/noaa-azure/packages_intel.yaml
@@ -30,5 +30,5 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH

--- a/configs/sites/tier1/noaa-gcloud/packages_intel.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages_intel.yaml
@@ -30,5 +30,5 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
   # *DH

--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -32,4 +32,4 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'

--- a/configs/sites/tier1/s4/packages.yaml
+++ b/configs/sites/tier1/s4/packages.yaml
@@ -33,7 +33,7 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
-    - '@:1.25 ^openblas'
+    - '@:1.23 ^openblas'
 
 ### All other external packages listed alphabetically
   autoconf:


### PR DESCRIPTION
### Summary

During testing of an early 1.8.0 candidate, it was found that compiling numpy v1.25.x and matplotlib v3.8.x together with Intel caused matplotlib to fail to generate basic plots that included tick marks.  Reverting the versions to 1.23.5 and 3.7.4 resolved the issue.

### Testing

@climbfuji was able to generate basic plots using this combination.
I concretized the unified-dev environment on Hera.

### Applications affected

Verif-global and most any other plotting package.

### Systems affected

All

### Dependencies

N/A

### Issue(s) addressed

#1276 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
