### PR TITLE
Adding py-ruamel modules for gmao-swell-env

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -233,6 +233,9 @@ packages:
     require: '+excel'
   py-pybind11:
     require: '@2.11.0'
+  # To avoid duplicate packages
+  py-ruamel-yaml:
+    require: '@0.17.32'
   # Pin the py-setuptools version to avoid duplicate Python packages
   py-setuptools:
     require: '@63.4.3'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -235,7 +235,7 @@ packages:
     require: '@2.11.0'
   # To avoid duplicate packages
   py-ruamel-yaml:
-    require: '@0.17.32'
+    require: '@0.17.16'
   # Pin the py-setuptools version to avoid duplicate Python packages
   py-setuptools:
     require: '@63.4.3'

--- a/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
@@ -47,6 +47,8 @@ class GmaoSwellEnv(BundlePackage):
     depends_on("py-setuptools", type="run")
     depends_on("py-pycodestyle", type="run")
     depends_on("py-pyyaml", type="run")
+    depends_on("py-ruamel-yaml", type="run")
+    depends_on("py-ruamel-yaml-clib", type="run")
     # Note that the +delayed option is for compatibility
     # with the py-xnrl package (this restricts py-dask
     # to certain versions, since the newest versions


### PR DESCRIPTION
### Summary

This PR adds `py-ruamel-yaml` and `py-ruamel-yaml-clib` to the gmao-swell-env. 

### Testing

Describe the testing done for this PR.

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.

### Systems affected

List all systems intentionally or unintentionally affected by this PR.

### Dependencies

None

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1253

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
