### PR TITLE
fix openmpi version on Hercules

### DIFF
--- a/configs/sites/tier1/hercules/packages_gcc.yaml
+++ b/configs/sites/tier1/hercules/packages_gcc.yaml
@@ -2,13 +2,13 @@ packages:
   all:
     compiler:: [gcc@12.2.0]
     providers:
-      mpi:: [openmpi@4.1.6]
+      mpi:: [openmpi@4.1.4]
   mpi:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@4.1.6%gcc@12.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
+    - spec: openmpi@4.1.4%gcc@12.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
         schedulers=slurm
       modules:
       - gcc/12.2.0
-      - openmpi/4.1.6-gcc-12.2.0-spack
+      - openmpi/4.1.4


### PR DESCRIPTION
### Summary

Switched from used installed openmpi 4.1.6-gcc-12.2.0-spack to system installed openmpi@4.1.4
This fixed problem on installing gcc environment on Hercules.

### Testing

Installed spack-stack-1.8.0/gcc
Wiki [page](https://github.com/JCSDA/spack-stack/wiki/spack%E2%80%90stack%E2%80%901.8.0-release-documentation) updated,


### Systems affected

Hercules

### Issue(s) addressed

#1278 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
