### PR TITLE
Allow specifying compiler version for 'spack stack create env'

### DIFF
--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -100,7 +100,7 @@ class StackEnv(object):
 
         if not self.name:
             # site = self.site if self.site else 'default'
-            self.name = "{}.{}.{}".format(self.template, self.site, self.compiler)
+            self.name = "{}.{}.{}".format(self.template, self.site, self.compiler.replace("@", "-"))
 
     def env_dir(self):
         """env_dir is <dir>/<name>"""
@@ -170,7 +170,7 @@ class StackEnv(object):
         self._copy_or_merge_includes("modules", modules_yaml_path, modules_yaml_modulesys_path, destination)
         # Merge or copy common package config(s)
         packages_yaml_path = os.path.join(common_path, "packages.yaml")
-        packages_compiler_yaml_path = os.path.join(common_path, f"packages_{self.compiler}.yaml")
+        packages_compiler_yaml_path = os.path.join(common_path, f"packages_{self.compiler.split('@')[0]}.yaml")
         destination = os.path.join(env_common_dir, "packages.yaml")
         self._copy_or_merge_includes("packages", packages_yaml_path, packages_compiler_yaml_path, destination)
 
@@ -203,7 +203,7 @@ class StackEnv(object):
         self._copy_or_merge_includes("modules", modules_yaml_path, modules_yaml_modulesys_path, destination)
         # Merge or copy site package config(s)
         packages_yaml_path = os.path.join(env_path, "packages.yaml")
-        packages_compiler_yaml_path = os.path.join(env_path, f"packages_{self.compiler}.yaml")
+        packages_compiler_yaml_path = os.path.join(env_path, f"packages_{self.compiler.split('@')[0]}.yaml")
         destination = os.path.join(env_site_dir, "packages.yaml")
         self._copy_or_merge_includes("packages", packages_yaml_path, packages_compiler_yaml_path, destination)
 
@@ -260,7 +260,7 @@ class StackEnv(object):
         # DH I am too stupid to do this the "spack way" ...
         definitions = spack.config.get("definitions", scope=env_scope)
         if definitions:
-            target_compiler = f"%{self.compiler}"
+            target_compiler = f"%{self.compiler}".split("@")[0]
             for i in range(len(definitions)):
                 if "compilers" in definitions[i]:
                     j = len(definitions[i]["compilers"])-1

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -260,14 +260,10 @@ class StackEnv(object):
         # DH I am too stupid to do this the "spack way" ...
         definitions = spack.config.get("definitions", scope=env_scope)
         if definitions:
-            target_compiler = f"%{self.compiler}".split("@")[0]
+            target_compiler = f"%{self.compiler}"
             for i in range(len(definitions)):
                 if "compilers" in definitions[i]:
-                    j = len(definitions[i]["compilers"])-1
-                    while j>=0:
-                        if not definitions[i]["compilers"][j] == target_compiler:
-                            definitions[i]["compilers"].pop(j)
-                        j -= 1
+                    definitions[i] = {"compilers": [target_compiler]}
             spack.config.set("definitions", definitions, scope=env_scope)
 
         if self.install_prefix:


### PR DESCRIPTION
### Summary

This PR borrows the logic from #1213 that allows a compiler version to be specified in `spack stack create env`. It's a couple of tweaks to stack_env.py. This isn't strictly urgent, but I'm hoping to put this in the 1.8.0 release in anticipation of supporting installations by NCO (plus maybe others will find it useful; I know it will be useful for Acorn, and maybe also for NRL?).

### Testing

Tested on Acorn and personal machine.
 - `spack stack create env --compiler gcc` correctly yields `prefer: ['%gcc']` in spack.yaml
 - `spack stack create env --compiler gcc@8.5.0` correctly yields `prefer: ['%gcc@8.5.0']` in spack.yaml
 - `spack stack create env --compiler gcc` with unspecified name correctly yields env directory with name `empty.linux.default.gcc`
 - `spack stack create env --compiler gcc@8.5.0` with unspecified name correctly yields env directory with name `empty.linux.default.gcc-8.5.0`


### Applications affected

n/a

### Systems affected

All

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
