### PR TITLE
Add site config for tier2 machine bounty and update doc/source/NewSiteConfigs.rst for Ubuntu

### DIFF
--- a/configs/sites/tier2/blackpearl/README.md
+++ b/configs/sites/tier2/blackpearl/README.md
@@ -1,3 +1,1 @@
-Blackpearl is @climbfuji's development system (Dell Laptop running Oracle Linux 9.1 under Windows WSL2).
-
-The site config currently requires a manual copy of the correct packages_COMPILER.yaml to the environment site directory. This will be improved later.
+Blackpearl is one of @climbfuji's development systems (Dell Laptop running Oracle Linux 9.1 under Windows WSL2).

--- a/configs/sites/tier2/bounty/README.md
+++ b/configs/sites/tier2/bounty/README.md
@@ -1,0 +1,1 @@
+Blackpearl is one of @climbfuji's development systems (Dell Laptop running Ubuntu Linux 22.04 under Windows WSL2).

--- a/configs/sites/tier2/bounty/README.md
+++ b/configs/sites/tier2/bounty/README.md
@@ -1,1 +1,1 @@
-Blackpearl is one of @climbfuji's development systems (Dell Laptop running Ubuntu Linux 22.04 under Windows WSL2).
+Bounty is one of @climbfuji's development systems (Dell Laptop running Ubuntu Linux 22.04 under Windows WSL2).

--- a/configs/sites/tier2/bounty/compilers.yaml
+++ b/configs/sites/tier2/bounty/compilers.yaml
@@ -1,0 +1,27 @@
+compilers:
+- compiler:
+    spec: gcc@=11.4.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu22.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@=12.3.0
+    paths:
+      cc: /usr/bin/gcc-12
+      cxx: /usr/bin/g++-12
+      f77: /usr/bin/gfortran-12
+      fc: /usr/bin/gfortran-12
+    flags: {}
+    operating_system: ubuntu22.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/configs/sites/tier2/bounty/config.yaml
+++ b/configs/sites/tier2/bounty/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 4

--- a/configs/sites/tier2/bounty/mirrors.yaml
+++ b/configs/sites/tier2/bounty/mirrors.yaml
@@ -1,0 +1,2 @@
+mirrors:
+  local-source: file:///home/dom/prod/spack-source-cache

--- a/configs/sites/tier2/bounty/modules.yaml
+++ b/configs/sites/tier2/bounty/modules.yaml
@@ -1,0 +1,10 @@
+modules:
+  default:
+    enable::
+    - tcl
+    tcl:
+      include:
+      # List of packages for which we need modules that are blacklisted by default
+      - openmpi
+      - mpich
+      - python

--- a/configs/sites/tier2/bounty/packages.yaml
+++ b/configs/sites/tier2/bounty/packages.yaml
@@ -1,0 +1,73 @@
+packages:
+  autoconf:
+    externals:
+    - spec: autoconf@2.71
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.16.5
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.38
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.32
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.8
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.8.0
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@5.1.0
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.21
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.34.1~tcltk
+      prefix: /usr
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.0.2
+      prefix: /usr
+  gmake:
+    externals:
+    - spec: gmake@4.3
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.4
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.34.0~cpanm+opcode+open+shared+threads
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.8
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.34
+      prefix: /usr
+  texlive:
+    externals:
+    - spec: texlive@20220321
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.21.2
+      prefix: /usr

--- a/configs/sites/tier2/bounty/packages_gcc.yaml
+++ b/configs/sites/tier2/bounty/packages_gcc.yaml
@@ -1,0 +1,5 @@
+packages:
+  all:
+    compiler:: [gcc@12.3.0]
+    providers:
+      mpi:: [openmpi@5.0.3]

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -393,7 +393,6 @@ The following instructions were used to prepare a basic Red Hat 8 system as it i
    yum -y install patch
    yum -y install automake
    yum -y install xorg-x11-xauth
-   yum -y install xterm
    yum -y install perl-IPC-Cmd
    yum -y install gettext-devel
    yum -y install texlive
@@ -459,20 +458,14 @@ The following instructions were used to prepare a basic Ubuntu 20.04 or 22.04 LT
    apt install -y automake
    apt install -y autopoint
    apt install -y gettext
-   apt install -y xterm
    apt install -y texlive
    apt install -y libcurl4-openssl-dev
    apt install -y libssl-dev
-   apt install -y meson
-   apt install -y bison
 
    # Note - only needed for running JCSDA's
    # JEDI-Skylab system (using R2D2 localhost)
    apt install -y mysql-server
    apt install -y libmysqlclient-dev
-
-   # Python
-   apt install -y python3-dev python3-pip
 
    # Exit root session
    exit

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -393,6 +393,7 @@ The following instructions were used to prepare a basic Red Hat 8 system as it i
    yum -y install patch
    yum -y install automake
    yum -y install xorg-x11-xauth
+   yum -y install xterm
    yum -y install perl-IPC-Cmd
    yum -y install gettext-devel
    yum -y install texlive


### PR DESCRIPTION
### Summary

(for develop)

1. Update `doc/source/NewSiteConfigs.rst` for Ubuntu: - don't install meson and bison via apt anymore
2. Add site config for tier2 system bounty

### Testing

Built unified environment with gcc@12.3.0 on new system following the updated instructions.

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
