### PR TITLE
Update spack-stack-dev from spack develop as of 2024/10/31

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -159,7 +159,7 @@ jobs:
           source ./setup.sh
           # Important!
           export SPACK_PYTHON=/usr/bin/python3
-          export BUILDCACHE_ENVNAME=ue-apple-clang-14.0.3-builddcache
+          export BUILDCACHE_ENVNAME=ue-apple-clang-14.0.3-buildcache
           export BUILDCACHE_ENVDIR=$PWD/envs/${BUILDCACHE_ENVNAME}
           export ENVNAME=ue-apple-clang-14.0.3
           export ENVDIR=$PWD/envs/${ENVNAME}

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p /Users/ec2-user/spack-stack/build-cache
           mkdir -p /Users/ec2-user/spack-stack/source-cache
 
-      - name: create-env
+      - name: create-buildcache
         run: |
           # Get day of week to decide whether to use build caches or not
           DOW=$(date +%u)
@@ -56,15 +56,13 @@ jobs:
           source ./setup.sh
           # Important!
           export SPACK_PYTHON=/usr/bin/python3
-          export ENVNAME=ue-apple-clang-14.0.3
-          export ENVDIR=$PWD/envs/${ENVNAME}
-
           spack clean -ab
           spack bootstrap now
-
+          #
+          export ENVNAME=ue-apple-clang-14.0.3-buildcache
+          export ENVDIR=$PWD/envs/${ENVNAME}
           spack stack create env --site macos.default --template unified-dev --name ${ENVNAME} --compiler apple-clang
           spack env activate ${ENVDIR}
-          spack add ${{ inputs.specs || '' }}
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
@@ -86,8 +84,11 @@ jobs:
 
           export -n SPACK_SYSTEM_CONFIG_PATH
 
+          # For buildcaches
+          spack config add config:install_tree:padded_length:200
+
           # Set compiler and MPI specs
-          spack config add "packages:all:providers:mpi:[openmpi@5.0.3]"
+          spack config add "packages:all:providers:mpi:[openmpi@5.0.5]"
           spack config add "packages:all:compiler:[apple-clang@14.0.3]"
 
           # Add additional variants for MET packages, different from config/common/packages.yaml
@@ -97,8 +98,8 @@ jobs:
           # *DH
 
           # Concretize and check for duplicates
-          spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.3
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm -i esmf -i mapl
+          spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.3-buildcache
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3-buildcache -i fms -i crtm -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///Users/ec2-user/spack-stack/source-cache/
@@ -128,6 +129,11 @@ jobs:
           spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.apple-clang-14.0.3.jedi-base-env
           spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ jedi-base-env
 
+          # jedi-ufs-env
+          echo "jedi-ufs-env ..."
+          spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.apple-clang-14.0.3.jedi-ufs-env
+          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ jedi-ufs-env
+
           # the rest
           echo "unified-env ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.3.unified-env
@@ -138,12 +144,44 @@ jobs:
             spack mirror rm local-binary
           fi
 
+          # Remove buildcache config settings
+          spack config remove config:install_tree:padded_length
+
+          # Next steps: synchronize source and build cache to a central/combined mirror?
+
+          # Cleanup
+          spack clean -a
+          spack env deactivate
+
+      - name: create-env
+        run: |
+          # Set up spack-stack
+          source ./setup.sh
+          # Important!
+          export SPACK_PYTHON=/usr/bin/python3
+          export BUILDCACHE_ENVNAME=ue-apple-clang-14.0.3-builddcache
+          export BUILDCACHE_ENVDIR=$PWD/envs/${BUILDCACHE_ENVNAME}
+          export ENVNAME=ue-apple-clang-14.0.3
+          export ENVDIR=$PWD/envs/${ENVNAME}
+          rsync -av --exclude='install' --exclude='spack.lock' --exclude='.spack_db' ${BUILDCACHE_ENVDIR}/ ${ENVDIR}/
+          spack env activate ${ENVDIR}
+
+          # Concretize and check for duplicates
+          spack concretize --force 2>&1 | tee log.concretize.apple-clang-14.0.3
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm -i esmf -i mapl
+
+          # Add binary cache back in
+          spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/
+          echo "Packages in combined spack build caches:"
+          spack buildcache list
+
+          # Install from cache
+          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.3.unified-env
+
           # Create modules
           spack clean -a
           spack module lmod refresh -y
           spack stack setup-meta-modules
-
-          # Next steps: synchronize source and build cache to a central/combined mirror?
           spack env deactivate
 
           # Test environment chaining
@@ -160,7 +198,6 @@ jobs:
 
       - name: test-env
         run: |
-          # Set up homebrew and lmod support
           eval "$(/opt/homebrew/bin/brew shellenv)"
           source /opt/homebrew/opt/lmod/init/profile
 
@@ -170,7 +207,7 @@ jobs:
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-apple-clang/14.0.3
-          module load stack-openmpi/5.0.3
+          module load stack-openmpi/5.0.5
           module load stack-python/3.11.7
           module available
 

--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -122,22 +122,22 @@ jobs:
           # base-env
           echo "base-env ..."
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.apple-clang-14.0.3.base-env
-          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ base-env
+          spack buildcache create -u /Users/ec2-user/spack-stack/build-cache/ base-env
 
           # jedi-base-env
           echo "jedi-base-env ..."
           spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.apple-clang-14.0.3.jedi-base-env
-          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ jedi-base-env
+          spack buildcache create -u /Users/ec2-user/spack-stack/build-cache/ jedi-base-env
 
           # jedi-ufs-env
           echo "jedi-ufs-env ..."
           spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.apple-clang-14.0.3.jedi-ufs-env
-          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/ jedi-ufs-env
+          spack buildcache create -u /Users/ec2-user/spack-stack/build-cache/ jedi-ufs-env
 
           # the rest
           echo "unified-env ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.apple-clang-14.0.3.unified-env
-          spack buildcache create -a -u /Users/ec2-user/spack-stack/build-cache/
+          spack buildcache create -u /Users/ec2-user/spack-stack/build-cache/
 
           # Remove binary cache for next round of concretization
           if [ "$USE_BINARY_CACHE" = true ] ; then

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -122,6 +122,11 @@ jobs:
             spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-base-env
             spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
 
+            # jedi-ufs-env
+            echo "jedi-ufs-env ..."
+            spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-ufs-env
+            spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+
             # the rest
             echo "${TEMPLATE} ..."
             spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}
@@ -145,6 +150,7 @@ jobs:
 
       - name: create-env
         run: |
+          # Set up spack-stack
           source ./setup.sh
           export BUILDCACHE_ENVNAME=ue-gcc-11.4.0-buildcache
           export BUILDCACHE_ENVDIR=$PWD/envs/${BUILDCACHE_ENVNAME}
@@ -153,20 +159,22 @@ jobs:
           rsync -av --exclude='install' --exclude='spack.lock' --exclude='.spack_db' ${BUILDCACHE_ENVDIR}/ ${ENVDIR}/
           spack env activate ${ENVDIR}
 
-          # Concretize
+          # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.gnu-11.4.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.gnu-11.4.0 -i fms -i crtm -i esmf -i mapl
 
-          # Add binary cache back in and reindex it
+          # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
-          # base-env
-          echo "base-env ..."
+          # Install from cache
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.gnu-11.4.0.unified-env
 
+          # Check shared libraries
           ${SPACK_STACK_DIR}/util/ldd_check.py $SPACK_ENV 2>&1 | tee log.ldd_check
+
+          # Create modules
           spack clean -a
           spack module tcl refresh -y
           spack stack setup-meta-modules
@@ -201,7 +209,7 @@ jobs:
 
           module use ${ENVDIR}/install/modulefiles/Core
           module load stack-gcc/11.4.0
-          module load stack-openmpi/5.0.3
+          module load stack-openmpi/5.0.5
           module load stack-python/3.11.7
           module available
 

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -115,22 +115,22 @@ jobs:
             # base-env
             echo "base-env ..."
             spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.base-env
-            spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ base-env
+            spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ base-env
 
             # jedi-base-env
             echo "jedi-base-env ..."
             spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-base-env
-            spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
+            spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
 
             # jedi-ufs-env
             echo "jedi-ufs-env ..."
             spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-ufs-env
-            spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+            spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
 
             # the rest
             echo "${TEMPLATE} ..."
             spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}
-            spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/
+            spack buildcache create -u /home/ubuntu/spack-stack/build-cache/
 
             # Remove binary cache for next round of concretization
             if [ "$USE_BINARY_CACHE" = true ] ; then

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -93,7 +93,7 @@ jobs:
           echo "  intel-oneapi-mpi:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "    buildable: false" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "    externals:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
-          echo "    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
+          echo "    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0 +classic-names" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "      prefix: /opt/intel/oneapi" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
           # Add external Intel MKL and oneAPI runtime
@@ -161,6 +161,11 @@ jobs:
           echo "jedi-base-env ..."
           spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.intel-2021.10.0-buildcache.jedi-base-env
           spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
+
+          # jedi-ufs-env
+          echo "jedi-ufs-env ..."
+          spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.intel-2021.10.0-buildcache.jedi-ufs-env
+          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
 
           # the rest
           echo "unified-env ..."

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -183,6 +183,7 @@ jobs:
 
       - name: create-env
         run: |
+          # Set up spack-stack
           source ./setup.sh
           export BUILDCACHE_ENVNAME=ue-intel-2021.10.0-buildcache
           export BUILDCACHE_ENVDIR=$PWD/envs/${BUILDCACHE_ENVNAME}
@@ -191,20 +192,22 @@ jobs:
           rsync -av --exclude='install' --exclude='spack.lock' --exclude='.spack_db' ${BUILDCACHE_ENVDIR}/ ${ENVDIR}/
           spack env activate ${ENVDIR}
 
-          # Concretize
+          # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.intel-2021.10.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2021.10.0 -i fms -i crtm -i esmf -i mapl
 
-          # Add binary cache back in and reindex it
+          # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
-          # base-env
-          echo "base-env ..."
+          # Install from cache
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.intel-2021.10.0.unified-env
 
+          # Check shared libraries
           ${SPACK_STACK_DIR}/util/ldd_check.py $SPACK_ENV 2>&1 | tee log.ldd_check
+
+          # Create modules
           spack clean -a
           spack module tcl refresh -y
           spack stack setup-meta-modules

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -155,22 +155,22 @@ jobs:
           # base-env
           echo "base-env ..."
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.intel-2021.10.0-buildcache.base-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ base-env
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ base-env
 
           # jedi-base-env
           echo "jedi-base-env ..."
           spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.intel-2021.10.0-buildcache.jedi-base-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
 
           # jedi-ufs-env
           echo "jedi-ufs-env ..."
           spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.intel-2021.10.0-buildcache.jedi-ufs-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
 
           # the rest
           echo "unified-env ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.intel-2021.10.0-buildcache.unified-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/
 
           # Remove binary cache for next round of concretization
           if [ "$USE_BINARY_CACHE" = true ] ; then

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -168,6 +168,11 @@ jobs:
           spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.jedi-base-env
           spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
 
+          # jedi-ufs-env
+          echo "jedi-ufs-env ..."
+          spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.jedi-ufs-env
+          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+
           # the rest
           echo "unified-env ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.unified-env
@@ -189,6 +194,7 @@ jobs:
 
       - name: create-env
         run: |
+          # Set up spack-stack
           source ./setup.sh
           export BUILDCACHE_ENVNAME=ue-oneapi-2024.2.0-buildcache
           export BUILDCACHE_ENVDIR=$PWD/envs/${BUILDCACHE_ENVNAME}
@@ -197,38 +203,26 @@ jobs:
           rsync -av --exclude='install' --exclude='spack.lock' --exclude='.spack_db' ${BUILDCACHE_ENVDIR}/ ${ENVDIR}/
           spack env activate ${ENVDIR}
 
-          # Concretize
+          # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.oneapi-2024.2.0
           ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-2024.2.0 -i fms -i crtm -i esmf -i mapl
 
-          # Add binary cache back in and reindex it
+          # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
           echo "Packages in combined spack build caches:"
           spack buildcache list
 
-          # base-env
-          echo "base-env ..."
+          # Install from cache
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneapi-2024.2.0.unified-env
 
+          # Check shared libraries
           ${SPACK_STACK_DIR}/util/ldd_check.py $SPACK_ENV 2>&1 | tee log.ldd_check
+
+          # Create modules
           spack clean -a
           spack module tcl refresh -y
           spack stack setup-meta-modules
           spack env deactivate
-
-          ### # Test environment chaining
-          ### echo "Test environment chaining"
-          ### spack stack create env --name chaintest --template empty --site linux.default --upstream ${ENVDIR}/install --compiler intel
-          ### # Retain config from upstream so we don't have to rebuild:
-          ### cp -r ${ENVDIR}/{site,common} $PWD/envs/chaintest/.
-          ### spack env activate ${PWD}/envs/chaintest
-          ### # Pin gmake to avoid duplicate packages (excluded gmake from spack external find above)
-          ### spack config add "packages:gmake:require:'@:4.2'"
-          ### spack add nccmp@1.9.0.1%oneapi
-          ### spack concretize | tee envs/chaintest/log.concretize
-          ### unwanted_duplicates=$(( cat envs/chaintest/log.concretize | grep -E '^ - ' | grep -Fv 'nccmp@1.9.0.1' || true ) | wc -l)
-          ### if [ ${unwanted_duplicates} -gt 0 ]; then echo "Environment chaining test failed"; exit 1; fi
-          ### spack env deactivate
 
       - name: test-env
         run: |

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -161,22 +161,22 @@ jobs:
           # base-env
           echo "base-env ..."
           spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.base-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ base-env
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ base-env
 
           # jedi-base-env
           echo "jedi-base-env ..."
           spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.jedi-base-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
 
           # jedi-ufs-env
           echo "jedi-ufs-env ..."
           spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.jedi-ufs-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
 
           # the rest
           echo "unified-env ..."
           spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneapi-2024.2.0-buildcache.unified-env
-          spack buildcache create -a -u /home/ubuntu/spack-stack/build-cache/
+          spack buildcache create -u /home/ubuntu/spack-stack/build-cache/
 
           # Remove binary cache for next round of concretization
           if [ "$USE_BINARY_CACHE" = true ] ; then

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_from_spack_dev_20241031
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_from_spack_dev_20241031
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -102,7 +102,7 @@ packages:
     # Note: Uncommenting this entry will break
     # the container builds.
     #require: '@2.11.0'
-    # To avoid duplicate packages being built
+  # To avoid duplicate packages being built
   gmake:
     require:
     - one_of: ['@=4.2.1', '@=4.4.1']
@@ -142,6 +142,10 @@ packages:
   mapl:
     require: '@2.46.3 ~shared ~f2py'
     variants: '+pflogger'
+  # To avoid duplicate packages being built
+  meson:
+    require:
+    - '@1.5.1:'
   # If making changes here, also check the Discover site configs and the CI workflows
   met:
     require: '@11.1.1 +python +grib2'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -102,6 +102,10 @@ packages:
     # Note: Uncommenting this entry will break
     # the container builds.
     #require: '@2.11.0'
+    # To avoid duplicate packages being built
+  gmake:
+    require:
+    - one_of: ['@=4.2.1', '@=4.4.1']
   grib-util:
     require: '@1.4.0'
   gsibec:
@@ -170,7 +174,7 @@ packages:
   odc:
     require: '@1.5.2 ~fortran'
   openblas:
-    require: '@0.3.24 +noavx512'
+    require: '@0.3.24'
   openmpi:
     require: '~internal-hwloc +two_level_namespace'
   openssl:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -28,7 +28,7 @@ spack:
       require: '%gcc'
       target: [x86_64]
       providers:
-        mpi: [openmpi@5.0.3]
+        mpi: [openmpi@5.0.5]
       compiler: [gcc@12.3.0]
     gcc:
       buildable: false

--- a/configs/sites/tier1/narwhal/compilers.yaml
+++ b/configs/sites/tier1/narwhal/compilers.yaml
@@ -9,7 +9,7 @@ compilers::
       flags: {}
       operating_system: sles15
       modules:
-      - PrgEnv-intel/8.3.3
+      - PrgEnv-intel/8.4.0
       - intel-classic/2023.2.0
       - cray-libsci/23.05.1.4
       - libfabric/1.12.1.2.2.1
@@ -55,7 +55,7 @@ compilers::
       flags: {}
       operating_system: sles15
       modules:
-      - PrgEnv-gnu/8.3.3
+      - PrgEnv-gnu/8.4.0
       - gcc/10.3.0
       - cray-libsci/23.05.1.4
       - libfabric/1.12.1.2.2.1

--- a/configs/sites/tier2/blackpearl/config.yaml
+++ b/configs/sites/tier2/blackpearl/config.yaml
@@ -1,2 +1,2 @@
 config:
-  build_jobs: 2
+  build_jobs: 1

--- a/configs/sites/tier2/blackpearl/packages_gcc.yaml
+++ b/configs/sites/tier2/blackpearl/packages_gcc.yaml
@@ -2,4 +2,4 @@ packages:
   all:
     compiler:: [gcc@13.3.0]
     providers:
-      mpi:: [openmpi@5.0.3]
+      mpi:: [openmpi@5.0.5]

--- a/configs/sites/tier2/bounty/packages_gcc.yaml
+++ b/configs/sites/tier2/bounty/packages_gcc.yaml
@@ -2,4 +2,4 @@ packages:
   all:
     compiler:: [gcc@12.3.0]
     providers:
-      mpi:: [openmpi@5.0.3]
+      mpi:: [openmpi@5.0.5]

--- a/configs/templates/nco/spack.yaml
+++ b/configs/templates/nco/spack.yaml
@@ -35,7 +35,7 @@ spack:
   - g2
   - g2c
   - g2tmpl
-  - gdal
+  - gdal@3.8.5
   - geos
   - gfsio
   - gftl-shared

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -13,7 +13,7 @@ spack:
     - geos-gcm-env          ^esmf@=8.6.1
     - global-workflow-env   ^esmf@=8.6.1
     - gmao-swell-env
-    - gsi-env               ^esmf@=8.6.1
+    - gsi-env
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env


### PR DESCRIPTION
### Summary

- Update submodule pointer for spack for the changes in https://github.com/JCSDA/spack/pull/482 (update from spack develop as of 2024/10/31)
- Make macOS CI test look like the UBuntu CI tests (split into two steps: first create buildcache environment, then install test environment from the buildcache)
- Remove deprecated `-a` flag from `spack buildcache push` for all GitHub actions workflows
- Add `+classic-names` to the `intel-oneapi-mpi` external package definition in GitHub actions. May need to do the same for each of the preconfigured sites when using `icc`+`icpc`+`ifort`. Without `+classic-names`, it works for `icx`+`icpx`+`ifort` and for ``icx`+`icpx`+`ifx`.
- Updates to `configs/common/packages.yaml` to remove deprecated variants and pin certain packages to avoid duplicate packages 
- Update tier2 site config for blackpeark and bump PrgEnv for Narwhal
- Bug fix: gsi-env does not depend on `esmf`, for some reason the concretizer didn't realize this until now

### Testing

Describe the testing done for this PR.
- [x] Built NEPTUNE standalone environment on Blackpearl with `gcc@13.3.0`, compiled NEPTUNE with it
- [x] Built NEPTUNE standalone environment on Blackpearl with `oneapi@2024.2.1`, compiled NEPTUNE with it
- [x] Built unified environment on Blackpearl with `gcc@13.3.0`
- [x] @srherbener tested JEDI on macOS and got the same successes/failures as with the current spack-stack develop branch (thanks for testing!)
- [x] CI
- [x] Tested UE concretization on Acorn (@AlexanderRichert-NOAA)
- [x] Tested installing NCO stack on Acorn (@AlexanderRichert-NOAA)

### Applications affected

Potentially all

### Systems affected

None directly

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack/pull/482

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1181

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
