### PR TITLE
Update modules_lmod.yaml

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -259,8 +259,6 @@ modules:
 
       hierarchy:
       - mpi
-      - g2virt
-      - g2tmplvirt
 
     prefix_inspections:
       bin:


### PR DESCRIPTION
Sorry I missed this in the review of #1312-- these virtual providers shouldn't be in modules_lmod.yaml. It causes fatal errors during installation.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
