### PR TITLE
Move NEPTUNE Python dependencies into its their own package neptune-python-env, remove legacy environment variables for NEPTUNE

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -112,20 +112,10 @@ modules:
         environment:
           set:
             'ESMFMKFILE': '{prefix}/lib/esmf.mk'
-      hdf5:
-        environment:
-          set:
-            'HDF5_DIR': '{prefix}'
       libpng:
         environment:
           set:
             'PNG_ROOT': '{prefix}'
-      libyaml:
-        environment:
-          set:
-            'YAML_DIR': '{prefix}'
-            'YAML_LIB': '{prefix}/lib'
-            'YAML_INC': '{prefix}/include'
       madis:
         environment:
           set:
@@ -151,12 +141,6 @@ modules:
           set:
             'OMPI_MCA_rmaps_base_oversubscribe': '1'
             'PRTE_MCA_rmaps_default_mapping_policy': ':oversubscribe'
-      p4est:
-        environment:
-          set:
-            'P4EST_API_DIR': '{prefix}'
-            'P4EST_API_LIB': '{prefix}/lib'
-            'P4EST_API_INC': '{prefix}/include'
       bacio:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -114,20 +114,10 @@ modules:
         environment:
           set:
             'ESMFMKFILE': '{prefix}/lib/esmf.mk'
-      hdf5:
-        environment:
-          set:
-            'HDF5_DIR': '{prefix}'
       libpng:
         environment:
           set:
             'PNG_ROOT': '{prefix}'
-      libyaml:
-        environment:
-          set:
-            'YAML_DIR': '{prefix}'
-            'YAML_LIB': '{prefix}/lib'
-            'YAML_INC': '{prefix}/include'
       madis:
         environment:
           set:
@@ -153,12 +143,6 @@ modules:
           set:
             'OMPI_MCA_rmaps_base_oversubscribe': '1'
             'PRTE_MCA_rmaps_default_mapping_policy': ':oversubscribe'
-      p4est:
-        environment:
-          set:
-            'P4EST_API_DIR': '{prefix}'
-            'P4EST_API_LIB': '{prefix}/lib'
-            'P4EST_API_INC': '{prefix}/include'
       bacio:
         environment:
           set:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,8 +8,8 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc ^esmf@8.7.0b11 snapshot=b11
-      - neptune-python-env +xnrl
+      - neptune-env +espc        ^esmf@8.7.0b11 snapshot=b11
+      - neptune-python-env +xnrl ^esmf@8.7.0b11 snapshot=b11
 
   specs:
     - matrix:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,7 +8,8 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc +python +xnrl ^esmf@8.7.0b11 snapshot=b11
+      - neptune-env +espc ^esmf@8.7.0b11 snapshot=b11
+      - neptune-python-env +xnrl
 
   specs:
     - matrix:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -17,7 +17,8 @@ spack:
     - jedi-neptune-env      ^esmf@=8.7.0b11 snapshot=b11
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env ~espc +python ~xnrl ^esmf@=8.7.0b11 snapshot=b11
+    - neptune-env           ^esmf@=8.7.0b11 snapshot=b11
+    - neptune-python-env    ^esmf@=8.7.0b11 snapshot=b11
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -21,7 +21,8 @@ spack:
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env ~espc +python ~xnrl ^esmf@=8.7.0b11 snapshot=b11
+    - neptune-env           ^esmf@=8.7.0b11 snapshot=b11
+    - neptune-python-env    ^esmf@=8.7.0b11 snapshot=b11
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.6.1
     - ufs-weather-model-env ^esmf@=8.6.1

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -211,11 +211,11 @@ Creating a new environment
 
 Remember to activate the ``lua`` module environment and have MacTeX in your search path, if applicable. It is also recommended to increase the stacksize limit to 65Kb using ``ulimit -S -s unlimited``.
 
-1. You will need to clone spack-stack and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
+1. You will need to clone spack-stack (selecting your desired spack-stack branch) and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
 
 .. code-block:: console
 
-   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone [-b develop OR release/branch-name] --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -500,11 +500,11 @@ Creating a new environment
 
 It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimited``, and to test if the module environment functions correctly (``module available``).
 
-1. You will need to clone spack-stack and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
+1. You will need to clone spack-stack (selecting your desired spack-stack branch) and its dependencies and activate the spack-stack tool. It is also a good idea to save the directory in your environment for later use.
 
 .. code-block:: console
 
-   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone [-b develop OR release/branch-name] --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
@@ -675,11 +675,11 @@ With all of that in mind, the following instructions were used on an Amazon Web 
    module use /opt/nvidia/hpc_sdk/modulefiles
    module load nvhpc-openmpi3/24.3
 
-4. Clone spack-stack and its dependencies and activate the spack-stack tool.
+4. Clone spack-stack (selecting your desired spack-stack branch) and its dependencies and activate the spack-stack tool.
 
 .. code-block:: console
 
-   git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
+   git clone [-b develop OR release/branch-name] --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}

--- a/spack-ext/repos/spack-stack/packages/neptune-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-env/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -9,7 +9,7 @@ from spack.package import *
 
 
 class NeptuneEnv(BundlePackage):
-    """Development environment for neptune standalone"""
+    """Development environment for NEPTUNE standalone"""
 
     # Fake URL
     homepage = "https://github.com/notavalidaccount/neptune"
@@ -17,11 +17,9 @@ class NeptuneEnv(BundlePackage):
 
     maintainers("climbfuji", "areinecke")
 
-    version("1.4.0")
+    version("1.5.0")
 
-    variant("python", default=True, description="Build Python dependencies")
-    variant("espc", default=True, description="Build ESPC dependencies")
-    variant("xnrl", default=True, description="Build XNRL and its extra Python dependencies")
+    variant("espc", default=False, description="Build ESPC dependencies")
 
     depends_on("base-env", type="run")
 
@@ -33,7 +31,6 @@ class NeptuneEnv(BundlePackage):
     depends_on("libyaml", type="run")
     depends_on("p4est", type="run")
     depends_on("w3emc", type="run")
-    depends_on("w3nco", type="run")
     depends_on("sp", type="run", when="%aocc")
     depends_on("ip@5:", type="run", when="%apple-clang")
     depends_on("ip@5:", type="run", when="%gcc")
@@ -43,28 +40,12 @@ class NeptuneEnv(BundlePackage):
     depends_on("nco", type="run")
     depends_on("mct", type="run")
 
-    conflicts("+xnrl", when="~python", msg="Variant xnrl requires variant python")
-
     with when("+espc"):
         depends_on("fftw", type="build")
         depends_on("netlib-lapack", type="build")
 
-    with when("+python"):
-        depends_on("py-f90nml", type="run")
-        depends_on("py-h5py", type="run")
-        depends_on("py-netcdf4", type="run")
-        depends_on("py-pandas", type="run")
-        depends_on("py-pycodestyle", type="run")
-        depends_on("py-pybind11", type="run")
-        depends_on("py-pyhdf", type="run")
-        depends_on("py-python-dateutil", type="run")
-        depends_on("py-pyyaml", type="run")
-        depends_on("py-scipy", type="run")
-        depends_on("py-xarray", type="run")
-        depends_on("py-pytest", type="run")
-        depends_on("py-fortranformat", type="run")
-
-    with when("+xnrl"):
-        depends_on("py-xnrl", type="run")
+    # Basic Python dependencies that are always needed
+    depends_on("py-f90nml", type="run")
+    depends_on("py-python-dateutil", type="run")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/neptune-python-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-python-env/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack.package import *
+
+
+class NeptunePythonEnv(BundlePackage):
+    """Development environment for NEPTUNE standalone with all Python dependencies"""
+
+    # Fake URL
+    homepage = "https://github.com/notavalidaccount/neptune"
+    git = "https://github.com/notavalidaccount/neptune.git"
+
+    maintainers("climbfuji", "areinecke")
+
+    version("1.5.0")
+
+    variant("xnrl", default=False, description="Build non-pulic XNRL")
+
+    depends_on("neptune-env", type="run")
+
+    depends_on("py-h5py", type="run")
+    depends_on("py-netcdf4", type="run")
+    depends_on("py-pandas", type="run")
+    depends_on("py-pycodestyle", type="run")
+    depends_on("py-pybind11", type="run")
+    depends_on("py-pyhdf", type="run")
+    depends_on("py-pyyaml", type="run")
+    depends_on("py-scipy", type="run")
+    depends_on("py-xarray", type="run")
+    depends_on("py-pytest", type="run")
+    depends_on("py-fortranformat", type="run")
+
+    with when("+xnrl"):
+        depends_on("py-xnrl", type="run")
+
+    # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

This PR moves the full NEPTUNE Python dependencies into their own package `neptune-python-dev`. Only the basic dependencies on `f90nml` and `python-dateutil` remain in `neptune-env` (needed by NUOPC).

The `espc` variant is turned off by default in `neptune-env`, but the `neptune-dev` template enables it. Likewise, the `xnrl` variant is turned off by default in `neptune-python-env`, but the `neptune-dev` template enables it.

Several legacy environment variables for `hdf5`, `libyaml`, `p4est` are removed from `configs/common/modules_*.yaml`.

### Testing

- [x] Manual testing on @climbfuji's development system blackpearl with `gcc` in neptune_atmos
- [x] CI testing in NEPTUNE on Nautilus with Intel classic, Intel llvm, GNU
- [x] Manual testing on @climbfuji's development system blackpearl with `gcc` in dsapi
- [x] Manual testing on @climbfuji's development system blackpearl with `gcc` in ioapi
- [x] spack-stack CI (see below)

### Applications affected

NEPTUNE, JEDI-NEPTUNE

### Systems affected

None

### Dependencies

n/a

### Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1342 (for NEPTUNE only)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
