### PR TITLE
release/1.8.0: Update derecho site config

### DIFF
--- a/configs/sites/tier1/derecho/compilers.yaml
+++ b/configs/sites/tier1/derecho/compilers.yaml
@@ -14,9 +14,9 @@ compilers::
     - intel-classic/2023.2.1
     environment:
       prepend_path:
-        PATH: '/opt/cray/pe/gcc/12.2.0/bin'
-        CPATH: '/opt/cray/pe/gcc/12.2.0/snos/include'
-        LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2023.2.1/compiler/2023.2.1/linux/compiler/lib/intel64_lin:/opt/cray/pe/gcc/12.2.0/snos/lib:/opt/cray/pe/gcc/12.2.0/lib64'
+        PATH: '/opt/cray/pe/gcc/11.2.0/snos/bin'
+        CPATH: '/opt/cray/pe/gcc/11.2.0/snos/include'
+        LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2023.2.1/compiler/2023.2.1/linux/compiler/lib/intel64_lin:/opt/cray/pe/gcc/11.2.0/snos/lib:/opt/cray/pe/gcc/11.2.0/snos/lib64'
       set:
         # https://github.com/JCSDA/spack-stack/issues/957
         FI_CXI_RX_MATCH_MODE: 'hybrid'
@@ -36,6 +36,25 @@ compilers::
     modules:
     - ncarenv/23.09
     - gcc/12.2.0
+    environment:
+      set:
+        # https://github.com/JCSDA/spack-stack/issues/957
+        FI_CXI_RX_MATCH_MODE: 'hybrid'
+    extra_rpaths: []
+# Needed for intel
+- compiler:
+    spec: gcc@11.2.0
+    paths:
+      cc: /opt/cray/pe/gcc/11.2.0/bin/gcc
+      cxx: /opt/cray/pe/gcc/11.2.0/bin/g++
+      f77: /opt/cray/pe/gcc/11.2.0/bin/gfortran
+      fc: /opt/cray/pe/gcc/11.2.0/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - ncarenv/23.09
+    - gcc/11.2.0
     environment:
       set:
         # https://github.com/JCSDA/spack-stack/issues/957

--- a/configs/sites/tier1/derecho/config.yaml
+++ b/configs/sites/tier1/derecho/config.yaml
@@ -1,2 +1,2 @@
 config:
-  build_jobs: 8
+  build_jobs: 3

--- a/configs/sites/tier1/derecho/packages.yaml
+++ b/configs/sites/tier1/derecho/packages.yaml
@@ -7,6 +7,11 @@ packages:
   # Need to force spack to build python with ssl variant when using older openssl from OS
   python:
     require: "+ssl"
+  # py-scipy 1.12 does not build with intel on Derecho, pin to 1.11.4
+  # use same version with gcc for consistency on the machine
+  py-scipy:
+    require:
+    - '@1.11.4'
 ### All other external packages listed alphabetically
   autoconf:
     externals:
@@ -26,8 +31,8 @@ packages:
       prefix: /usr
   curl:
     externals:
-    - spec: curl@7.79.1+gssapi+ldap+nghttp2
-      prefix: /usr
+    - spec: curl@8.1.2+gssapi+ldap+nghttp2
+      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/curl/8.1.2/gcc/7.5.0/uq6y
   cvs:
     externals:
     - spec: cvs@1.12.13
@@ -36,13 +41,6 @@ packages:
     externals:
     - spec: diffutils@3.6
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /glade/work/epicufsrt/contrib/spack-stack/derecho/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   findutils:
     externals:
     - spec: findutils@4.8.0
@@ -96,6 +94,11 @@ packages:
     externals:
     - spec: pkg-config@0.29.2
       prefix: /usr
+  qt:
+    buildable: False
+    externals:
+    - spec: qt@5.14.2
+      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/qt/5.14.2/gcc/7.5.0/eqcj
   sed:
     externals:
     - spec: sed@4.4

--- a/configs/sites/tier1/derecho/packages_intel.yaml
+++ b/configs/sites/tier1/derecho/packages_intel.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [intel@2021.10.0,gcc@12.2.0]
+    compiler:: [intel@2021.10.0,gcc@11.2.0]
     providers:
       mpi:: [cray-mpich@8.1.25]
       # Remove the next three lines to switch to intel-oneapi-mkl

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -233,7 +233,6 @@ The following is required for building new spack environments with any supported
    export LMOD_TMOD_FIND_FIRST=yes
    module load ncarenv/23.09
    module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
-   module load ecflow/5.8.4
 
 
 .. _Preconfigured_Sites_Acorn:


### PR DESCRIPTION
### Summary

Update Derecho site config for `release/1.8.0`:
- use only three build jobs to avoid getting booted off the system by the arbiter
- use gcc@11.2.0 as backend for Intel to fix build errors for `met` and `py-scipy`
- pin `py-scipy` to 1.11.4
- ecflow/qt changes as discussed earlier

### Testing

Built unified environment with `intel@2021.10.4` (using `gcc@11.2.0` as backend) and with `gcc@12.2.0`

### Applications affected

n/a

### Systems affected

Derecho

### Dependencies

n/a

### Issue(s) addressed

Working towards #1278 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
