### PR TITLE
orion: Update packages_intel.yaml to use intel-oneapi-mpi +classic-names

### DIFF
--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -11,7 +11,7 @@ packages:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.9.0%intel@2021.9.0
+    - spec: intel-oneapi-mpi@2021.9.0%intel@2021.9.0 +classic-names
       modules:
       - intel-oneapi-mpi/2021.9.0
   intel-oneapi-mkl:


### PR DESCRIPTION
### Summary

Make sure MPI compilers use Intel classic on Orion.

### Testing

Tested with mct and fftw on Orion.

### Applications affected

all

### Systems affected

Orion

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
