### PR TITLE
[skip ci] Clarify instructions about the python version that is being used to create a new local environment

### DIFF
--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -548,7 +548,7 @@ The following instructions install a new spack environment on a pre-configured s
    # Ensure Python 3.6+ is available and the default before sourcing spack.
    # Note this is only used for building the environment. Once the
    # environment is built, spack-stack provides the proper python
-   # executable which needs to be used to build applications with the
+   # executable which needs to be utilized to build applications with the
    # newly created environment.
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -545,7 +545,11 @@ The following instructions install a new spack environment on a pre-configured s
    git clone --recurse-submodules https://github.com/jcsda/spack-stack.git
    cd spack-stack
 
-   # Ensure Python 3.8+ is available and the default before sourcing spack
+   # Ensure Python 3.6+ is available and the default before sourcing spack.
+   # Note this is only used for building the environment. Once the
+   # environment is built, spack-stack provides the proper python
+   # executable which needs to be used to build applications with the
+   # newly created environment.
 
    # Sources Spack from submodule and sets ${SPACK_STACK_DIR}
    source setup.sh


### PR DESCRIPTION
### Summary

This PR adds some clarification that was discovered while debugging spack-stack builds on S4. See #1384 for details.

### Testing

Documentation only update. Relying on the github check that builds the documentation.

### Applications affected

None - documentation update for building a new local environment

### Systems affected

All - documentation update for building a new environment (no config chagnes)

### Dependencies

None

### Issue(s) addressed

None, but this provides a correction for documentation about building a new local environment

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
