### PR TITLE
Update submodule pointer for spack (spack-stack-dev update to spack release 0.23)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_to_spack_v0p23
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_to_spack_v0p23
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -204,8 +204,9 @@ packages:
     require: '@21.4.0'
   py-cartopy:
     require: '+plotting'
+  # Avoid full rust dependency: version 43+ requires py-maturin
   py-cryptography:
-    require: '+rust_bootstrap'
+    require: '@:42 +rust_bootstrap'
   # Introduced in https://github.com/JCSDA/spack-stack/pull/894, pin py-cython
   # to avoid duplicate packages being built (cylc dependencies soft-want @3:)
   py-cython:

--- a/configs/common/packages_intel.yaml
+++ b/configs/common/packages_intel.yaml
@@ -24,3 +24,6 @@ packages:
   ecflow:
     require:
     - '%gcc'
+  pixman:
+    require:
+    - '%gcc'


### PR DESCRIPTION
### Summary

Apart from the submodule pointer update:
- Pin `py-cryptography` to version 42 or earlier to avoid full dependency on `rust`
- Build `pixman` with `%gcc` if the preferred compiler is `%intel` (Intel Classic)

See https://github.com/JCSDA/spack/pull/487.

### Testing

- [x] CI

### Applications affected

Potentially all.

### Systems affected

None.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/487

### Issue(s) addressed

Resolves #1391 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
