### PR TITLE
Pin numpy to 1.24 on Acorn

### DIFF
--- a/configs/sites/tier1/acorn/packages_intel.yaml
+++ b/configs/sites/tier1/acorn/packages_intel.yaml
@@ -31,7 +31,7 @@
       - '@1.2.1 ~mkl'
     py-numpy:
       require::
-      - '@:1.23 ^openblas'
+      - '@:1.24 ^openblas'
     # *DH
     eckit:
       require:

--- a/configs/sites/tier1/acorn/packages_intel.yaml
+++ b/configs/sites/tier1/acorn/packages_intel.yaml
@@ -39,7 +39,7 @@
         when: "%intel@19.1.3.304"
     eccodes:
       require:
-      - any_of: ["@2.27.0"]
+      - any_of: ["@2.31.0"]
         when: "%intel@19.1.3.304"
     py-scipy:
       require:

--- a/configs/sites/tier1/acorn/packages_intel.yaml
+++ b/configs/sites/tier1/acorn/packages_intel.yaml
@@ -39,7 +39,7 @@
         when: "%intel@19.1.3.304"
     eccodes:
       require:
-      - any_of: ["@2.31.0"]
+      - any_of: ["@2.25.0"]
         when: "%intel@19.1.3.304"
     py-scipy:
       require:


### PR DESCRIPTION
### Summary

This is a follow-up to #1283 where numpy was pinned to 1.23 on all platforms.  Acorn needs numpy to be pinned at 1.24.4.

### Testing

Will test on Acorn once dogwood is made available to developers.

### Applications affected

Likely all of them.

### Systems affected

Acorn

### Issue(s) addressed

References #1276 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.