### PR TITLE
Update new machine (Gaea-C6) and upgraded machine (Gaea-C5)

### DIFF
--- a/configs/sites/tier1/gaea-c5/compilers.yaml
+++ b/configs/sites/tier1/gaea-c5/compilers.yaml
@@ -1,22 +1,22 @@
 compilers:
 - compiler:
-    spec: intel@2023.1.0
+    spec: intel@2023.2.0
     paths:
       cc: cc
       cxx: CC
       f77: ftn
       fc: ftn
-    flags: {}
     operating_system: sles15
     modules:
-    - PrgEnv-intel/8.3.3
-    - intel-classic/2023.1.0
-    - craype/2.7.20
+    - PrgEnv-intel/8.5.0
+    - intel-classic/2023.2.0
+    - craype/2.7.30
+    - libfabric/1.20.1
+    flags:
+      cflags: "-gcc-name=/usr/bin/gcc-12"
+      cxxflags: "-gxx-name=/usr/bin/g++-12 -gcc-name=/usr/bin/gcc-12 -static-libstdc++"
+      fflags: "-gcc-name=/usr/bin/gcc-12"
     environment:
-      prepend_path:
-        PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
-        CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
-        LD_LIBRARY_PATH: '/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
       set:
         # OpenSUSE on Gaea C5 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
@@ -24,15 +24,15 @@ compilers:
         CONFIG_SITE: ''
     extra_rpaths: []
 - compiler:
-    spec: gcc@12.2.0
+    spec: gcc@12.3.0
     paths:
-      cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
-      cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
-      f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-      fc:  /opt/cray/pe/gcc/12.2.0/bin/gfortran
+      cc: /usr/bin/gcc-12
+      cxx: /usr/bin/g++-12
+      f77: /usr/bin/gfortran-12
+      fc:  /usr/bin/gfortran-12
     flags: {}
     operating_system: sles15
     modules:
-    - gcc/12.2.0
+    - gcc-native-mixed/12.3
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -1,8 +1,8 @@
 packages:
   all:
-    compiler:: [intel@2023.1.0] # todo: add gcc here
+    compiler:: [intel@2023.2.0] # todo: add gcc here
     providers:
-      mpi:: [cray-mpich@8.1.25]
+      mpi:: [cray-mpich@8.1.28]
       # Remove the next three lines to switch to intel-oneapi-mkl
       blas:: [openblas]
       fftw-api:: [fftw]
@@ -13,11 +13,10 @@ packages:
     buildable: False
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.25%intel@2023.1.0~wrappers
-      prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
+    - spec: cray-mpich@8.1.28%intel@2023.2.0~wrappers
       modules:
       - craype-network-ofi
-      - cray-mpich/8.1.25
+      - cray-mpich/8.1.28
   intel-oneapi-mkl:
     # Remove buildable: False and configure+uncomment externals section below to use intel-oneapi-mkl
     buildable: False
@@ -53,25 +52,25 @@ packages:
       prefix: /usr
   binutils:
     externals:
-    - spec: binutils@2.37.20211103
+    - spec: binutils@2.41
       prefix: /usr
   # Don't use, it's missing the headers
   #bzip2:
   #  externals:
   #  - spec: bzip2@1.0.6
   #    prefix: /usr
-  cmake:
-    buildable: false
-    externals:
-    - spec: cmake@3.23.1
-      modules: [cmake/3.23.1]
+# cmake:
+#   buildable: false
+#   externals:
+#   - spec: cmake@3.23.1
+#     modules: [cmake/3.23.1]
   coreutils:
     externals:
     - spec: coreutils@8.32
       prefix: /usr
   cpio:
     externals:
-    - spec: cpio@2.12
+    - spec: cpio@2.13
       prefix: /usr
   diffutils:
     externals:
@@ -121,23 +120,23 @@ packages:
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.3
+    - spec: groff@1.22.4
       prefix: /usr
   hwloc:
     externals:
-    - spec: hwloc@2.6.0a1
+    - spec: hwloc@2.9.0
       prefix: /usr
   # This package is currently incomplete (no headers), but still works
   krb5:
     externals:
-    - spec: krb5@1.16.3
+    - spec: krb5@1.20
       #prefix: /usr/lib/mit
       prefix: /usr
   libfuse:
     externals:
     - spec: libfuse@2.9.7
       prefix: /usr
-    - spec: libfuse@3.6.1
+    - spec: libfuse@3.10.5
       prefix: /usr
   libtirpc:
     variants: ~gssapi
@@ -148,7 +147,7 @@ packages:
       prefix: /usr
   libxml2:
     externals:
-    - spec: libxml2@2.9.7
+    - spec: libxml2@2.10.3
       prefix: /usr
   # This package is currently incomplete (no headers) and doesn't work
   # for us. But it's only needed to build libxaw, for which we can use
@@ -168,16 +167,15 @@ packages:
   mysql:
     buildable: False
     externals:
-    - spec: mysql@8.0.31
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/mysql-8.0.31
-      modules: [mysql/8.0.31]
+    - spec: mysql@8.0.36
+      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/mysql-8.0.36
   ncurses:
     externals:
     - spec: ncurses@6.1.20180317+termlib abi=6
       prefix: /usr
   openjdk:
     externals:
-    - spec: openjdk@11.0.16_8-suse-150000.3.83.1-x8664
+    - spec: openjdk@11.0.22
       prefix: /usr
   perl:
     externals:
@@ -191,14 +189,14 @@ packages:
   qt:
     externals:
     - spec: qt@5.15.2
-      prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
+      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
   rdma-core:
     externals:
-    - spec: rdma-core@37.0
+    - spec: rdma-core@42.0
       prefix: /usr
   rsync:
     externals:
-    - spec: rsync@3.1.3
+    - spec: rsync@3.2.3
       prefix: /usr
   ruby:
     externals:
@@ -210,19 +208,15 @@ packages:
       prefix: /usr
   slurm:
     externals:
-    - spec: slurm@21.08.8
+    - spec: slurm@24.05.3
       prefix: /usr
   subversion:
     externals:
-    - spec: subversion@1.10.6
+    - spec: subversion@1.14.1
       prefix: /usr
   tar:
     externals:
     - spec: tar@1.34
-      prefix: /usr
-  texinfo:
-    externals:
-    - spec: texinfo@6.5
       prefix: /usr
   wget:
     externals:

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -264,9 +264,9 @@ The following is required for building new spack environments with Intel on this
 .. code-block:: console
 
    # These modules should be loaded by default, if not load (swap) with:
-   module load PrgEnv-intel/8.3.3
-   module load intel-classic/2023.1.0
-   module load cray-mpich/8.1.25
+   module load PrgEnv-intel/8.5.0
+   module load intel-classic/2023.2.0
+   module load cray-mpich/8.1.28
    module load python/3.9.12
 
 
@@ -292,10 +292,10 @@ The following is required for building new spack environments with Intel on this
 .. code-block:: console
 
    # These modules should be loaded by default, if not load (swap) with:
-   module load PrgEnv-intel/8.3.3
+   module load PrgEnv-intel/8.5.0
    module load intel-classic/2023.2.0
-   module load cray-mpich/8.1.25
-   module load python/3.9.12
+   module load cray-mpich/8.1.29
+   module load python/3.11
 
 
 .. note::


### PR DESCRIPTION
### Summary

Update documentation and yaml files for affected machines: Gaea-C5 and Gaea-C6

### Testing

Already installed spack stacks on these machines.

### Applications affected

All using spack stack on Gaea

### Systems affected

Gaea C5 and C6

### Issue(s) addressed

#1368 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
