### PR TITLE
Follow-up 2 to #1363 (update from spack dev 20241031): fix JEDI CI container builds for gcc and clang, and work towards fixing intel

### DIFF
--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -59,7 +59,7 @@ spack:
       - spec: mpich@4.2.1
         prefix: /opt/mpich-4.2.1
       version: [4.2.1]
-    gmake:
+    gmake::
       buildable: false
       externals:
       - spec: gmake@4.3

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -59,11 +59,11 @@ spack:
       - spec: mpich@4.2.1
         prefix: /opt/mpich-4.2.1
       version: [4.2.1]
-    gmake::
-      buildable: false
-      externals:
-      - spec: gmake@4.3
-        prefix: /usr
+    #gmake:
+    #  buildable: false
+    #  externals:
+    #  - spec: gmake@4.3
+    #    prefix: /usr
     diffutils:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -59,11 +59,6 @@ spack:
       - spec: mpich@4.2.1
         prefix: /opt/mpich-4.2.1
       version: [4.2.1]
-    #gmake:
-    #  buildable: false
-    #  externals:
-    #  - spec: gmake@4.3
-    #    prefix: /usr
     diffutils:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -40,11 +40,6 @@ spack:
       externals:
       - spec: gcc-runtime@12.3.0
         prefix: /usr
-    gmake::
-      buildable: false
-      externals:
-      - spec: gmake@4.3
-        prefix: /usr
     diffutils:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -40,7 +40,7 @@ spack:
       externals:
       - spec: gcc-runtime@12.3.0
         prefix: /usr
-    gmake:
+    gmake::
       buildable: false
       externals:
       - spec: gmake@4.3

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -50,11 +50,6 @@ spack:
     #  externals:
     #  - spec: intel-oneapi-mkl@2022.1.0
     #    prefix: /opt/intel/oneapi
-    gmake::
-      buildable: false
-      externals:
-      - spec: gmake@4.3
-        prefix: /usr
     diffutils:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -50,7 +50,7 @@ spack:
     #  externals:
     #  - spec: intel-oneapi-mkl@2022.1.0
     #    prefix: /opt/intel/oneapi
-    gmake:
+    gmake::
       buildable: false
       externals:
       - spec: gmake@4.3


### PR DESCRIPTION
### Summary

This PR is a follow up to the update from spack develop in #1363. It removes the external `gmake` packages so that the new requirement for `gmake` to be one of `4.2.1` or `4.4.1` can be honored.

### Testing

- [x] `ubuntu-clang-mpich` with `jedi-ci` specs: https://github.com/JCSDA/spack-stack/actions/runs/11836736765/job/32982264182
- [x] `ubuntu-gcc-openmpi` with `jedi-ci` specs: https://github.com/JCSDA/spack-stack/actions/runs/11849699792/job/33023385023
- [ ] `ubuntu-intel-impi` with `jedi-ci` specs: https://github.com/JCSDA/spack-stack/actions/runs/11856641403/job/33043320658 - **Failed with an unrelated error that JCSDA needs to fix (also a result of the update from spack develop as of 2024/10/31:**
```
#18 ERROR: process "docker-shell cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y" did not complete successfully: exit code: 1
------
 > [builder 6/8] RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y:
33.03 ==> Error: failed to concretize `fms@2024.02`, `g2@3.5.1`, `py-shapely@1.8.0`, `udunits@2.2.28`, ..., `py-pygithub@2.1.1` for the following reasons:
33.03      1. rust: Rust not compatible with Intel Classic compilers
33.03      2. rust: Rust not compatible with Intel Classic compilers
33.03         required because conflict is triggered when %intel 
33.03         required because conflict constraint  . You could consider setting `concretizer:unify` to `when_possible` or `false` to allow multiple versions of some packages.
```

### Applications affected

JEDI CI

### Systems affected

JEDI CI containers

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
