### PR TITLE
Add note to docs for selecting branch when cloning

### DIFF
--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -215,7 +215,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. code-block:: console
 
-   git clone -b <develop OR release/branch-name> --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone [-b develop OR release/branch-name] --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -504,7 +504,7 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
 .. code-block:: console
 
-   git clone -b <develop OR release/branch-name> --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone [-b develop OR release/branch-name] --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -679,7 +679,7 @@ With all of that in mind, the following instructions were used on an Amazon Web 
 
 .. code-block:: console
 
-   git clone -b <develop OR release/branch-name> --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone [-b develop OR release/branch-name] --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -211,11 +211,11 @@ Creating a new environment
 
 Remember to activate the ``lua`` module environment and have MacTeX in your search path, if applicable. It is also recommended to increase the stacksize limit to 65Kb using ``ulimit -S -s unlimited``.
 
-1. You will need to clone spack-stack and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
+1. You will need to clone spack-stack (selecting your desired spack-stack branch) and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
 
 .. code-block:: console
 
-   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone -b <develop OR release/branch-name> --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -500,11 +500,11 @@ Creating a new environment
 
 It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimited``, and to test if the module environment functions correctly (``module available``).
 
-1. You will need to clone spack-stack and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
+1. You will need to clone spack-stack (selecting your desired spack-stack branch) and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
 
 .. code-block:: console
 
-   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone -b <develop OR release/branch-name> --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -675,11 +675,11 @@ With all of that in mind, the following instructions were used on an Amazon Web 
    module use /opt/nvidia/hpc_sdk/modulefiles
    module load nvhpc-openmpi3/24.3
 
-4. Clone spack-stack and its dependencies and activate the spack-stack tool.
+4. Clone spack-stack (selecting your desired spack-stack branch) and its dependencies and activate the spack-stack tool.
 
 .. code-block:: console
 
-   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone -b <develop OR release/branch-name> --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}


### PR DESCRIPTION
### Summary

Small change that makes instructions for building spack-stack more explicit for choosing a branch when cloning.

### Testing

Rendered docs appear as intended:
<img width="1074" alt="Screenshot 2024-10-11 at 2 32 46 PM" src="https://github.com/user-attachments/assets/95b4075b-b1e1-4b5d-87f8-9a3b1bebcf27">


### Applications affected

None

### Systems affected

None

### Dependencies

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ N/A ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
