### PR TITLE
Add grep to linux tier2 site config to fix intel build errors [proposed change and discussion]

### DIFF
--- a/configs/sites/tier2/linux.default/packages.yaml
+++ b/configs/sites/tier2/linux.default/packages.yaml
@@ -1,0 +1,6 @@
+packages:
+  grep:
+    buildable: false
+    externals:
+    - spec: grep@3.11
+      prefix: /usr


### PR DESCRIPTION
This is a proposed change to address the failing grep build observed when building with the intel legacy compiler and gcc-11.x. A log of the failure is included [here: spack-stack-intel-grep-build-failure.txt](https://github.com/user-attachments/files/18142302/spack-stack-intel-grep-build-failure.txt). While this PR includes a specific fix by updating the `linux.default` site config, I'll outline several other options none of which seem much more satisfactory. I'm open to changing this PR if anyone can think of a compelling reason to use a different approach.

Fixes considered:
 * Update the linux.default site config to use an external build for grep [current proposal]
     * Pros: works for new site configs and integration tests
     * Cons: not compiler specific.
 * Update the `configs/common/packages_intel.yaml` to use an external package.
      * Pros: specific to intel,.
      * Cons: affects existing sites where this isn't an issue.
 * Update the integration test yaml to manually apply this fix. 
      * Pros: Fixes tests,.
      * Cons: leaves this issue to be resolved manually for site-config creators.
 * Use `spack external find grep`.
     * Cons: spack is unable to find this package.

### Testing

Manually tested on ubuntu and tested with CI.

### Applications affected

N/A

### Systems affected

New linux site configs.

### Dependencies

This change is blocking https://github.com/JCSDA/spack-stack/pull/1416 (and possibly more).

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
