### PR TITLE
Update changes to 1.6.0 for machines that switched to Rocky OS

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -190,7 +190,7 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB': '{prefix}/bin/wgrib2'
+            'WGRIB': '{prefix}/bin/wgrib'
       landsfcutil:
         environment:
           set:
@@ -259,6 +259,8 @@ modules:
 
       hierarchy:
       - mpi
+      - g2virt
+      - g2tmplvirt
 
     prefix_inspections:
       bin:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -192,7 +192,7 @@ modules:
             'TOCGRIB': '{prefix}/bin/tocgrib'
             'TOCGRIB2': '{prefix}/bin/tocgrib2'
             'TOCGRIB2SUPER': '{prefix}/bin/tocgrib2super'
-            'WGRIB': '{prefix}/bin/wgrib2'
+            'WGRIB': '{prefix}/bin/wgrib'
       landsfcutil:
         environment:
           set:

--- a/configs/sites/hera/compilers.yaml
+++ b/configs/sites/hera/compilers.yaml
@@ -7,7 +7,7 @@ compilers:
       f77: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
       fc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     modules:
     - intel/2022.1.2
     environment:
@@ -24,7 +24,7 @@ compilers:
       f77: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
       fc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     modules:
     - intel/18.0.5.274
 - compiler:

--- a/configs/sites/hera/compilers.yaml
+++ b/configs/sites/hera/compilers.yaml
@@ -35,7 +35,7 @@ compilers:
       f77: /apps/gnu/gcc-9.2.0/bin/gfortran
       fc:  /apps/gnu/gcc-9.2.0/bin/gfortran
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     modules:
     - gnu/9.2.0
     environment: {}

--- a/configs/sites/hera/packages.yaml
+++ b/configs/sites/hera/packages.yaml
@@ -45,10 +45,6 @@ packages:
     externals:
     - spec: berkeley-db@5.3.21
       prefix: /usr
-  bzip2:
-    externals:
-    - spec: bzip2@1.0.6
-      prefix: /usr
   cpio:
     externals:
     - spec: cpio@2.11
@@ -116,10 +112,6 @@ packages:
     externals:
     - spec: openjdk@1.8.0_312-b07
       prefix: /usr
-  krb5:
-    externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
   libfuse:
     externals:
     - spec: libfuse@2.9.2
@@ -183,11 +175,10 @@ packages:
     externals:
     - spec: wget@1.14
       prefix: /usr
-  xz:
-    externals:
-    - spec: xz@5.2.2
-      prefix: /usr
   zip:
     externals:
     - spec: zip@3.0
       prefix: /usr
+
+  zlib:
+    require: ["~shared"]

--- a/configs/sites/jet/compilers.yaml
+++ b/configs/sites/jet/compilers.yaml
@@ -7,7 +7,7 @@ compilers:
       f77: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
       fc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     modules:
     - intel/2022.1.2
     environment:
@@ -24,7 +24,7 @@ compilers:
       f77: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
       fc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     modules:
     - intel/18.0.5.274
 - compiler:
@@ -35,7 +35,7 @@ compilers:
       f77: /apps/gnu/gcc-9.2.0/bin/gfortran
       fc:  /apps/gnu/gcc-9.2.0/bin/gfortran
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     modules:
     - gnu/9.2.0
     environment: {}

--- a/configs/sites/jet/mirrors.yaml
+++ b/configs/sites/jet/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/source-cache
+      url: file:///contrib/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/source-cache
+      url: file:///contrib/spack-stack/source-cache
       access_pair:
       - null
       - null

--- a/configs/sites/jet/mirrors.yaml
+++ b/configs/sites/jet/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///contrib/spack-stack/source-cache
+      url: file:///mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///contrib/spack-stack/source-cache
+      url: file:///mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/source-cache
       access_pair:
       - null
       - null

--- a/configs/sites/jet/packages.yaml
+++ b/configs/sites/jet/packages.yaml
@@ -46,10 +46,6 @@ packages:
     externals:
     - spec: berkeley-db@5.3.21
       prefix: /usr
-  bzip2:
-    externals:
-    - spec: bzip2@1.0.6
-      prefix: /usr
   cpio:
     externals:
     - spec: cpio@2.11
@@ -121,10 +117,6 @@ packages:
     externals:
     - spec: openjdk@1.8.0_322-b06
       prefix: /usr
-  krb5:
-    externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
   libfuse:
     externals:
     - spec: libfuse@2.9.2
@@ -145,13 +137,11 @@ packages:
     buildable: False
     externals:
     - spec: mysql@8.0.31
-      prefix: /lfs4/HFIP/hfv3gfs/role.epic/apps/mysql-8.0.31
+      prefix: /contrib/spack-stack/installs/mysql-8.0.31
       modules:
       - mysql/8.0.31
   ncurses:
     externals:
-    - spec: ncurses@6.3.20211021+termlib abi=6
-      prefix: /lfs4/HFIP/hfv3gfs/Kyle.Gerheiser/miniconda/miniconda-3.9.7
     - spec: ncurses@5.9.20130511+termlib abi=5
       prefix: /usr
   perl:
@@ -186,11 +176,9 @@ packages:
     externals:
     - spec: wget@1.14
       prefix: /usr
-  xz:
-    externals:
-    - spec: xz@5.2.5
-      prefix: /lfs4/HFIP/hfv3gfs/Kyle.Gerheiser/miniconda/miniconda-3.9.7
   zip:
     externals:
     - spec: zip@3.0
       prefix: /usr
+  zlib:
+    require: ["~shared"]

--- a/configs/sites/noaa-aws/README.md
+++ b/configs/sites/noaa-aws/README.md
@@ -52,24 +52,14 @@ exit
 
 # Build external packages for spack-stack
 
-mkdir -p /contrib/spack-stack
+mkdir -p /contrib/spack-stack-rocky8
 mkdir /contrib/spack-stack/modulefiles
-cd /contrib/spack-stack/
 
-mkdir -p git-lfs-2.4.1/src
-cd git-lfs-2.4.1/src
-wget http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/r/rh-git218-git-lfs-2.4.1-3.el7.x86_64.rpm
-rpm2cpio rh-git218-git-lfs-2.4.1-3.el7.x86_64.rpm | cpio -idmv
-mv opt/rh/rh-git218/root/usr/* ..
-rm -fr opt
-cd /contrib/spack-stack/modulefiles
-mkdir git-lfs
 # Create the modulefile from the template in doc/modulefile_templates
 
-cd /contrib/spack-stack/
+cd /contrib/spack-stack-rocky8
 mkdir -p mysql-8.0.31/src
 cd mysql-8.0.31/src
-ldd --version
 wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.31-linux-glibc2.17-x86_64-minimal.tar.xz
 tar -xvf mysql-8.0.31-linux-glibc2.17-x86_64-minimal.tar.xz
 mv mysql-8.0.31-linux-glibc2.17-x86_64-minimal/* ..
@@ -78,37 +68,20 @@ cd /contrib/spack-stack/modulefiles
 mkdir mysql
 # Create the modulefile from the template in doc/modulefile_templates
 
-cd /contrib/spack-stack/
-mkdir -p cmake-3.27.2/src
-cd cmake-3.27.2/src
-wget https://github.com/Kitware/CMake/releases/download/v3.27.2/cmake-3.27.2-linux-x86_64.tar.gz
-tar -xvzf cmake-3.27.2-linux-x86_64.tar.gz
-mv cmake-3.27.2-linux-x86_64/* ..
-rmdir cmake-3.27.2-linux-x86_64
-cd /contrib/spack-stack/modulefiles
-mkdir cmake
-# Create the modulefile from the template in doc/modulefile_templates
 
 # Set up basic modules for building the external ecflow package
-module unuse /opt/cray/craype/default/modulefiles
-module unuse /opt/cray/modulefiles
-
-module purge
-module load gnu/9.2.0
-module use /contrib/spack-stack/modulefiles
-module load cmake/3.27.2
-
-mkdir -p /contrib/spack-stack/ecflow-5.8.4/src
-cd /contrib/spack-stack/ecflow-5.8.4/src
+mkdir -p /contrib/spack-stack-rocky8/ecflow-5.8.4/src
+cd /contrib/spack-stack-rocky8/ecflow-5.8.4/src
 wget https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.4-Source.tar.gz?api=v2
 wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
 mv ecFlow-5.8.4-Source.tar.gz\?api\=v2 ecFlow-5.8.4-Source.tar.gz
 tar -xvzf boost_1_78_0.tar.gz
 tar -xvzf ecFlow-5.8.4-Source.tar.gz
-export WK=/contrib/spack-stack/ecflow-5.8.4/src/ecFlow-5.8.4-Source
-export BOOST_ROOT=/contrib/spack-stack/ecflow-5.8.4/src/boost_1_78_0
+export WK=/contrib/spack-stack-rocky8/ecflow-5.8.4/src/ecFlow-5.8.4-Source
+export BOOST_ROOT=/contrib/spack-stack-rocky8/ecflow-5.8.4/src/boost_1_78_0
 
 # Build static boost (to not interfere with spack-stack boost)
+# Note that the default compiler supplied with the OS is used
 cd $BOOST_ROOT
 ./bootstrap.sh 2>&1 | tee bootstrap.log
 $WK/build_scripts/boost_build.sh 2>&1 | tee boost_build.log
@@ -117,21 +90,51 @@ $WK/build_scripts/boost_build.sh 2>&1 | tee boost_build.log
 cd $WK
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/contrib/spack-stack/ecflow-5.8.4 2>&1 | tee log.cmake
+cmake .. -DPython3_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=/contrib/spack-stack-rocky8/ecflow-5.8.4 2>&1 | tee log.cmake
 make -j4 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
-cd /contrib/spack-stack/modulefiles
-mkdir ecflow
+cd /contrib/spack-stack-rocky8/
+mkdir -p ./modulefiles/ecflow
 # Create the modulefile from the template in doc/modulefile_templates
+
 
 ############## Steps to perform when starting a new cluster ##############
 source /contrib/admin/basic_setup.sh  # sudo privileges requred to install packages
+module purge
 module unuse /opt/cray/craype/default/modulefiles
 module unuse /opt/cray/modulefiles
-module use /contrib/spack-stack/modulefiles
-module load cmake/3.27.2
+
+# For noaa-aws, run the line below as well:
+module unuse /opt/intel/impi/2019.5.281/intel64/modulefiles
+module use /contrib/spack-stack-rocky8/modulefiles
+
+# Loading modules
+# 
 module load ecflow/5.8.4
 module load mysql/8.0.31
-module load git-lfs/2.4.1
 
+module load gnu
+module load intel/2023.2.0
+module load impi/2023.2.0 
+module unload gnu
+
+cd /contrib/spack-stack-rocky8/spack-stack-1.6.0
+source setup.sh
+## Create spack-stack environment, use the CSP name as needed:
+## set CLOUD variable to noaa-aws, noaa-gcloud, or noaa-azure
+CLOUD=noaa-aws
+spack stack create env --site $CLOUD --template unified-dev --name ue-intel
+cd envs/ue-intel
+spack env activate .
+
+############## spack.yaml edits:
+edit spack.yaml:
+#  1) leave only "%intel" in "compilers" definitions
+#  2) replace ^esmf@8.5.0  by ^esmf@8.6.0 under definitions,
+#       except for the Various esmf/mapl tags section
+
+spack concretize 2>&1 | tee log.concretize
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
+spack module lmod refresh
+spack stack setup-meta-modules

--- a/configs/sites/noaa-aws/compilers.yaml
+++ b/configs/sites/noaa-aws/compilers.yaml
@@ -1,32 +1,17 @@
 compilers:
 - compiler:
-    spec: intel@2021.3.0
+    spec: intel@2021.10.0
     paths:
-      cc: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/icc
-      cxx: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/icpc
-      f77: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/ifort
-      fc: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
+      cc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icc
+      cxx: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icpc
+      f77: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+      fc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+    operating_system: rocky8
     target: x86_64
     modules:
-    - intel/2021.3.0
+    - intel/2023.2.0
     environment:
       prepend_path:
-        PATH: '/apps/gnu/gcc-9.2.0/bin'
-        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-9.2.0/lib64'
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.2.0
-    paths:
-      cc: /apps/gnu/gcc-9.2.0/bin/gcc
-      cxx: /apps/gnu/gcc-9.2.0/bin/g++
-      f77: /apps/gnu/gcc-9.2.0/bin/gfortran
-      fc: /apps/gnu/gcc-9.2.0/bin/gfortran
+        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-13.2.0/lib64'
     flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - gnu/9.2.0
-    environment: {}
     extra_rpaths: []

--- a/configs/sites/noaa-aws/packages.yaml
+++ b/configs/sites/noaa-aws/packages.yaml
@@ -1,63 +1,58 @@
 packages:
   all:
-    compiler:: [intel@2021.3.0, gcc@9.2.0]
+    compiler:: [intel@2021.10.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.3.0, openmpi@3.1.4]
+      mpi:: [intel-oneapi-mpi@2021.10.0]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.3.0%intel@2021.3.0
+    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0
       prefix: /apps/oneapi
       modules:
-      - impi/2021.3.0
-  openmpi:
-    externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0
-      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
-      modules:
-      - openmpi/3.1.4
+      - impi/2023.2.0
 
 ### Modifications of common packages
-  # Pin flex to avoid duplicate packages
-  flex:
-    version: ['2.6.4']
 
 ### All other external packages listed alphabetically
   bash:
     externals:
-    - spec: bash@4.2.46
+    - spec: bash@4.4.20
       prefix: /usr
   berkeley-db:
     externals:
-    - spec: berkeley-db@5.3.21
+    - spec: berkeley-db@5.3.28
       prefix: /usr
   cpio:
     externals:
-    - spec: cpio@2.11
+    - spec: cpio@2.12
       prefix: /usr
   diffutils:
     externals:
-    - spec: diffutils@3.3
+    - spec: diffutils@3.6
       prefix: /usr
   ecflow:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack/ecflow-5.8.4
+      prefix: /contrib/spack-stack-rocky8/ecflow-5.8.4
   file:
     externals:
-    - spec: file@5.11
+    - spec: file@5.33
       prefix: /usr
   findutils:
     externals:
-    - spec: findutils@4.5.11
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1
       prefix: /usr
   gawk:
     externals:
-    - spec: gawk@4.0.2
+    - spec: gawk@4.2.1
       prefix: /usr
   gettext:
     externals:
@@ -65,73 +60,75 @@ packages:
       prefix: /usr
   git:
     externals:
-    - spec: git@1.8.3.1~tcltk
+    - spec: git@2.39.3~tcltk
       prefix: /usr
   git-lfs:
     externals:
-    - spec: git-lfs@2.4.1
-      prefix: /contrib/spack-stack/git-lfs-2.4.1
+    - spec: git-lfs@3.2.0
+      prefix: /usr
   gmake:
     externals:
-    - spec: gmake@3.82
+    - spec: gmake@4.2.1
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.2
+    - spec: groff@1.21
       prefix: /usr
   hwloc:
     externals:
-    - spec: hwloc@1.11.8
+    - spec: hwloc@2.2.0
       prefix: /usr
   krb5:
     externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
-  lustre:
-    externals:
-    - spec: lustre@2.12.7
+    - spec: krb5@1.18.2
       prefix: /usr
   mysql:
     externals:
     - spec: mysql@8.0.31
       prefix: /contrib/spack-stack/mysql-8.0.31
+  ncurses:
+    externals:
+    - spec: ncurses@6.1-10.20180224+termlib abi=5
+      prefix: /usr
   openjdk:
     externals:
-    - spec: openjdk@1.8.0_322-b06
+    - spec: openjdk@1.8.0_402-b06
       prefix: /usr
   perl:
     externals:
-    - spec: perl@5.16.3~cpanm+shared+threads
+    - spec: perl@5.26.3~cpanm+shared+threads
       prefix: /usr
   pkg-config:
     externals:
-    - spec: pkg-config@0.27.1
+    - spec: pkg-config@1.4.2
       prefix: /usr
   rsync:
     externals:
-    - spec: rsync@3.1.2
+    - spec: rsync@3.1.3
       prefix: /usr
   ruby:
     externals:
-    - spec: ruby@2.0.0
+    - spec: ruby@2.5.9p229
       prefix: /usr
   sed:
     externals:
-    - spec: sed@4.2.2
+    - spec: sed@4.5
       prefix: /usr
   tar:
     externals:
-    - spec: tar@1.26
+    - spec: tar@1.30
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@5.1
+    - spec: texinfo@6.5-7
       prefix: /usr
   wget:
     externals:
-    - spec: wget@1.14
+    - spec: wget@1.19.5
       prefix: /usr
   zip:
     externals:
     - spec: zip@3.0
       prefix: /usr
+  zlib:
+     require: ["~shared"]

--- a/configs/sites/noaa-azure/README.md
+++ b/configs/sites/noaa-azure/README.md
@@ -6,15 +6,13 @@ that the site configuration files in `configs/sites/noaa-azure` work out of the 
 
 sudo su
 chmod 777 /contrib
-yum install -y m4
 yum install -y qt5-qtbase-devel
 yum install -y qt5-qtsvg-devel
 yum install -y xorg-x11-xauth
 yum install -y xorg-x11-apps
 yum install -y perl-IPC-Cmd
 yum install -y gettext-devel
-yum install -y ncurses-devel
-yum install -y ncurses-static
+yum install -y m4
 exit
 
 # Create a script that can be added to the cluster resource config so that these packages get installed automatically
@@ -30,8 +28,6 @@ yum install -y xorg-x11-xauth
 yum install -y xorg-x11-apps
 yum install -y perl-IPC-Cmd
 yum install -y gettext-devel
-yum install -y ncurses-devel
-yum install -y ncurses-static
 yum install -y m4
 EOF
 
@@ -56,24 +52,14 @@ exit
 
 # Build external packages for spack-stack
 
-mkdir -p /contrib/spack-stack
+mkdir -p /contrib/spack-stack-rocky8
 mkdir /contrib/spack-stack/modulefiles
-cd /contrib/spack-stack/
 
-mkdir -p git-lfs-2.4.1/src
-cd git-lfs-2.4.1/src
-wget http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/r/rh-git218-git-lfs-2.4.1-3.el7.x86_64.rpm
-rpm2cpio rh-git218-git-lfs-2.4.1-3.el7.x86_64.rpm | cpio -idmv
-mv opt/rh/rh-git218/root/usr/* ..
-rm -fr opt
-cd /contrib/spack-stack/modulefiles
-mkdir git-lfs
 # Create the modulefile from the template in doc/modulefile_templates
 
-cd /contrib/spack-stack/
+cd /contrib/spack-stack-rocky8
 mkdir -p mysql-8.0.31/src
 cd mysql-8.0.31/src
-ldd --version
 wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.31-linux-glibc2.17-x86_64-minimal.tar.xz
 tar -xvf mysql-8.0.31-linux-glibc2.17-x86_64-minimal.tar.xz
 mv mysql-8.0.31-linux-glibc2.17-x86_64-minimal/* ..
@@ -82,37 +68,20 @@ cd /contrib/spack-stack/modulefiles
 mkdir mysql
 # Create the modulefile from the template in doc/modulefile_templates
 
-cd /contrib/spack-stack/
-mkdir -p cmake-3.27.2/src
-cd cmake-3.27.2/src
-wget https://github.com/Kitware/CMake/releases/download/v3.27.2/cmake-3.27.2-linux-x86_64.tar.gz
-tar -xvzf cmake-3.27.2-linux-x86_64.tar.gz
-mv cmake-3.27.2-linux-x86_64/* ..
-rmdir cmake-3.27.2-linux-x86_64
-cd /contrib/spack-stack/modulefiles
-mkdir cmake
-# Create the modulefile from the template in doc/modulefile_templates
 
 # Set up basic modules for building the external ecflow package
-module unuse /opt/cray/craype/default/modulefiles
-module unuse /opt/cray/modulefiles
-
-module purge
-module load gnu/9.2.0
-module use /contrib/spack-stack/modulefiles
-module load cmake/3.27.2
-
-mkdir -p /contrib/spack-stack/ecflow-5.8.4/src
-cd /contrib/spack-stack/ecflow-5.8.4/src
+mkdir -p /contrib/spack-stack-rocky8/ecflow-5.8.4/src
+cd /contrib/spack-stack-rocky8/ecflow-5.8.4/src
 wget https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.4-Source.tar.gz?api=v2
 wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
 mv ecFlow-5.8.4-Source.tar.gz\?api\=v2 ecFlow-5.8.4-Source.tar.gz
 tar -xvzf boost_1_78_0.tar.gz
 tar -xvzf ecFlow-5.8.4-Source.tar.gz
-export WK=/contrib/spack-stack/ecflow-5.8.4/src/ecFlow-5.8.4-Source
-export BOOST_ROOT=/contrib/spack-stack/ecflow-5.8.4/src/boost_1_78_0
+export WK=/contrib/spack-stack-rocky8/ecflow-5.8.4/src/ecFlow-5.8.4-Source
+export BOOST_ROOT=/contrib/spack-stack-rocky8/ecflow-5.8.4/src/boost_1_78_0
 
 # Build static boost (to not interfere with spack-stack boost)
+# Note that the default compiler supplied with the OS is used
 cd $BOOST_ROOT
 ./bootstrap.sh 2>&1 | tee bootstrap.log
 $WK/build_scripts/boost_build.sh 2>&1 | tee boost_build.log
@@ -121,23 +90,51 @@ $WK/build_scripts/boost_build.sh 2>&1 | tee boost_build.log
 cd $WK
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/contrib/spack-stack/ecflow-5.8.4 2>&1 | tee log.cmake
+cmake .. -DPython3_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=/contrib/spack-stack-rocky8/ecflow-5.8.4 2>&1 | tee log.cmake
 make -j4 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
-cd /contrib/spack-stack/modulefiles
-mkdir ecflow
+cd /contrib/spack-stack-rocky8/
+mkdir -p ./modulefiles/ecflow
 # Create the modulefile from the template in doc/modulefile_templates
+
 
 ############## Steps to perform when starting a new cluster ##############
 source /contrib/admin/basic_setup.sh  # sudo privileges requred to install packages
+module purge
 module unuse /opt/cray/craype/default/modulefiles
 module unuse /opt/cray/modulefiles
-module use /contrib/spack-stack/modulefiles
-module load cmake/3.27.2
+
+# For noaa-aws, run the line below as well:
+module unuse /opt/intel/impi/2019.5.281/intel64/modulefiles
+module use /contrib/spack-stack-rocky8/modulefiles
+
+# Loading modules
+# 
 module load ecflow/5.8.4
 module load mysql/8.0.31
-module load git-lfs/2.4.1
-#
 
+module load gnu
+module load intel/2023.2.0
+module load impi/2023.2.0 
+module unload gnu
 
+cd /contrib/spack-stack-rocky8/spack-stack-1.6.0
+source setup.sh
+## Create spack-stack environment, use the CSP name as needed:
+## set CLOUD variable to noaa-aws, noaa-gcloud, or noaa-azure
+CLOUD=noaa-azure
+spack stack create env --site $CLOUD --template unified-dev --name ue-intel
+cd envs/ue-intel
+spack env activate .
+
+############## spack.yaml edits:
+edit spack.yaml:
+#  1) leave only "%intel" in "compilers" definitions
+#  2) replace ^esmf@8.5.0  by ^esmf@8.6.0 under definitions,
+#       except for the Various esmf/mapl tags section
+
+spack concretize 2>&1 | tee log.concretize
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
+spack module lmod refresh
+spack stack setup-meta-modules

--- a/configs/sites/noaa-azure/compilers.yaml
+++ b/configs/sites/noaa-azure/compilers.yaml
@@ -1,32 +1,17 @@
 compilers:
 - compiler:
-    spec: intel@2021.3.0
+    spec: intel@2021.10.0
     paths:
-      cc: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/icc
-      cxx: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/icpc
-      f77: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/ifort
-      fc: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
+      cc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icc
+      cxx: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icpc
+      f77: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+      fc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+    operating_system: rocky8
     target: x86_64
     modules:
-    - intel/2021.3.0
+    - intel/2023.2.0
     environment:
       prepend_path:
-        PATH: '/apps/gnu/gcc-9.2.0/bin'
-        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-9.2.0/lib64'
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.2.0
-    paths:
-      cc: /apps/gnu/gcc-9.2.0/bin/gcc
-      cxx: /apps/gnu/gcc-9.2.0/bin/g++
-      f77: /apps/gnu/gcc-9.2.0/bin/gfortran
-      fc: /apps/gnu/gcc-9.2.0/bin/gfortran
+        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-13.2.0/lib64'
     flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - gnu/9.2.0
-    environment: {}
     extra_rpaths: []

--- a/configs/sites/noaa-azure/config.yaml
+++ b/configs/sites/noaa-azure/config.yaml
@@ -1,5 +1,5 @@
 config:
-  build_jobs: 4
+  build_jobs: 6
 
   # Overrides for spack build and staging areas to speed up builds
   # and avoid errors with hard links on the NFS filesystem /contrib

--- a/configs/sites/noaa-azure/packages.yaml
+++ b/configs/sites/noaa-azure/packages.yaml
@@ -1,75 +1,58 @@
 packages:
   all:
-    compiler:: [intel@2021.3.0, gcc@9.2.0]
+    compiler:: [intel@2021.10.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.3.0, openmpi@3.1.4]
+      mpi:: [intel-oneapi-mpi@2021.10.0]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.3.0%intel@2021.3.0
+    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0
       prefix: /apps/oneapi
       modules:
-      - impi/2021.3.0
-  openmpi:
-    externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0
-      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
-      modules:
-      - openmpi/3.1.4
+      - impi/2023.2.0
 
 ### Modifications of common packages
-  # Pin flex to avoid duplicate packages
-  flex:
-    version: ['2.6.4']
 
 ### All other external packages listed alphabetically
-  autoconf:
-    externals:
-    - spec: autoconf@2.69
-      prefix: /usr
-  automake:
-    externals:
-    - spec: automake@1.13.4
-      prefix: /usr
   bash:
     externals:
-    - spec: bash@4.2.46
+    - spec: bash@4.4.20
       prefix: /usr
   berkeley-db:
     externals:
-    - spec: berkeley-db@5.3.21
+    - spec: berkeley-db@5.3.28
       prefix: /usr
   cpio:
     externals:
-    - spec: cpio@2.11
+    - spec: cpio@2.12
       prefix: /usr
   diffutils:
     externals:
-    - spec: diffutils@3.3
-      prefix: /usr
-  doxygen:
-    externals:
-    - spec: doxygen@1.8.5~graphviz~mscgen
+    - spec: diffutils@3.6
       prefix: /usr
   ecflow:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack/ecflow-5.8.4
+      prefix: /contrib/spack-stack-rocky8/ecflow-5.8.4
   file:
     externals:
-    - spec: file@5.11
+    - spec: file@5.33
       prefix: /usr
   findutils:
     externals:
-    - spec: findutils@4.5.11
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1
       prefix: /usr
   gawk:
     externals:
-    - spec: gawk@4.0.2
+    - spec: gawk@4.2.1
       prefix: /usr
   gettext:
     externals:
@@ -77,46 +60,27 @@ packages:
       prefix: /usr
   git:
     externals:
-    - spec: git@1.8.3.1~tcltk
+    - spec: git@2.39.3~tcltk
       prefix: /usr
   git-lfs:
     externals:
-    - spec: git-lfs@2.4.1
-      prefix: /contrib/spack-stack/git-lfs-2.4.1
+    - spec: git-lfs@3.2.0
+      prefix: /usr
   gmake:
     externals:
-    - spec: gmake@3.82
+    - spec: gmake@4.2.1
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.2
+    - spec: groff@1.21
       prefix: /usr
   hwloc:
     externals:
-    - spec: hwloc@1.11.8
+    - spec: hwloc@2.2.0
       prefix: /usr
   krb5:
     externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.2
-      prefix: /usr
-  # Problem untarring libxml2 on the Azure filesystem
-  # so mark it as external
-  libxml2:
-    buildable: False
-    externals:
-    - spec: libxml2@2.9.1
-      prefix: /usr
-  lustre:
-    externals:
-    - spec: lustre@2.12.7
-      prefix: /usr
-  m4:
-    externals:
-    - spec: m4@1.4.16
+    - spec: krb5@1.18.2
       prefix: /usr
   mysql:
     externals:
@@ -124,45 +88,47 @@ packages:
       prefix: /contrib/spack-stack/mysql-8.0.31
   ncurses:
     externals:
-    - spec: ncurses@5.9-14.20130511+termlib abi=5
+    - spec: ncurses@6.1-10.20180224+termlib abi=5
       prefix: /usr
   openjdk:
     externals:
-    - spec: openjdk@1.8.0_322-b06
+    - spec: openjdk@1.8.0_402-b06
       prefix: /usr
   perl:
     externals:
-    - spec: perl@5.16.3~cpanm+shared+threads
+    - spec: perl@5.26.3~cpanm+shared+threads
       prefix: /usr
   pkg-config:
     externals:
-    - spec: pkg-config@0.27.1
+    - spec: pkg-config@1.4.2
       prefix: /usr
   rsync:
     externals:
-    - spec: rsync@3.1.2
+    - spec: rsync@3.1.3
       prefix: /usr
   ruby:
     externals:
-    - spec: ruby@2.0.0
+    - spec: ruby@2.5.9p229
       prefix: /usr
   sed:
     externals:
-    - spec: sed@4.2.2
+    - spec: sed@4.5
       prefix: /usr
   tar:
     externals:
-    - spec: tar@1.26
+    - spec: tar@1.30
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@5.1
+    - spec: texinfo@6.5-7
       prefix: /usr
   wget:
     externals:
-    - spec: wget@1.14
+    - spec: wget@1.19.5
       prefix: /usr
   zip:
     externals:
     - spec: zip@3.0
       prefix: /usr
+  zlib:
+     require: ["~shared"]

--- a/configs/sites/noaa-gcloud/README.md
+++ b/configs/sites/noaa-gcloud/README.md
@@ -52,24 +52,14 @@ exit
 
 # Build external packages for spack-stack
 
-mkdir -p /contrib/spack-stack
+mkdir -p /contrib/spack-stack-rocky8
 mkdir /contrib/spack-stack/modulefiles
-cd /contrib/spack-stack/
 
-mkdir -p git-lfs-2.4.1/src
-cd git-lfs-2.4.1/src
-wget http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/r/rh-git218-git-lfs-2.4.1-3.el7.x86_64.rpm
-rpm2cpio rh-git218-git-lfs-2.4.1-3.el7.x86_64.rpm | cpio -idmv
-mv opt/rh/rh-git218/root/usr/* ..
-rm -fr opt
-cd /contrib/spack-stack/modulefiles
-mkdir git-lfs
 # Create the modulefile from the template in doc/modulefile_templates
 
-cd /contrib/spack-stack/
+cd /contrib/spack-stack-rocky8
 mkdir -p mysql-8.0.31/src
 cd mysql-8.0.31/src
-ldd --version
 wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.31-linux-glibc2.17-x86_64-minimal.tar.xz
 tar -xvf mysql-8.0.31-linux-glibc2.17-x86_64-minimal.tar.xz
 mv mysql-8.0.31-linux-glibc2.17-x86_64-minimal/* ..
@@ -78,37 +68,20 @@ cd /contrib/spack-stack/modulefiles
 mkdir mysql
 # Create the modulefile from the template in doc/modulefile_templates
 
-cd /contrib/spack-stack/
-mkdir -p cmake-3.27.2/src
-cd cmake-3.27.2/src
-wget https://github.com/Kitware/CMake/releases/download/v3.27.2/cmake-3.27.2-linux-x86_64.tar.gz
-tar -xvzf cmake-3.27.2-linux-x86_64.tar.gz
-mv cmake-3.27.2-linux-x86_64/* ..
-rmdir cmake-3.27.2-linux-x86_64
-cd /contrib/spack-stack/modulefiles
-mkdir cmake
-# Create the modulefile from the template in doc/modulefile_templates
 
 # Set up basic modules for building the external ecflow package
-module unuse /opt/cray/craype/default/modulefiles
-module unuse /opt/cray/modulefiles
-
-module purge
-module load gnu/9.2.0
-module use /contrib/spack-stack/modulefiles
-module load cmake/3.27.2
-
-mkdir -p /contrib/spack-stack/ecflow-5.8.4/src
-cd /contrib/spack-stack/ecflow-5.8.4/src
+mkdir -p /contrib/spack-stack-rocky8/ecflow-5.8.4/src
+cd /contrib/spack-stack-rocky8/ecflow-5.8.4/src
 wget https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.4-Source.tar.gz?api=v2
 wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
 mv ecFlow-5.8.4-Source.tar.gz\?api\=v2 ecFlow-5.8.4-Source.tar.gz
 tar -xvzf boost_1_78_0.tar.gz
 tar -xvzf ecFlow-5.8.4-Source.tar.gz
-export WK=/contrib/spack-stack/ecflow-5.8.4/src/ecFlow-5.8.4-Source
-export BOOST_ROOT=/contrib/spack-stack/ecflow-5.8.4/src/boost_1_78_0
+export WK=/contrib/spack-stack-rocky8/ecflow-5.8.4/src/ecFlow-5.8.4-Source
+export BOOST_ROOT=/contrib/spack-stack-rocky8/ecflow-5.8.4/src/boost_1_78_0
 
 # Build static boost (to not interfere with spack-stack boost)
+# Note that the default compiler supplied with the OS is used
 cd $BOOST_ROOT
 ./bootstrap.sh 2>&1 | tee bootstrap.log
 $WK/build_scripts/boost_build.sh 2>&1 | tee boost_build.log
@@ -117,21 +90,51 @@ $WK/build_scripts/boost_build.sh 2>&1 | tee boost_build.log
 cd $WK
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/contrib/spack-stack/ecflow-5.8.4 2>&1 | tee log.cmake
+cmake .. -DPython3_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=/contrib/spack-stack-rocky8/ecflow-5.8.4 2>&1 | tee log.cmake
 make -j4 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
-cd /contrib/spack-stack/modulefiles
-mkdir ecflow
+cd /contrib/spack-stack-rocky8/
+mkdir -p ./modulefiles/ecflow
 # Create the modulefile from the template in doc/modulefile_templates
+
 
 ############## Steps to perform when starting a new cluster ##############
 source /contrib/admin/basic_setup.sh  # sudo privileges requred to install packages
+module purge
 module unuse /opt/cray/craype/default/modulefiles
 module unuse /opt/cray/modulefiles
-module use /contrib/spack-stack/modulefiles
-module load cmake/3.27.2
+
+# For noaa-aws, run the line below as well:
+module unuse /opt/intel/impi/2019.5.281/intel64/modulefiles
+module use /contrib/spack-stack-rocky8/modulefiles
+
+# Loading modules
+# 
 module load ecflow/5.8.4
 module load mysql/8.0.31
-module load git-lfs/2.4.1
 
+module load gnu
+module load intel/2023.2.0
+module load impi/2023.2.0 
+module unload gnu
+
+cd /contrib/spack-stack-rocky8/spack-stack-1.6.0
+source setup.sh
+## Create spack-stack environment, use the CSP name as needed:
+## set CLOUD variable to noaa-aws, noaa-gcloud, or noaa-azure
+CLOUD=noaa-gcloud
+spack stack create env --site $CLOUD --template unified-dev --name ue-intel
+cd envs/ue-intel
+spack env activate .
+
+############## spack.yaml edits:
+edit spack.yaml:
+#  1) leave only "%intel" in "compilers" definitions
+#  2) replace ^esmf@8.5.0  by ^esmf@8.6.0 under definitions,
+#       except for the Various esmf/mapl tags section
+
+spack concretize 2>&1 | tee log.concretize
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
+spack module lmod refresh
+spack stack setup-meta-modules

--- a/configs/sites/noaa-gcloud/compilers.yaml
+++ b/configs/sites/noaa-gcloud/compilers.yaml
@@ -1,32 +1,17 @@
 compilers:
 - compiler:
-    spec: intel@2021.3.0
+    spec: intel@2021.10.0
     paths:
-      cc: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/icc
-      cxx: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/icpc
-      f77: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/ifort
-      fc: /apps/oneapi/compiler/2021.3.0/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
+      cc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icc
+      cxx: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icpc
+      f77: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+      fc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+    operating_system: rocky8
     target: x86_64
     modules:
-    - intel/2021.3.0
+    - intel/2023.2.0
     environment:
       prepend_path:
-        PATH: '/apps/gnu/gcc-9.2.0/bin'
-        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-9.2.0/lib64'
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.2.0
-    paths:
-      cc: /apps/gnu/gcc-9.2.0/bin/gcc
-      cxx: /apps/gnu/gcc-9.2.0/bin/g++
-      f77: /apps/gnu/gcc-9.2.0/bin/gfortran
-      fc: /apps/gnu/gcc-9.2.0/bin/gfortran
+        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-13.2.0/lib64'
     flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - gnu/9.2.0
-    environment: {}
     extra_rpaths: []

--- a/configs/sites/noaa-gcloud/config.yaml
+++ b/configs/sites/noaa-gcloud/config.yaml
@@ -1,5 +1,5 @@
 config:
-  build_jobs: 4
+  build_jobs: 6
 
   # Overrides for spack build and staging areas to speed up builds
   # and avoid errors with hard links on the NFS filesystem /contrib

--- a/configs/sites/noaa-gcloud/packages.yaml
+++ b/configs/sites/noaa-gcloud/packages.yaml
@@ -1,63 +1,58 @@
 packages:
   all:
-    compiler:: [intel@2021.3.0, gcc@9.2.0]
+    compiler:: [intel@2021.10.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.3.0, openmpi@3.1.4]
+      mpi:: [intel-oneapi-mpi@2021.10.0]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.3.0%intel@2021.3.0
+    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0
       prefix: /apps/oneapi
       modules:
-      - impi/2021.3.0
-  openmpi:
-    externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0
-      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
-      modules:
-      - openmpi/3.1.4
+      - impi/2023.2.0
 
 ### Modifications of common packages
-  # Pin flex to avoid duplicate packages
-  flex:
-    version: ['2.6.4']
 
 ### All other external packages listed alphabetically
   bash:
     externals:
-    - spec: bash@4.2.46
+    - spec: bash@4.4.20
       prefix: /usr
   berkeley-db:
     externals:
-    - spec: berkeley-db@5.3.21
+    - spec: berkeley-db@5.3.28
       prefix: /usr
   cpio:
     externals:
-    - spec: cpio@2.11
+    - spec: cpio@2.12
       prefix: /usr
   diffutils:
     externals:
-    - spec: diffutils@3.3
+    - spec: diffutils@3.6
       prefix: /usr
   ecflow:
     buildable: False
     externals:
     - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack/ecflow-5.8.4
+      prefix: /contrib/spack-stack-rocky8/ecflow-5.8.4
   file:
     externals:
-    - spec: file@5.11
+    - spec: file@5.33
       prefix: /usr
   findutils:
     externals:
-    - spec: findutils@4.5.11
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1
       prefix: /usr
   gawk:
     externals:
-    - spec: gawk@4.0.2
+    - spec: gawk@4.2.1
       prefix: /usr
   gettext:
     externals:
@@ -65,77 +60,75 @@ packages:
       prefix: /usr
   git:
     externals:
-    - spec: git@1.8.3.1~tcltk
+    - spec: git@2.39.3~tcltk
       prefix: /usr
   git-lfs:
     externals:
-    - spec: git-lfs@2.4.1
-      prefix: /contrib/spack-stack/git-lfs-2.4.1
+    - spec: git-lfs@3.2.0
+      prefix: /usr
   gmake:
     externals:
-    - spec: gmake@3.82
+    - spec: gmake@4.2.1
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.2
+    - spec: groff@1.21
       prefix: /usr
   hwloc:
     externals:
-    - spec: hwloc@1.11.8
+    - spec: hwloc@2.2.0
       prefix: /usr
   krb5:
     externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
-  lustre:
-    externals:
-    - spec: lustre@2.12.7
-      prefix: /usr
-  m4:
-    externals:
-    - spec: m4@1.4.16
+    - spec: krb5@1.18.2
       prefix: /usr
   mysql:
     externals:
     - spec: mysql@8.0.31
       prefix: /contrib/spack-stack/mysql-8.0.31
+  ncurses:
+    externals:
+    - spec: ncurses@6.1-10.20180224+termlib abi=5
+      prefix: /usr
   openjdk:
     externals:
-    - spec: openjdk@1.8.0_322-b06
+    - spec: openjdk@1.8.0_402-b06
       prefix: /usr
   perl:
     externals:
-    - spec: perl@5.16.3~cpanm+shared+threads
+    - spec: perl@5.26.3~cpanm+shared+threads
       prefix: /usr
   pkg-config:
     externals:
-    - spec: pkg-config@0.27.1
+    - spec: pkg-config@1.4.2
       prefix: /usr
   rsync:
     externals:
-    - spec: rsync@3.1.2
+    - spec: rsync@3.1.3
       prefix: /usr
   ruby:
     externals:
-    - spec: ruby@2.0.0
+    - spec: ruby@2.5.9p229
       prefix: /usr
   sed:
     externals:
-    - spec: sed@4.2.2
+    - spec: sed@4.5
       prefix: /usr
   tar:
     externals:
-    - spec: tar@1.26
+    - spec: tar@1.30
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@5.1
+    - spec: texinfo@6.5-7
       prefix: /usr
   wget:
     externals:
-    - spec: wget@1.14
+    - spec: wget@1.19.5
       prefix: /usr
   zip:
     externals:
     - spec: zip@3.0
       prefix: /usr
+  zlib:
+     require: ["~shared"]

--- a/configs/sites/orion/compilers.yaml
+++ b/configs/sites/orion/compilers.yaml
@@ -1,51 +1,32 @@
 compilers:
 - compiler:
-    spec: intel@2022.0.2
+    spec: intel@2021.9.0
     paths:
-      cc: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/icc
-      cxx: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/icpc
-      f77: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/ifort
-      fc: /apps/intel-2022.1.2/intel-2022.1.2/compiler/2022.0.2/linux/bin/intel64/ifort
+      cc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icc
+      cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icpc
+      f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
+      fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky9
     target: x86_64
     modules:
-    - intel/2022.1.2
+    - intel-oneapi-compilers/2023.1.0
     environment:
-      prepend_path:
-        PATH: '/apps/gcc-10.2.0/gcc-10.2.0/bin'
-        LD_LIBRARY_PATH: '/apps/gcc-10.2.0/gcc-10.2.0/lib64:/apps/gcc-10.2.0/gcc-10.2.0/contrib/lib'
-        CPATH: '/apps/gcc-10.2.0/gcc-10.2.0/include'
+      set:
+        # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
+        I_MPI_EXTRA_FILESYSTEM: 'ON'
     extra_rpaths: []
 - compiler:
-    spec: intel@18.0.5
+    spec: gcc@12.2.0
     paths:
-      cc: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/icc
-      cxx: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/icpc
-      f77: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/ifort
-      fc: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/bin/intel64/ifort
+      cc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gcc
+      cxx: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/g++
+      f77: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+      fc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
     flags: {}
-    operating_system: centos7
+    operating_system: rocky9
     target: x86_64
     modules:
-    - intel/2018.4
-    environment:
-      prepend_path:
-        PATH: '/apps/gcc-8/gcc-8.3.0/bin'
-        LD_LIBRARY_PATH: '/apps/gcc-8/gcc-8.3.0/lib64:/apps/gcc-8/gcc-8.3.0//lib:/apps/gcc-8/gcc-8.3.0/mpfr-4.0.2/lib:/apps/gcc-8/gcc-8.3.0/mpc-1.1.0/lib:/apps/gcc-8/gcc-8.3.0/gmp-6.1.2/lib'
-        CPATH: '/apps/gcc-8/gcc-8.3.0/include'
-    extra_rpaths: []
-- compiler:
-    spec: gcc@10.2.0
-    paths:
-      cc: /apps/gcc-10.2.0/gcc-10.2.0/bin/gcc
-      cxx: /apps/gcc-10.2.0/gcc-10.2.0/bin/g++
-      f77: /apps/gcc-10.2.0/gcc-10.2.0/bin/gfortran
-      fc: /apps/gcc-10.2.0/gcc-10.2.0/bin/gfortran
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - gcc/10.2.0
+    - gcc/12.2.0
     environment: {}
     extra_rpaths: []

--- a/configs/sites/orion/packages.yaml
+++ b/configs/sites/orion/packages.yaml
@@ -1,38 +1,25 @@
 packages:
   all:
-    compiler:: [intel@2022.0.2, gcc@10.2.0]
-    #compiler:: [intel@18.0.5]
+    compiler:: [intel@2021.9.0, gcc@12.2.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.5.1, openmpi@4.0.4]
-      #mpi:: [intel-mpi@2018.5.274]
+      mpi:: [intel-oneapi-mpi@2021.9.0, mvapich2@2.3.7]
 
 ### MPI, Python, MKL
   mpi:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.5.1%intel@2022.0.2
-      prefix: /apps/intel-2022.1.2/intel-2022.1.2
+    - spec: intel-oneapi-mpi@2021.9.0%intel@2021.9.0
+      prefix: /apps/spack-managed/oneapi-2023.1.0/intel-oneapi-mpi-2021.9.0-a66eaipzsnyrdgaqzxmqmqz64qzvhkse
       modules:
-      - impi/2022.1.2
-  intel-mpi:
+      - intel-oneapi-mpi/2021.9.0
+  mvapich2:
     externals:
-    - spec: intel-mpi@2018.5.274%intel@18.0.5
-      prefix: /apps/intel-2018/intel-2018.u4/compilers_and_libraries_2018.5.274/linux/mpi
+    - spec: mvapich2@2.3.7%gcc@12.2.0~cuda~debug~regcache~wrapperrpath process_managers=slurm
+      prefix: /work/noaa/epic/role-epic/spack-stack/hercules/mvapich2-2.3.7/gcc-12.2.0
       modules:
-      - impi/2018.4
-  openmpi:
-    externals:
-    - spec: openmpi@4.0.4%gcc@10.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath
-        fabrics=ucx schedulers=slurm +internal-hwloc +two_level_namespace
-      prefix: /apps/gcc-10.2.0/openmpi-4.0.4/openmpi-4.0.4
-      modules:
-      - openmpi/4.0.4
-
-### Modifications of common packages
-  # Temporary - see https://github.com/spack/spack/issues/41947
-  cdo:
-    require: '@2.0.5'
+      - gcc/12.2.0
+      - mvapich2/2.3.7
 
 ### All other external packages listed alphabetically
   autoconf:
@@ -41,31 +28,19 @@ packages:
       prefix: /usr
   automake:
     externals:
-    - spec: automake@1.13.4
+    - spec: automake@1.16.2
       prefix: /usr
-  bash:
+  binutils:
     externals:
-    - spec: bash@4.2.46
+    - spec: binutils@2.35.2
       prefix: /usr
-  berkeley-db:
+  coreutils:
     externals:
-    - spec: berkeley-db@5.3.21
-      prefix: /usr
-  bzip2:
-    externals:
-    - spec: bzip2@1.0.6
-      prefix: /usr
-  cpio:
-    externals:
-    - spec: cpio@2.11
+    - spec: coreutils@8.32
       prefix: /usr
   diffutils:
     externals:
-    - spec: diffutils@3.3
-      prefix: /usr
-  doxygen:
-    externals:
-    - spec: doxygen@1.8.5+graphviz~mscgen
+    - spec: diffutils@3.7
       prefix: /usr
   ecflow:
     buildable: False
@@ -74,71 +49,39 @@ packages:
       prefix: /work/noaa/epic/role-epic/spack-stack/orion/ecflow-5.8.4
       modules:
       - ecflow/5.8.4
-  file:
-    externals:
-    - spec: file@5.11
-      prefix: /usr
   findutils:
     externals:
-    - spec: findutils@4.5.11
+    - spec: findutils@4.8.0
       prefix: /usr
   flex:
     externals:
-    - spec: flex@2.5.37+lex
+    - spec: flex@2.6.4+lex
       prefix: /usr
   gawk:
     externals:
-    - spec: gawk@4.0.2
-      prefix: /usr
-  gettext:
-    externals:
-    - spec: gettext@0.19.8.1
-      prefix: /usr
-  ghostscript:
-    externals:
-    - spec: ghostscript@9.07
+    - spec: gawk@5.1.0
       prefix: /usr
   git:
     externals:
-    - spec: git@2.28.0+tcltk
-      prefix: /apps/git-2.28.0
-    - spec: git@1.8.3.1~tcltk
+    - spec: git@2.31.1~tcltk
       prefix: /usr
   git-lfs:
     externals:
-    - spec: git-lfs@2.12.0
-      prefix: /apps/git-2.28.0
+    - spec: git-lfs@3.1.2
+      prefix: /apps/spack-managed/gcc-11.3.1/git-lfs-3.1.2-sjfqfgha27na65g3lrcqamncnryjoa7l
+      modules:
+      - git-lfs/3.1.2
   gmake:
     externals:
-    - spec: gmake@3.82
+    - spec: gmake@4.3
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.2
-      prefix: /usr
-  openjdk:
-    externals:
-    - spec: openjdk@1.8.0_222-b10
-      prefix: /usr
-  krb5:
-    externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
-  libfuse:
-    externals:
-    - spec: libfuse@2.9.2
-      prefix: /usr
-  libxpm:
-    externals:
-    - spec: libxpm@4.11.0
-      prefix: /usr
-  lustre:
-    externals:
-    - spec: lustre@2.12.6_ddn51
+    - spec: groff@1.22.4
       prefix: /usr
   m4:
     externals:
-    - spec: m4@1.4.16
+    - spec: m4@1.4.19
       prefix: /usr
   mysql:
     buildable: False
@@ -147,55 +90,29 @@ packages:
       prefix: /work/noaa/epic/role-epic/spack-stack/orion/mysql-8.0.31
       modules:
       - mysql/8.0.31
-  ncurses:
+  pkgconf:
     externals:
-    - spec: ncurses@5.9.20130511+termlib abi=5
-      prefix: /usr
-  perl:
-    externals:
-    - spec: perl@5.16.3+cpanm+shared+threads
-      prefix: /usr
-  pkg-config:
-    externals:
-    - spec: pkg-config@0.27.1
+    - spec: pkgconf@1.7.3
       prefix: /usr
   qt:
     externals:
-    - spec: qt@5.9.2
-      prefix: /usr
-  rsync:
-    externals:
-    - spec: rsync@3.1.2
-      prefix: /usr
-  ruby:
-    externals:
-    - spec: ruby@2.0.0
-      prefix: /usr
+    - spec: qt@5.15.8
+      prefix: /apps/spack-managed/gcc-12.2.0/qt-5.15.8-gayzhaahclvlybiiykwj2cym4vo33w6x
+      modules:
+      - qt/5.15.8
   sed:
     externals:
-    - spec: sed@4.2.2
+    - spec: sed@4.8
       prefix: /usr
-  tar:
+  subversion:
     externals:
-    - spec: tar@1.26
+    - spec: subversion@1.14.1
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@5.1
-      prefix: /usr
-  texlive:
-    externals:
-    - spec: texlive@20130530
+    - spec: texinfo@6.7
       prefix: /usr
   wget:
     externals:
-    - spec: wget@1.14
-      prefix: /usr
-  xz:
-    externals:
-    - spec: xz@5.2.2
-      prefix: /usr
-  zip:
-    externals:
-    - spec: zip@3.0
+    - spec: wget@1.21.1
       prefix: /usr


### PR DESCRIPTION
### Summary

Since 1.6.0 release some machines switched to Rocky OS. Need to update config files for those machines.

### Testing

Install from new branch

### Applications affected

All

### Systems affected

Hera, Orion, NOAA-cloud,... (will check for others)

### Dependencies
No dependences

### Issue(s) addressed

Closes issue #1316 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
