### PR TITLE
Updated macos notes to reflect that apple-clang@15.x compilers are now fully supported

### DIFF
--- a/doc/source/KnownIssues.rst
+++ b/doc/source/KnownIssues.rst
@@ -109,10 +109,6 @@ macOS
 
    Can happen when trying to use the raster plotting scripts in ``fv3-jedi-tools``. In that case, exporting ``DYLD_LIBRARY_PATH=/usr/lib/:$DYLD_LIBRARY_PATH`` can help. If ``git`` commands fail after this, you might need to verify where ``which git`` points to (Homebrew vs module) and unload the ``git`` module.
 
-6. Not all versions of ``apple-clang@15.0.0`` are currently supported.
-
-   If you are running macOS Sonoma 14.5 you may have a recent version of clang that does not yet build spack packages. On the console you should run ``clang --version`` and verify that the underlying clang compiler is ``clang-1500.1.0.2.5`` which is the version provided with Command Line Tools for XCode 15.1. You can downgrade your Command Line Tool packages by first running ``sudo rm -rf /Library/Developer/CommandLineTools`` then you can download and install the Command Line Tools 15.1 APK from `developer.apple.com <https://developer.apple.com/download/all/>`_. The Apple Developer site requires an iCloud login.
-
 ==============================
 Ubuntu
 ==============================

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -32,8 +32,7 @@ The instructions below are for GNU (`gcc`), since this is the easiest and best s
   We have noted problems on some - not all - platforms with ``intel@2021.5.0`` when we switched from ``zlib`` to ``zlib-ng`` in spack-stack-1.7.0. These issues went away when using a different version of the compiler (anything between 2021.3.0 and 2021.11.0). It is therefore recommended to avoid using ``intel@2021.5.0`` unless it is the only option.
 
 .. [#fn2]
-  Note that ``apple-clang@14.x`` compiler versions are fully supported, and ``apple-clang@15.0.0`` will work but requires the :ref:`workaround noted below<apple-clang-15-workaround>`.
-  Also, when using ``apple-clang@15.0.0`` you must use Command Line Tools version 15.1, and the Command Line Tools versions 15.3 and newer are not yet supported.
+  Note that ``apple-clang@14.x`` and ``apple-clang@15.x`` compiler versions are fully supported, and when using ``apple-clang@15.x`` the :ref:`workaround noted below<apple-clang-15-workaround>` is required.
 
 .. [#fn3]
   Support for Nvidia compilers is experimental and limited to a subset of packages. Please refer to :numref:`Section %s <NewSiteConfigs_Linux_CreateEnv_Nvidia>` below.
@@ -285,8 +284,8 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 
 .. _apple-clang-15-workaround:
 .. note::
-  When using apple-clang@15.0.0 (or newer) compilers, you need to manually add the following ldflags spec in the `site/compilers.yaml` file.
-  There are known issues with new features in the Apple linker/loader that comes with the 15.0.0 compiler set, and this change tells the linker/loader to use its legacy features which work fine.
+  When using apple-clang@15.x (or newer) compilers, you need to manually add the following ldflags spec in the `site/compilers.yaml` file.
+  There are known issues with new features in the Apple linker/loader that comes with the 15.x compiler set, and this change tells the linker/loader to use its legacy features which work fine.
 
 .. code-block:: yaml
   :emphasize-lines: 9,10


### PR DESCRIPTION
### Summary

The note about apple-clang@15.0.0 compilers being restricted to Command Line Tools 15.1 no longer applies, so this information was removed from the MacOS build instructions.

### Testing

Built the updated html docs on my Mac and verified that the NewSiteConfig.rst changes rendered properly.

### Applications affected

Applications run on MacOS platform

### Systems affected

MacOS

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
