### PR TITLE
Enable scotch+esmumps by default

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -258,7 +258,7 @@ packages:
   qt:
     require: '@5'
   scotch:
-    require: '@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch'
+    require: '@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps'
   sfcio:
     require: '@1.4.2'
   shumlib:


### PR DESCRIPTION
### Summary

Enable esmumps by default.

### Testing

Tested on PC and Acorn.

### Applications affected

UWM

### Systems affected

All

### Dependencies

none

### Issue(s) addressed

Fixes #1366 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
