### PR TITLE
AWS PCluster site: include ecflow in modules.yaml (or, don't exclude it)

### DIFF
--- a/configs/sites/tier1/aws-pcluster/modules.yaml
+++ b/configs/sites/tier1/aws-pcluster/modules.yaml
@@ -5,5 +5,3 @@ modules:
     lmod:
       include:
       - python
-      exclude:
-      - ecflow


### PR DESCRIPTION
Remove the "exclude: ecflow" directive in modules.yaml.

Tested on current pcluster. Works as expected.