### PR TITLE
Remove LaTeX documentation from readthedocs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,14 +1,8 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-project(spack-stack VERSION 1.3.1)
+project(spack-stack VERSION 1.9.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/Modules")
-
-option(SPHINX_OUTPUT_HTML "Build HTML documentation" ON)
-option(SPHINX_OUTPUT_LATEX "Build LaTeX (PDF) documentation" OFF)
-
-message(STATUS "SPHINX_OUTPUT_HTML: ${SPHINX_OUTPUT_HTML}")
-message(STATUS "SPHINX_OUTPUT_LATEX: ${SPHINX_OUTPUT_LATEX}")
 
 find_package(Sphinx REQUIRED)
 
@@ -20,51 +14,17 @@ set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_doctrees")
  
 # HTML output directory
 set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/html")
-
-# LaTeX output directory
-set(SPHINX_PDF_DIR "${CMAKE_CURRENT_BINARY_DIR}/pdf")
  
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/source/conf.py"
     "${BINARY_BUILD_DIR}/conf.py"
     @ONLY)
 
-if(SPHINX_OUTPUT_HTML)
-  add_custom_target(spack-stack-doc-html ALL
-      ${SPHINX_EXECUTABLE}
-          -q -b html
-          -c "${BINARY_BUILD_DIR}"
-          -d "${SPHINX_CACHE_DIR}"
-          "${CMAKE_CURRENT_SOURCE_DIR}/source"
-          "${SPHINX_HTML_DIR}"
-      COMMENT "Building HTML documentation with Sphinx")
-endif()
-
-if(SPHINX_OUTPUT_LATEX)
-  find_package(LATEX COMPONENTS PDFLATEX REQUIRED)
-  set(PDF_OUTPUT_FILE "${SPHINX_PDF_DIR}/spack-stack.pdf")
-  # Create LaTeX input file with Sphinx
-  add_custom_command(OUTPUT "${SPHINX_PDF_DIR}"
-      COMMAND "${SPHINX_EXECUTABLE}" -q -b latex
-          -c "${BINARY_BUILD_DIR}"
-          -d "${SPHINX_CACHE_DIR}"
-          "${CMAKE_CURRENT_SOURCE_DIR}/source"
-          "${SPHINX_PDF_DIR}"
-      COMMENT "Running Sphinx to generate documentation (LaTeX)"
-      VERBATIM
-      )
-  # Create PDF output file with pdflatex
-  add_custom_command(OUTPUT "${PDF_OUTPUT_FILE}"
-      COMMAND "${CMAKE_MAKE_PROGRAM}" all-pdf
-      WORKING_DIRECTORY "${SPHINX_PDF_DIR}"
-      DEPENDS "${SPHINX_PDF_DIR}"
-      COMMENT "Generating PDF version of documentation"
-      VERBATIM
-      )
-  #
-  add_custom_target(spack-stack-doc-pdf ALL
-      COMMENT "Generating PDF version of documentation ..."
-      SOURCES "${PDF_OUTPUT_FILE}"
-      VERBATIM
-      )
-endif()
+add_custom_target(spack-stack-doc-html ALL
+    ${SPHINX_EXECUTABLE}
+        -q -b html
+        -c "${BINARY_BUILD_DIR}"
+        -d "${SPHINX_CACHE_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/source"
+        "${SPHINX_HTML_DIR}"
+    COMMENT "Building HTML documentation with Sphinx")

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,1 @@
-sphinxcontrib-bibtex
 urllib3<2

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -175,7 +175,8 @@ These instructions are meant to be a reference that users can follow to set up t
   Make sure you upgrade cmake in homebrew.
 
 .. code-block:: console
-  brew upgrade cmake
+
+   brew upgrade cmake
 
 4. Configure your terminal to use the homebrew installed bash
 
@@ -671,6 +672,7 @@ With all of that in mind, the following instructions were used on an Amazon Web 
 3. Load the correct module shipped with ``nvhpc-24-3``. Note that this is only required for ``spack`` to detect the compiler and ``openmpi`` library during the environment configuration below. It is not required when using the new environment to compile code.
 
 .. code-block:: console
+
    module purge
    module use /opt/nvidia/hpc_sdk/modulefiles
    module load nvhpc-openmpi3/24.3

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,11 +51,8 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'sphinx.ext.napoleon',
-    'sphinxcontrib.bibtex'
+    'sphinx.ext.napoleon'
 ]
-
-bibtex_bibfiles = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -122,37 +119,6 @@ html_theme_options = {"body_max_width": "none"}
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'spack-stack'
-
-
-# -- Options for LaTeX output ------------------------------------------------
-
-latex_engine = 'pdflatex'
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-    'maketitle': r'\newcommand\sphinxbackoftitlepage{For referencing this document please use: \newline \break Heinzeller, D., A. Richert, C. Book, E. Hartnett, H. Lei, N. Perlin, R. Vasic, S. Herbener, 2024. spack-stack documentation develop. Available at https://spack-stack.readthedocs.io/\textunderscore/downloads/en/latest/pdf/.}\sphinxmaketitle'
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'spack-stack.tex', 'spack-stack documentation',
-     author,'manual'),
-]
 
 
 # -- Options for manual page output ------------------------------------------


### PR DESCRIPTION
### Summary

Remove LaTeX documentation from the readthedocs configuration and fix two formatting errors in `doc/source/NewSiteConfigs.rst`. There are four warnings when I build the documentation manually, but no errors anymore. I checked the rendered HTML documentation, and the output looks ok (not sure what the warnings are about).

### Testing

See readthedocs build below (https://spack-stack--1346.org.readthedocs.build/en/1346/NewSiteConfigs.html)

### Applications affected

none

### Systems affected

none

### Dependencies

none

### Issue(s) addressed

Resolves #1069 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
