### PR TITLE
Use external grep package in GitHub actions, new site config instructions, and pre-configured tier-1 sites

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -69,6 +69,7 @@ jobs:
           spack external find --scope system \
               --exclude bison --exclude openssl \
               --exclude curl --exclude python
+          spack external find --scope system grep
           spack external find --scope system perl
           spack external find --scope system libiconv
           spack external find --scope system wget

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -69,6 +69,7 @@ jobs:
             spack external find --scope system \
                 --exclude bison --exclude openssl \
                 --exclude curl --exclude python
+            spack external find --scope system grep
             spack external find --scope system sed
             spack external find --scope system perl
             spack external find --scope system wget

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -60,6 +60,7 @@ jobs:
           spack external find --scope system \
               --exclude bison --exclude openssl \
               --exclude curl --exclude python
+          spack external find --scope system grep
           spack external find --scope system sed
           spack external find --scope system perl
           spack external find --scope system wget

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -61,6 +61,7 @@ jobs:
               --exclude bison --exclude openssl \
               --exclude curl --exclude python \
               --exclude gmake
+          spack external find --scope system grep
           spack external find --scope system sed
           spack external find --scope system perl
           spack external find --scope system wget

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -61,6 +61,7 @@ jobs:
               --exclude bison --exclude openssl \
               --exclude curl --exclude python \
               --exclude gmake
+          spack external find --scope system grep
           spack external find --scope system sed
           spack external find --scope system perl
           spack external find --scope system wget

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/find_ext_grep
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/find_ext_grep
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/containers/docker-ubuntu-clang-mpich.yaml
+++ b/configs/containers/docker-ubuntu-clang-mpich.yaml
@@ -74,6 +74,11 @@ spack:
       externals:
       - spec: git-lfs@3.0.2
         prefix: /usr
+    grep:
+      buildable: false
+      externals:
+      - spec: grep@3.7
+        prefix: /usr
     mysql:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-gcc-openmpi.yaml
+++ b/configs/containers/docker-ubuntu-gcc-openmpi.yaml
@@ -55,6 +55,11 @@ spack:
       externals:
       - spec: git-lfs@3.0.2
         prefix: /usr
+    grep:
+      buildable: false
+      externals:
+      - spec: grep@3.7
+        prefix: /usr
     mysql:
       buildable: false
       externals:

--- a/configs/containers/docker-ubuntu-intel-impi.yaml
+++ b/configs/containers/docker-ubuntu-intel-impi.yaml
@@ -65,6 +65,11 @@ spack:
       externals:
       - spec: git-lfs@3.0.2
         prefix: /usr
+    grep:
+      buildable: false
+      externals:
+      - spec: grep@3.7
+        prefix: /usr
     mysql:
       buildable: false
       externals:

--- a/configs/sites/tier1/atlantis/packages.yaml
+++ b/configs/sites/tier1/atlantis/packages.yaml
@@ -1,33 +1,86 @@
 packages:
-  curl:
+  autoconf:
     externals:
-    - spec: curl@7.61.1
-      prefix: /usr
-  wget:
-    externals:
-    - spec: wget@1.19.5
-      prefix: /usr
-  # Can't use with py-xnrl
-  #perl:
-  #  externals:
-  #  - spec: perl@5.26.3~cpanm+shared+threads
-  #    prefix: /usr
-  gmake:
-    externals:
-    - spec: gmake@4.2.1
+    - spec: autoconf@2.69
       prefix: /usr
   automake:
     externals:
     - spec: automake@1.16.1
       prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.30.117
+      prefix: /usr
   bison:
     externals:
     - spec: bison@3.0.4
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.30
+      prefix: /usr
+  curl:
+    externals:
+    - spec: curl@7.61.1
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1+lex
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.39.2+tcltk
+      prefix: /software8/depot/git-2.39.2
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.3.0
+      prefix: /software8/depot/git-2.39.2
+  gmake:
+    externals:
+    - spec: gmake@4.2.1
+      prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
       prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.3
       prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  openssh:
+    externals:
+    - spec: openssh@8.0p1
+      prefix: /usr
+  # Can no longer use, issues with py-cryptography
+  #openssl:
+  #  externals:
+  #  - spec: openssl@1.1.1k
+  #    prefix: /usr
+  # Can't use with py-xnrl
+  #perl:
+  #  externals:
+  #  - spec: perl@5.26.3~cpanm+shared+threads
+  #    prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.4.2
@@ -36,64 +89,15 @@ packages:
     externals:
     - spec: subversion@1.10.2
       prefix: /usr
-  autoconf:
-    externals:
-    - spec: autoconf@2.69
-      prefix: /usr
-  binutils:
-    externals:
-    - spec: binutils@2.30.117
-      prefix: /usr
-  git-lfs:
-    externals:
-    - spec: git-lfs@3.3.0
-      prefix: /software8/depot/git-2.39.2
-  m4:
-    externals:
-    - spec: m4@1.4.18
-      prefix: /usr
   tar:
     externals:
     - spec: tar@1.30
-      prefix: /usr
-  coreutils:
-    externals:
-    - spec: coreutils@8.30
       prefix: /usr
   texinfo:
     externals:
     - spec: texinfo@6.5
       prefix: /usr
-  git:
+  wget:
     externals:
-    - spec: git@2.39.2+tcltk
-      prefix: /software8/depot/git-2.39.2
-  diffutils:
-    externals:
-    - spec: diffutils@3.6
-      prefix: /usr
-  openssh:
-    externals:
-    - spec: openssh@8.0p1
-      prefix: /usr
-  flex:
-    externals:
-    - spec: flex@2.6.1+lex
-      prefix: /usr
-  # Can no longer use, issues with py-cryptography
-  #openssl:
-  #  externals:
-  #  - spec: openssl@1.1.1k
-  #    prefix: /usr
-  gawk:
-    externals:
-    - spec: gawk@4.2.1
-      prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.6
-      prefix: /usr
-  findutils:
-    externals:
-    - spec: findutils@4.6.0
+    - spec: wget@1.19.5
       prefix: /usr

--- a/configs/sites/tier1/aws-pcluster/packages.yaml
+++ b/configs/sites/tier1/aws-pcluster/packages.yaml
@@ -27,6 +27,10 @@ packages:
     externals:
     - spec: gawk@5.1.0
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.7
+      prefix: /usr
   tar:
     externals:
     - spec: tar@1.34

--- a/configs/sites/tier1/blueback/packages.yaml
+++ b/configs/sites/tier1/blueback/packages.yaml
@@ -59,6 +59,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier1/derecho/packages.yaml
+++ b/configs/sites/tier1/derecho/packages.yaml
@@ -63,6 +63,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier1/discover-scu16/packages.yaml
+++ b/configs/sites/tier1/discover-scu16/packages.yaml
@@ -82,6 +82,10 @@ packages:
     externals:
     - spec: gmake@4.0
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@2.16
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.2

--- a/configs/sites/tier1/discover-scu17/packages.yaml
+++ b/configs/sites/tier1/discover-scu17/packages.yaml
@@ -83,6 +83,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -119,6 +119,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.3

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -108,6 +108,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier1/hera/packages.yaml
+++ b/configs/sites/tier1/hera/packages.yaml
@@ -62,6 +62,10 @@ packages:
     externals:
     - spec: gmake@3.82
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.2

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -49,6 +49,10 @@ packages:
     externals:
     - spec: gmake@4.3
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.6
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier1/jet/packages.yaml
+++ b/configs/sites/tier1/jet/packages.yaml
@@ -70,6 +70,10 @@ packages:
     externals:
     - spec: go@1.16.13
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.2

--- a/configs/sites/tier1/narwhal/packages.yaml
+++ b/configs/sites/tier1/narwhal/packages.yaml
@@ -45,6 +45,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.3

--- a/configs/sites/tier1/nautilus/packages.yaml
+++ b/configs/sites/tier1/nautilus/packages.yaml
@@ -54,6 +54,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.3

--- a/configs/sites/tier1/navy-aws/packages.yaml
+++ b/configs/sites/tier1/navy-aws/packages.yaml
@@ -65,6 +65,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.3

--- a/configs/sites/tier1/noaa-aws/packages.yaml
+++ b/configs/sites/tier1/noaa-aws/packages.yaml
@@ -43,6 +43,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.21

--- a/configs/sites/tier1/noaa-azure/packages.yaml
+++ b/configs/sites/tier1/noaa-azure/packages.yaml
@@ -43,6 +43,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   hwloc:
     externals:
     - spec: hwloc@2.2.0

--- a/configs/sites/tier1/noaa-gcloud/packages.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages.yaml
@@ -43,6 +43,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   hwloc:
     externals:
     - spec: hwloc@2.2.0

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -59,6 +59,10 @@ packages:
     externals:
     - spec: gmake@4.3
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.6
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier1/s4/packages.yaml
+++ b/configs/sites/tier1/s4/packages.yaml
@@ -125,6 +125,10 @@ packages:
     externals:
     - spec: go@1.21.13
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.3

--- a/configs/sites/tier2/blackpearl/packages.yaml
+++ b/configs/sites/tier2/blackpearl/packages.yaml
@@ -51,6 +51,10 @@ packages:
   #  externals:
   #  - spec: gmake@4.3
   #    prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.6
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier2/bounty/packages.yaml
+++ b/configs/sites/tier2/bounty/packages.yaml
@@ -51,6 +51,10 @@ packages:
     externals:
     - spec: gmake@4.3
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.6
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/configs/sites/tier2/casper/packages.yaml
+++ b/configs/sites/tier2/casper/packages.yaml
@@ -111,6 +111,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
   groff:
     externals:
     - spec: groff@1.22.4

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -245,6 +245,7 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
        --exclude bison --exclude openssl \
        --exclude python --exclude gettext \
        --exclude m4
+   spack external find --scope system grep
    spack external find --scope system perl
    spack external find --scope system wget
 
@@ -536,6 +537,9 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
        --exclude cmake \
        --exclude curl --exclude openssl \
        --exclude openssh --exclude python
+   spack external find --scope system grep
+   spack external find --scope system sed
+   spack external find --scope system perl
    spack external find --scope system wget
 
    # Note - only needed for running JCSDA's


### PR DESCRIPTION
### Summary

External grep in new site configs (documentation), CI, Containers, pre-configured sites (at least tier 1).

Tier 1 (mandatory):
- [ ] ~~acorn (EMC):~~ deferred to https://github.com/JCSDA/spack-stack/issues/1431
- [x] atlantis (@climbfuji)
- [x] aws-pcluster (JCSDA)
- [x] blueback (@climbfuji)
- [x] derecho (EPIC)
- [x] discover-scu16 (JCSDA)
- [x] discover-scu17 (JCSDA)
- [x] gaea-c5 (EPIC)
- [x] gaea-c6 (EPIC)
- [x] hera (EPIC)
- [x] hercules (EPIC)
- [x] jet (EPIC)
- [x] narwhal (@climbfuji)
- [x] nautilus (@climbfuji)
- [x] navy-aws (@climbfuji)
- [x] noaa-aws (EPIC)
- [x] noaa-azure (EPIC)
- [x] noaa-gcloud (EPIC)
- [x] orion (EPIC)
- [x] s4 (climbfuji)

Tier 2 (optional):
- [x] blackpearl(@climbfuji)
- [x] bounty (@climbfuji)
- [x] casper (@climbfuji)
- [ ] emc-rhel
- [ ] frontera
- [x] ~~linux.default~~ in documentation (secion "New Site Config")
- [x] ~~macos.default~~ in documentation (secion "New Site Config")

Container recipes:
- [x] GNU (@climbfuji)
- [x] Clang (@climbfuji)
- [x] Intel (@climbfuji)

CI:
- [x] All Linux runners (@climbfuji)
- [x] macOS runner (@climbfuji)

### Testing

See above

### Applications affected

None (external `grep` is a prerequisite for the upcoming GitHub CLI `gh` package).

### Systems affected

All.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/492

### Issue(s) addressed

Working towards #1105 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
