### PR TITLE
AWS PCluster site: remove external ecflow install.

### DIFF
--- a/configs/sites/tier1/aws-pcluster/packages.yaml
+++ b/configs/sites/tier1/aws-pcluster/packages.yaml
@@ -19,11 +19,6 @@ packages:
     externals:
     - spec: diffutils@3.8
       prefix: /usr
-  ecflow:
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /home/ubuntu/jedi/ecflow-5.8.4
   findutils:
     externals:
     - spec: findutils@4.8.0


### PR DESCRIPTION
This change removes the external install of ecflow. The config change has been tested on the current AWS PCluster. The doc changes have not been tested (since it requires a clean site install) but they simply remove the install instructions for the external ecflow server.

### Testing

Tested on existing pcluster. Install works and JEDI builds and tests.

### Applications affected

N/A

### Systems affected

AWS Parallel Cluster

### Dependencies

None

### Issue(s) addressed

Release

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
