### PR TITLE
Bump ip to 5.1.0 in JEDI CI container specs

### DIFF
--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -24,7 +24,7 @@
     gsibec@1.2.1,
     hdf@4.2.15,
     hdf5@1.14.3,
-    ip@5.0.0,
+    ip@5.1.0,
     jasper@2.0.32,
     jedi-cmake@1.4.0,
     libpng@1.6.37,


### PR DESCRIPTION
### Summary

Bump ip to 5.1.0 in container specs to fix https://github.com/JCSDA/spack-stack/issues/1402 (for all compilers).

Note that this does not fix the previously existing build failure for the JEDI CI Intel container.

### Testing

None (next nightly container build will tell)

### Applications affected

JEDI CI

### Systems affected

JEDI CI containers

### Dependencies

n/a

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1402

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
