### PR TITLE
Updated jedi-ci.yaml to use latest fckit version

### DIFF
--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -17,7 +17,7 @@
     fiat@1.4.1,
     ectrans@1.5.0 +fftw,
     eigen@3.4.0,
-    fckit@0.11.0,
+    fckit@0.13.2,
     fms@2024.02,
     g2@3.5.1,
     g2tmpl@1.13.0,


### PR DESCRIPTION
### Summary

Update the jedi-ci.yaml to use proper fckit version of 0.13.2

### Testing

### Applications affected

JEDI CI

### Systems affected

Only affects the jedi-ci.

### Dependencies

None

### Issue(s) addressed

Fixes #1412

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
