### PR TITLE
Release 1.8.0 additional fixes for Jet, Hercules and Orion (after running ufs-weather-model)

### DIFF
--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -15,6 +15,10 @@ packages:
     externals:
     - spec: coreutils@8.32
       prefix: /usr
+  curl:
+    externals:
+    - spec: curl@7.76.1+gssapi+ldap+nghttp2
+      prefix: /usr
   diffutils:
     externals:
     - spec: diffutils@3.7
@@ -60,6 +64,14 @@ packages:
       prefix: /work/noaa/epic/role-epic/spack-stack/hercules/mysql-8.0.31
       modules:
       - mysql/8.0.31
+  openssh:
+    externals:
+    - spec: openssh@8.7p1
+      prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@3.0.1
+      prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.7.3

--- a/configs/sites/tier1/jet/packages_intel.yaml
+++ b/configs/sites/tier1/jet/packages_intel.yaml
@@ -8,6 +8,8 @@ packages:
   intel-oneapi-mpi:
     externals:
     - spec: intel-oneapi-mpi@2021.5.1%intel@2021.5.0
+      modules:
+      - impi/2022.1.2
       prefix: /apps/oneapi
   intel-oneapi-mkl:
     externals:

--- a/configs/sites/tier1/orion/packages_gcc.yaml
+++ b/configs/sites/tier1/orion/packages_gcc.yaml
@@ -3,8 +3,6 @@ packages:
     compiler:: [gcc@12.2.0]
     providers:
       mpi:: [openmpi@4.1.4]
-      # https://github.com/JCSDA/spack-stack/issues/1055
-      zlib-api:: [zlib]
   mpi:
     buildable: False
   openmpi:

--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -3,8 +3,6 @@ packages:
     compiler:: [intel@2021.9.0,gcc@12.2.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.9.0]
-      # https://github.com/JCSDA/spack-stack/issues/1055
-      zlib-api:: [zlib]
       # Remove the next three lines to switch to intel-oneapi-mkl
       blas:: [openblas]
       fftw-api:: [fftw]


### PR DESCRIPTION
### Summary

After trying ufs-weather-model with new 1.8.0 release libraries, few machines needed small fixes:
Jet - return module line for impi
Orion: disable use of zlib instead of zlib-ng
Hercules: use system installed curl, openssh and openssl.

### Testing

Tested ufs-weather-model with this fixes

### Applications affected

WM

### Systems affected

Hercules, Orion and Jet

### Dependencies

none

### Issue(s) addressed

#1278 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
