### PR TITLE
Updates for the bufr-query upgrade to version 0.0.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/srherbener/spack
-  branch = feature/bufr-query-upgrade
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/srherbener/spack
+  branch = feature/bufr-query-upgrade
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -22,7 +22,7 @@ packages:
   bufr:
     require: '@12.1.0 +python'
   bufr-query:
-    require: '@0.0.2 +python'
+    require: '@0.0.4 +python'
   cairo:
     require: '+pic'
   cdo:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -8,7 +8,7 @@
     bacio@2.4.1,
     bison@3.8.2,
     bufr@12.1.0,
-    bufr-query@0.0.2,
+    bufr-query@0.0.4,
     ecbuild@3.7.2,
     eccodes@2.33.0,
     ecflow@5.11.4,


### PR DESCRIPTION
### Summary

This PR contains the configuration changes for moving bufr-query to version 0.0.4.

### Testing

Describe the testing done for this PR.

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.
JEDI, UFS

### Systems affected

List all systems intentionally or unintentionally affected by this PR.
HPCs, Mac

### Dependencies

- [x] waiting for jcsda/spack/pull/488

### Issue(s) addressed

Fixes #1377

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
