### PR TITLE
Downgrade ectrans version 1.5.0 to version 1.2.0

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -55,7 +55,7 @@ packages:
     require: '@0.40.0 +fckit +trans +tesselation +fftw'
   ectrans:
     require:
-    - '@1.5.0'
+    - '@1.2.0'
   eigen:
     require: '@3.4.0'
   # Attention - when updating the version also check the common modules.yaml

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -15,7 +15,7 @@
     eckit@1.28.3,
     ecmwf-atlas@0.40.0 +fckit +trans +tesselation +fftw,
     fiat@1.4.1,
-    ectrans@1.5.0 +fftw,
+    ectrans@1.2.0 +fftw,
     eigen@3.4.0,
     fckit@0.13.2,
     fms@2024.02,

--- a/configs/sites/tier1/acorn/packages_intel.yaml
+++ b/configs/sites/tier1/acorn/packages_intel.yaml
@@ -25,7 +25,7 @@
     # DH* Remove this section to switch to intel-oneapi-mkl
     ectrans:
       require::
-      - '@1.5.0 ~mkl +fftw'
+      - '@1.2.0 ~mkl +fftw'
     gsibec:
       require::
       - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/aws-pcluster/packages_intel.yaml
+++ b/configs/sites/tier1/aws-pcluster/packages_intel.yaml
@@ -25,7 +25,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -29,7 +29,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -28,7 +28,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/hera/packages_intel.yaml
+++ b/configs/sites/tier1/hera/packages_intel.yaml
@@ -24,7 +24,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/hercules/packages_intel.yaml
+++ b/configs/sites/tier1/hercules/packages_intel.yaml
@@ -24,7 +24,7 @@ packages:
   # Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/nautilus/packages_aocc.yaml
+++ b/configs/sites/tier1/nautilus/packages_aocc.yaml
@@ -26,7 +26,7 @@ packages:
     buildable: False
   ectrans:
     require::
-    - '@1.5.0 +mkl ~fftw'
+    - '@1.2.0 +mkl ~fftw'
   gsibec:
     require::
     - '@1.2.1 +mkl'

--- a/configs/sites/tier1/nautilus/packages_gcc.yaml
+++ b/configs/sites/tier1/nautilus/packages_gcc.yaml
@@ -25,7 +25,7 @@ packages:
     buildable: False
   ectrans:
     require::
-    - '@1.5.0 +mkl ~fftw'
+    - '@1.2.0 +mkl ~fftw'
   gsibec:
     require::
     - '@1.2.1 +mkl'

--- a/configs/sites/tier1/noaa-aws/packages_intel.yaml
+++ b/configs/sites/tier1/noaa-aws/packages_intel.yaml
@@ -24,7 +24,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/noaa-azure/packages_intel.yaml
+++ b/configs/sites/tier1/noaa-azure/packages_intel.yaml
@@ -24,7 +24,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/noaa-gcloud/packages_intel.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages_intel.yaml
@@ -24,7 +24,7 @@ packages:
   # DH* Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -24,7 +24,7 @@ packages:
   # Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'

--- a/configs/sites/tier1/s4/packages.yaml
+++ b/configs/sites/tier1/s4/packages.yaml
@@ -31,7 +31,7 @@ packages:
   # Remove this section to switch to intel-oneapi-mkl
   ectrans:
     require::
-    - '@1.5.0 ~mkl +fftw'
+    - '@1.2.0 ~mkl +fftw'
   gsibec:
     require::
     - '@1.2.1 ~mkl'


### PR DESCRIPTION
### Summary

This PR updates all of the places in the configuration, including containers, to move ectrans back to version 1.2.0. This is being done due to an issue (#1417) where ectrans@1.2.0 will compile successfully with the Intel LLVM based Fortran compiler (ifx) but ectrans@1.5.0 will not compile with ifx.

### Testing

- CI testing for this PR
- Offline testing with jedi-bundle where the new ECMWF library builds are part of the bundle
    - ECMWF libraries with their latest versions:
        - atlas: 0.40.0
        - ectrans: 1.5.0
        - fiat: 1.4.1
        - eckit: 1.28.3
        - fckit: 0.13.2
     - ectrans@1.2.0 with all the other ECMWF libraries at their latest version is working with both GNU and Intel compiler sets.

### Applications affected

JEDI, UFS, etc.

### Systems affected

List all systems intentionally or unintentionally affected by this PR.
HPCs, Mac

### Dependencies

None

### Issue(s) addressed

Fixes #1417

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
