### PR TITLE
Cherry-pick 87067e9 (Update site/packages.yaml and site/modules.yaml (#1322)) from release/1.8.0

### DIFF
--- a/configs/sites/tier1/derecho/modules.yaml
+++ b/configs/sites/tier1/derecho/modules.yaml
@@ -3,8 +3,6 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - cray-mpich
       - python

--- a/configs/sites/tier1/gaea-c5/modules.yaml
+++ b/configs/sites/tier1/gaea-c5/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -81,12 +81,6 @@ packages:
     externals:
     - spec: dos2unix@7.4.0
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/ecflow-5.8.4
-      modules: [ecflow/5.8.4]
   file:
     externals:
     - spec: file@5.32
@@ -197,7 +191,7 @@ packages:
   qt:
     externals:
     - spec: qt@5.15.2
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/qt-5.15.2/5.15.2/gcc_64
+      prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
   rdma-core:
     externals:
     - spec: rdma-core@37.0

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -70,11 +70,6 @@ packages:
     externals:
     - spec: dos2unix@7.4.0
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/ecflow-5.8.4
   file:
     externals:
     - spec: file@5.32
@@ -184,7 +179,7 @@ packages:
   qt:
     externals:
     - spec: qt@5.15.2
-      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
+      prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
   rdma-core:
     externals:
     - spec: rdma-core@42.0

--- a/configs/sites/tier1/hera/modules.yaml
+++ b/configs/sites/tier1/hera/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/hera/packages.yaml
+++ b/configs/sites/tier1/hera/packages.yaml
@@ -34,13 +34,6 @@ packages:
     externals:
     - spec: doxygen@1.8.5+graphviz~mscgen
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.5.3+ui+static_boost
-      prefix: /apps/ecflow/5.5.3
-      modules:
-      - ecflow/5.5.3
   file:
     externals:
     - spec: file@5.11
@@ -120,6 +113,10 @@ packages:
     externals:
     - spec: pkg-config@0.27.1
       prefix: /usr
+  qt:
+    externals:
+    - spec: qt@5.12.6
+      prefix: /scratch1/NCEPDEV/nems/role.epic/installs/qt-5.12.6/qtbase
   rsync:
     externals:
     - spec: rsync@3.1.2

--- a/configs/sites/tier1/hercules/modules.yaml
+++ b/configs/sites/tier1/hercules/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -19,13 +19,6 @@ packages:
     externals:
     - spec: diffutils@3.7
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   findutils:
     externals:
     - spec: findutils@4.8.0
@@ -73,10 +66,10 @@ packages:
       prefix: /usr
   qt:
     externals:
-    - spec: qt@5.15.8
-      prefix: /apps/spack-managed/gcc-11.3.1/qt-5.15.8-d47tsna6f5dylcpblkfgw4gpn2cucihd
+    - spec: qt@5.15.14
+      prefix: /apps/contrib/spack-stack-1.1/gcc-11.3.1/qt-5.15.14-mfeuvcidmyqoi2m5i2tfrk6yd7xtk6pt
       modules:
-      - qt/5.15.8
+      - qt/5.15.14
   sed:
     externals:
     - spec: sed@4.8

--- a/configs/sites/tier1/jet/modules.yaml
+++ b/configs/sites/tier1/jet/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/jet/packages.yaml
+++ b/configs/sites/tier1/jet/packages.yaml
@@ -34,13 +34,6 @@ packages:
     externals:
     - spec: doxygen@1.8.5+graphviz~mscgen
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.5.3+ui+static_boost
-      prefix: /apps/ecflow/5.5.3
-      modules:
-      - ecflow/5.5.3
   file:
     externals:
     - spec: file@5.11
@@ -124,6 +117,11 @@ packages:
     externals:
     - spec: pkg-config@0.27.1
       prefix: /usr
+  qt:
+    buildable: false
+    externals:
+    - spec: qt@5.12.6
+      prefix: /contrib/spack-stack/installs/qt-5.12.6/qtbase
   rsync:
     externals:
     - spec: rsync@3.1.2

--- a/configs/sites/tier1/noaa-aws/modules.yaml
+++ b/configs/sites/tier1/noaa-aws/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/noaa-aws/packages.yaml
+++ b/configs/sites/tier1/noaa-aws/packages.yaml
@@ -15,13 +15,6 @@ packages:
     externals:
     - spec: diffutils@3.6
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack-rocky8/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.33
@@ -82,6 +75,11 @@ packages:
     externals:
     - spec: pkg-config@1.4.2
       prefix: /usr
+  qt:
+    buildable: false
+    externals:
+    - spec: qt@5.15.3
+      prefix: /usr/lib64/qt5
   rsync:
     externals:
     - spec: rsync@3.1.3

--- a/configs/sites/tier1/noaa-azure/modules.yaml
+++ b/configs/sites/tier1/noaa-azure/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/noaa-azure/packages.yaml
+++ b/configs/sites/tier1/noaa-azure/packages.yaml
@@ -15,13 +15,6 @@ packages:
     externals:
     - spec: diffutils@3.6
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack-rocky8/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.33
@@ -78,6 +71,11 @@ packages:
     externals:
     - spec: pkg-config@1.4.2
       prefix: /usr
+  qt:
+    buildable: false
+    externals:
+    - spec: qt@5.15.3
+      prefix: /usr/lib64/qt5
   rsync:
     externals:
     - spec: rsync@3.1.3

--- a/configs/sites/tier1/noaa-gcloud/modules.yaml
+++ b/configs/sites/tier1/noaa-gcloud/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/noaa-gcloud/packages.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages.yaml
@@ -15,13 +15,6 @@ packages:
     externals:
     - spec: diffutils@3.6
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /contrib/spack-stack-rocky8/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   file:
     externals:
     - spec: file@5.33
@@ -78,6 +71,11 @@ packages:
     externals:
     - spec: pkg-config@1.4.2
       prefix: /usr
+  qt:
+    buildable: false
+    externals:
+    - spec: qt@5.15.3
+      prefix: /usr/lib64/qt5
   rsync:
     externals:
     - spec: rsync@3.1.3

--- a/configs/sites/tier1/orion/modules.yaml
+++ b/configs/sites/tier1/orion/modules.yaml
@@ -3,7 +3,5 @@ modules:
     enable::
     - lmod
     lmod:
-      exclude:
-      - ecflow
       include:
       - python

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -31,13 +31,6 @@ packages:
     externals:
     - spec: diffutils@3.7
       prefix: /usr
-  ecflow::
-    buildable: False
-    externals:
-    - spec: ecflow@5.8.4+ui+static_boost
-      prefix: /work/noaa/epic/role-epic/spack-stack/orion/ecflow-5.8.4
-      modules:
-      - ecflow/5.8.4
   findutils:
     externals:
     - spec: findutils@4.8.0


### PR DESCRIPTION
### Summary

This PR cherry-picks the squashed merge of PR #1322 that went into spack-stack-1.8.0 (release/1.8.0, retagged as 1.8.0) for develop. These are only site config updates, no CI testing needed.

### Testing

CI not needed; updated site configs were used for spack-stack-1.8.0 installations

### Applications affected

none

### Systems affected

NOAA RDHPCS platforms

### Dependencies

n/a

### Issue(s) addressed

Working towards #1278 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
