### PR TITLE
Update ESMF from spack develop and enable python variant; fix Github actions cleanup section (not for release/1.8.0)

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -20,7 +20,9 @@ jobs:
         run: |
           pwd
           ls -lart
+          set +e
           find ./* -type d -exec chmod u+xw {} \;
+          set -e
           rm -fr *
 
       - name: checkout

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -20,7 +20,9 @@ jobs:
         run: |
           pwd
           ls -lart
+          set +e
           find ./* -type d -exec chmod u+xw {} \;
+          set -e
           rm -fr *
 
       - name: checkout

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -20,7 +20,9 @@ jobs:
         run: |
           pwd
           ls -lart
+          set +e
           find ./* -type d -exec chmod u+xw {} \;
+          set -e
           rm -fr *
 
       - name: checkout

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -20,7 +20,9 @@ jobs:
         run: |
           pwd
           ls -lart
+          set +e
           find ./* -type d -exec chmod u+xw {} \;
+          set -e
           rm -fr *
 
       - name: checkout

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/esmf_python_dependency_and_extension
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/esmf_python_dependency_and_extension
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -54,7 +54,7 @@ packages:
   # Also, check the acorn and derecho site configs which have esmf modifications.
   esmf:
     require:
-      - '~xerces ~pnetcdf +shared +external-parallelio'
+      - '~xerces ~pnetcdf +shared +external-parallelio +python'
       - any_of: ['@=8.6.1 snapshot=none', '@=8.7.0b11 snapshot=b11']
       - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
         when: "%intel"


### PR DESCRIPTION
### Summary

Update the submodule pointer for the changes in https://github.com/JCSDA/spack/pull/470 (Update ESMF from spack develop: add python dependency and extension) and enable the `python` variant in `configs/common/packages.yaml`.

Fix the cleanup section Github workflows. The `find` command returns a non-zero exit code if no files are found, causing the CI run to abort. See https://github.com/JCSDA/spack-stack/actions/runs/10942526277 for an example. Wrapping this `find` command in `set +e` / `set -e` section resolves this. 

### Testing

- [x] CI
- [x] Built ESMF with `python` variant enabled on my laptop and tested importing the ESMPy module in Python

### Applications affected

All using ESMF

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/470

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1163
Resolves https://github.com/JCSDA/spack-stack/issues/1243

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
