### PR TITLE
[skip ci] Bug fix for wrong local-source paths on Narwhal and Nautilus

### DIFF
--- a/configs/sites/tier1/narwhal/mirrors.yaml
+++ b/configs/sites/tier1/narwhal/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/build-cache
+      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/build-cache
+      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/source-cache
       access_pair:
       - null
       - null

--- a/configs/sites/tier1/nautilus/mirrors.yaml
+++ b/configs/sites/tier1/nautilus/mirrors.yaml
@@ -1,7 +1,7 @@
 mirrors:
   local-source:
     fetch:
-      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/build-cache
+      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/source-cache
       access_pair:
       - null
       - null
@@ -9,7 +9,7 @@ mirrors:
       profile: null
       endpoint_url: null
     push:
-      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/build-cache
+      url: file:///p/cwfs/projects/NEPTUNE/spack-stack/source-cache
       access_pair:
       - null
       - null


### PR DESCRIPTION
### Summary

A small typo in the `local-source directory names for Narwhal and Nautilus, must be `source-cache` instead of `build-cache`. This typo had no effect yet. Can merge without running the CI tests.

### Testing

Verified that the new paths are indeed correct

### Applications affected

None

### Systems affected

Narwhal, Nautilus

### Dependencies

n/a

### Issue(s) addressed

n'a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
