### PR TITLE
For release/1.8.0: update S4 site config and documentation

### DIFF
--- a/configs/sites/tier1/s4/compilers.yaml
+++ b/configs/sites/tier1/s4/compilers.yaml
@@ -1,34 +1,45 @@
 compilers:
 - compiler:
-    spec: intel@2021.5.0
+    spec: intel@=2021.10.0
     paths:
-      cc: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/icc
-      cxx: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/icpc
-      f77: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/ifort
-      fc: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/ifort
+      cc: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/icc
+      cxx: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/icpc
+      f77: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/ifort
+      fc: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     target: x86_64
     modules:
-    - license_intel/S4
-    - intel/2022.1
+    - intel/2023.2
     environment:
-      prepend_path:
-        PATH: '/data/prod/hpc-stack/gnu/9.3.0/bin'
-        LD_LIBRARY_PATH: '/home/opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/compiler/lib/intel64_lin:/data/prod/hpc-stack/gnu/9.3.0/lib64'
-        CPATH: '/data/prod/hpc-stack/gnu/9.3.0/include'
+      PATH: /opt/gcc/13.3/lib64/bin
+      LD_LIBRARY_PATH: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/opt/gcc/13.3/lib64:/opt/gcc/13.3/lib
+      CPATH: /opt/gcc/13.3/lib64/include
     extra_rpaths: []
 - compiler:
-    spec: gcc@9.3.0
+    spec: gcc@=13.3.0
     paths:
-      cc: /data/prod/hpc-stack/gnu/9.3.0/bin/gcc
-      cxx: /data/prod/hpc-stack/gnu/9.3.0/bin/g++
-      f77: /data/prod/hpc-stack/gnu/9.3.0/bin/gfortran
-      fc: /data/prod/hpc-stack/gnu/9.3.0/bin/gfortran
+      cc: /opt/gcc/13.3/bin/gcc
+      cxx: /opt/gcc/13.3/bin/g++
+      f77: /opt/gcc/13.3/bin/gfortran
+      fc: /opt/gcc/13.3/bin/gfortran
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     target: x86_64
     modules:
-    - gnu/9.3.0
+    - gcc/13.3
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@=8.5.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: []
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/s4/compilers.yaml
+++ b/configs/sites/tier1/s4/compilers.yaml
@@ -13,9 +13,9 @@ compilers:
     - intel/2023.2
     environment:
       prepend_path:
-        PATH: /opt/gcc/13.3/lib64/bin
+        PATH: /opt/gcc/13.3/bin
         LD_LIBRARY_PATH: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/opt/gcc/13.3/lib64:/opt/gcc/13.3/lib
-        CPATH: /opt/gcc/13.3/lib64/include
+        CPATH: /opt/gcc/13.3/include
     extra_rpaths: []
 - compiler:
     spec: gcc@=13.3.0

--- a/configs/sites/tier1/s4/compilers.yaml
+++ b/configs/sites/tier1/s4/compilers.yaml
@@ -1,34 +1,46 @@
 compilers:
 - compiler:
-    spec: intel@2021.5.0
+    spec: intel@=2021.10.0
     paths:
-      cc: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/icc
-      cxx: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/icpc
-      f77: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/ifort
-      fc: /opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/bin/intel64/ifort
+      cc: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/icc
+      cxx: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/icpc
+      f77: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/ifort
+      fc: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/bin/intel64/ifort
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     target: x86_64
     modules:
-    - license_intel/S4
-    - intel/2022.1
+    - intel/2023.2
     environment:
       prepend_path:
-        PATH: '/data/prod/hpc-stack/gnu/9.3.0/bin'
-        LD_LIBRARY_PATH: '/home/opt/intel/oneapi/2022.1/compiler/2022.0.1/linux/compiler/lib/intel64_lin:/data/prod/hpc-stack/gnu/9.3.0/lib64'
-        CPATH: '/data/prod/hpc-stack/gnu/9.3.0/include'
+        PATH: /opt/gcc/13.3/lib64/bin
+        LD_LIBRARY_PATH: /opt/intel/oneapi/2023.2/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/opt/gcc/13.3/lib64:/opt/gcc/13.3/lib
+        CPATH: /opt/gcc/13.3/lib64/include
     extra_rpaths: []
 - compiler:
-    spec: gcc@9.3.0
+    spec: gcc@=13.3.0
     paths:
-      cc: /data/prod/hpc-stack/gnu/9.3.0/bin/gcc
-      cxx: /data/prod/hpc-stack/gnu/9.3.0/bin/g++
-      f77: /data/prod/hpc-stack/gnu/9.3.0/bin/gfortran
-      fc: /data/prod/hpc-stack/gnu/9.3.0/bin/gfortran
+      cc: /opt/gcc/13.3/bin/gcc
+      cxx: /opt/gcc/13.3/bin/g++
+      f77: /opt/gcc/13.3/bin/gfortran
+      fc: /opt/gcc/13.3/bin/gfortran
     flags: {}
-    operating_system: centos7
+    operating_system: rocky8
     target: x86_64
     modules:
-    - gnu/9.3.0
+    - gcc/13.3
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@=8.5.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: []
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/s4/packages.yaml
+++ b/configs/sites/tier1/s4/packages.yaml
@@ -3,8 +3,6 @@ packages:
     compiler:: [intel@2021.10.0,gcc@13.3.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.10.0]
-      ## https://github.com/JCSDA/spack-stack/issues/1055
-      #zlib-api:: [zlib]
       # Remove the next three lines to switch to intel-oneapi-mkl
       blas:: [openblas]
       fftw-api:: [fftw]
@@ -139,25 +137,10 @@ packages:
     externals:
     - spec: libtool@2.4.6
       prefix: /usr
-  #libxpm:
-  #  externals:
-  #  - spec: libxpm@4.11.0
-  #    prefix: /usr
-  #lustre:
-  #  externals:
-  #  - spec: lustre@2.10.5
-  #    prefix: /usr
   m4:
     externals:
     - spec: m4@1.4.18
       prefix: /usr
-  #mysql:
-  #  buildable: False
-  #  externals:
-  #  - spec: mysql@8.0.31
-  #    prefix: /data/prod/jedi/spack-stack/mysql-8.0.31
-  #    modules:
-  #    - mysql/8.0.31
   openssh:
     externals:
     - spec: openssh@8.0p1
@@ -174,6 +157,9 @@ packages:
     externals:
     - spec: pkgconf@1.4.2
       prefix: /usr
+  # TODO - installing via spack-stack works, for example for
+  # spack-stack-1.8.0, but would be good if we didn't have to.
+  # https://github.com/JCSDA/spack-stack/issues/1329
   #qt:
   #  buildable: False
   #  externals:

--- a/configs/sites/tier1/s4/packages.yaml
+++ b/configs/sites/tier1/s4/packages.yaml
@@ -1,10 +1,10 @@
 packages:
   all:
-    compiler:: [intel@2021.5.0,gcc@9.3.0]
+    compiler:: [intel@2021.10.0,gcc@13.3.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.5.0]
-      # https://github.com/JCSDA/spack-stack/issues/1055
-      zlib-api:: [zlib]
+      mpi:: [intel-oneapi-mpi@2021.10.0]
+      ## https://github.com/JCSDA/spack-stack/issues/1055
+      #zlib-api:: [zlib]
       # Remove the next three lines to switch to intel-oneapi-mkl
       blas:: [openblas]
       fftw-api:: [fftw]
@@ -15,15 +15,18 @@ packages:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.5.0%intel@2021.5.0
-      prefix: /opt/intel/oneapi/2022.1
+    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0
+      prefix: /opt/intel/oneapi/2023.2
+      modules:
+      - intel/2023.2
   intel-oneapi-mkl:
     # Remove buildable: False and uncomment externals section below to use intel-oneapi-mkl
     buildable: False
     #externals:
-    #- spec: intel-oneapi-mkl@2022.0.1%intel@2021.5.0
-    #  prefix: /opt/intel/oneapi/2022.1
-
+    #- spec: intel-oneapi-mkl@2023.2.0%intel@2021.10.0
+    #  prefix: /opt/intel/oneapi/2023.2
+    #  modules:
+    #  - intel/2023.2
   # Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
@@ -42,47 +45,63 @@ packages:
       prefix: /usr
   automake:
     externals:
-    - spec: automake@1.15
+    - spec: automake@1.16.1
       prefix: /usr
   bash:
     externals:
-    - spec: bash@4.2.46
+    - spec: bash@4.4.20
       prefix: /usr
   berkeley-db:
     externals:
-    - spec: berkeley-db@5.3.21
+    - spec: berkeley-db@5.3.28
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.30.123
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4
       prefix: /usr
   bzip2:
     externals:
     - spec: bzip2@1.0.6
       prefix: /usr
+  cmake:
+    externals:
+    - spec: cmake@3.26.5
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.30
+      prefix: /usr
   cpio:
     externals:
-    - spec: cpio@2.11
+    - spec: cpio@2.12
+      prefix: /usr
+  curl:
+    externals:
+    - spec: curl@7.61.1+gssapi+ldap+nghttp2
       prefix: /usr
   diffutils:
     externals:
-    - spec: diffutils@3.3
-      prefix: /usr
-  doxygen:
-    externals:
-    - spec: doxygen@1.8.5+graphviz~mscgen
+    - spec: diffutils@3.6
       prefix: /usr
   file:
     externals:
-    - spec: file@5.11
+    - spec: file@5.33
       prefix: /usr
   findutils:
     externals:
-    - spec: findutils@4.5.11
+    - spec: findutils@4.6.0
       prefix: /usr
   flex:
     externals:
-    - spec: flex@2.5.37+lex
+    - spec: flex@2.6.1+lex
       prefix: /usr
   gawk:
     externals:
-    - spec: gawk@4.0.2
+    - spec: gawk@4.2.1
       prefix: /usr
   gettext:
     externals:
@@ -90,105 +109,103 @@ packages:
       prefix: /usr
   ghostscript:
     externals:
-    - spec: ghostscript@9.25
+    - spec: ghostscript@9.27
       prefix: /usr
   git:
     externals:
-    - spec: git@2.30.0+tcltk
-      prefix: /opt/git/2.30.0
-      modules:
-      - git/2.30.0
+    - spec: git@2.43.5+tcltk
+      prefix: /usr
   git-lfs:
     externals:
-    - spec: git-lfs@2.10.0
+    - spec: git-lfs@3.5.1
       prefix: /usr
   gmake:
     externals:
-    - spec: gmake@3.82
+    - spec: gmake@4.2.1
       prefix: /usr
   go:
     externals:
-    - spec: go@1.11.5
+    - spec: go@1.21.13
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.2
-      prefix: /usr
-  openjdk:
-    externals:
-    - spec: openjdk@1.8.0_262-b10
+    - spec: groff@1.22.3
       prefix: /usr
   krb5:
     externals:
-    - spec: krb5@1.15.1
-      prefix: /usr
-  libfuse:
-    externals:
-    - spec: libfuse@2.9.2
+    - spec: krb5@1.18.2
       prefix: /usr
   libtool:
     externals:
-    - spec: libtool@2.4.2
+    - spec: libtool@2.4.6
       prefix: /usr
-  libxpm:
-    externals:
-    - spec: libxpm@4.11.0
-      prefix: /usr
-  lustre:
-    externals:
-    - spec: lustre@2.10.5
-      prefix: /usr
+  #libxpm:
+  #  externals:
+  #  - spec: libxpm@4.11.0
+  #    prefix: /usr
+  #lustre:
+  #  externals:
+  #  - spec: lustre@2.10.5
+  #    prefix: /usr
   m4:
     externals:
-    - spec: m4@1.4.16
+    - spec: m4@1.4.18
       prefix: /usr
-  mysql:
-    buildable: False
+  #mysql:
+  #  buildable: False
+  #  externals:
+  #  - spec: mysql@8.0.31
+  #    prefix: /data/prod/jedi/spack-stack/mysql-8.0.31
+  #    modules:
+  #    - mysql/8.0.31
+  openssh:
     externals:
-    - spec: mysql@8.0.31
-      prefix: /data/prod/jedi/spack-stack/mysql-8.0.31
-      modules:
-      - mysql/8.0.31
-  pkg-config:
-    externals:
-    - spec: pkg-config@0.27.1
+    - spec: openssh@8.0p1
       prefix: /usr
-  qt:
-    buildable: False
+  openssl:
     externals:
-    - spec: qt@5.9.7
+    - spec: openssl@1.1.1k
       prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.26.3~cpanm+opcode+open+shared+threads
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.4.2
+      prefix: /usr
+  #qt:
+  #  buildable: False
+  #  externals:
+  #  - spec: qt@5.9.7
+  #    prefix: /usr
   rsync:
     externals:
-    - spec: rsync@3.1.2
+    - spec: rsync@3.1.3
       prefix: /usr
   ruby:
     externals:
-    - spec: ruby@2.0.0
+    - spec: ruby@2.5.9
       prefix: /usr
   sed:
     externals:
-    - spec: sed@4.2.2
+    - spec: sed@4.5
       prefix: /usr
   tar:
     externals:
-    - spec: tar@1.26
+    - spec: tar@1.30
       prefix: /usr
   texinfo:
     externals:
-    - spec: texinfo@5.1
-      prefix: /usr
-  texlive:
-    externals:
-    - spec: texlive@20130530
+    - spec: texinfo@6.5
       prefix: /usr
   wget:
     externals:
-    - spec: wget@1.14
+    - spec: wget@1.19.5
       prefix: /usr
   xz:
     externals:
-    - spec: xz@5.2.2
+    - spec: xz@5.2.4
       prefix: /usr
   zip:
     externals:

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -343,8 +343,6 @@ UW (Univ. of Wisconsin) S4
 
 The following is required for building new spack environments with any supported compiler on this platform.
 
-**NEEDS UPDATING**
-
 .. code-block:: console
 
    module purge

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -348,9 +348,6 @@ The following is required for building new spack environments with any supported
 .. code-block:: console
 
    module purge
-   module use /data/prod/jedi/spack-stack/modulefiles
-   module load miniconda/3.9.12
-   module load ecflow/5.8.4
 
 
 .. _Preconfigured_Sites_AWS_Parallelcluster:


### PR DESCRIPTION
### Summary

Update S4 site config and documentation (readthedocs) for S4 after the Rocky 8 update. For spack-stack-1.8.0. Will retag release/1.8.0 as spack-stack-1.8.0 once this PR and #1326 are merged.

See https://github.com/JCSDA/spack-stack/issues/1329 for follow-up changes for spack-stack-1.9.0.

### Testing

Installed ue-intel-2021.10.0 in test environment, official install running. Will update Wiki after the jedipara installation is complete.

Built jedi-bundle (didn't run all ctests, that is for JCSDA)

### Applications affected

n/a

### Systems affected

S4

### Dependencies

n/a

### Issue(s) addressed

Working towards #1278 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
