### PR TITLE
Add mirror path for Hera

### DIFF
--- a/configs/sites/tier1/hera/mirrors.yaml
+++ b/configs/sites/tier1/hera/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///scratch1/NCEPDEV/nems/role.epic/spack-stack/source-cache
+      url: file:///contrib/spack-stack/mirror
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///scratch1/NCEPDEV/nems/role.epic/spack-stack/source-cache
+      url: file:///contrib/spack-stack/mirror
       access_pair:
       - null
       - null


### PR DESCRIPTION
### Summary

When installed 1.8.0, some packages were not downloaded. I used mirroring (from Hercules).

### Testing

Installed 1.8.0 on Hera (Intel and GNU) using mirrored directory from Hercules.

### Applications affected

### Systems affected

Hera.

### Dependencies

### Issue(s) addressed

Fixes #1289 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
