### PR TITLE
Fix Ubuntu CI builds 2024/12/22: turn off cylc variant in skylab-dev template, shorten env path for oneapi-ifx

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -50,7 +50,7 @@ jobs:
 
           # Set up spack-stack
           source ./setup.sh
-          export ENVNAME=ue-oneapi-ifx-2024.2.0-buildcache
+          export ENVNAME=ue-oneifx-2024.2.0-buildcache
           export ENVDIR=$PWD/envs/${ENVNAME}
           spack stack create env --site linux.default --template unified-dev --name ${ENVNAME} --compiler oneapi
           spack env activate ${ENVDIR}
@@ -138,8 +138,8 @@ jobs:
           spack config add "modules:default:tcl:exclude:[ecflow]"
 
           # Concretize and check for duplicates
-          spack concretize 2>&1 | tee log.concretize.oneapi-ifx-2024.2.0-buildcache
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-ifx-2024.2.0-buildcache -i fms -i crtm -i esmf -i mapl
+          spack concretize 2>&1 | tee log.concretize.oneifx-2024.2.0-buildcache
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneifx-2024.2.0-buildcache -i fms -i crtm -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/
@@ -161,22 +161,22 @@ jobs:
 
           # base-env
           echo "base-env ..."
-          spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.oneapi-ifx-2024.2.0-buildcache.base-env
+          spack install --fail-fast --source --no-check-signature base-env 2>&1 | tee log.install.oneifx-2024.2.0-buildcache.base-env
           spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ base-env
 
           # jedi-base-env
           echo "jedi-base-env ..."
-          spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.oneapi-ifx-2024.2.0-buildcache.jedi-base-env
+          spack install --fail-fast --source --no-check-signature jedi-base-env 2>&1 | tee log.install.oneifx-2024.2.0-buildcache.jedi-base-env
           spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-base-env
 
           # jedi-ufs-env
           echo "jedi-ufs-env ..."
-          spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.oneapi-ifx-2024.2.0-buildcache.jedi-ufs-env
+          spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.oneifx-2024.2.0-buildcache.jedi-ufs-env
           spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
 
           # the rest
           echo "unified-env ..."
-          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneapi-ifx-2024.2.0-buildcache.unified-env
+          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneifx-2024.2.0-buildcache.unified-env
           spack buildcache create -u /home/ubuntu/spack-stack/build-cache/
 
           # Remove binary cache for next round of concretization
@@ -197,16 +197,16 @@ jobs:
         run: |
           # Set up spack-stack
           source ./setup.sh
-          export BUILDCACHE_ENVNAME=ue-oneapi-ifx-2024.2.0-buildcache
+          export BUILDCACHE_ENVNAME=ue-oneifx-2024.2.0-buildcache
           export BUILDCACHE_ENVDIR=$PWD/envs/${BUILDCACHE_ENVNAME}
-          export ENVNAME=ue-oneapi-ifx-2024.2.0
+          export ENVNAME=ue-oneifx-2024.2.0
           export ENVDIR=$PWD/envs/${ENVNAME}
           rsync -av --exclude='install' --exclude='spack.lock' --exclude='.spack_db' ${BUILDCACHE_ENVDIR}/ ${ENVDIR}/
           spack env activate ${ENVDIR}
 
           # Concretize and check for duplicates
-          spack concretize --force 2>&1 | tee log.concretize.oneapi-ifx-2024.2.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-ifx-2024.2.0 -i fms -i crtm -i esmf -i mapl
+          spack concretize --force 2>&1 | tee log.concretize.oneifx-2024.2.0
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneifx-2024.2.0 -i fms -i crtm -i esmf -i mapl
 
           # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/
@@ -214,7 +214,7 @@ jobs:
           spack buildcache list
 
           # Install from cache
-          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneapi-ifx-2024.2.0.unified-env
+          spack install --fail-fast --source --no-check-signature 2>&1 | tee log.install.oneifx-2024.2.0.unified-env
 
           # Check shared libraries
           ${SPACK_STACK_DIR}/util/ldd_check.py $SPACK_ENV 2>&1 | tee log.ldd_check
@@ -230,7 +230,7 @@ jobs:
           source /etc/profile.d/modules.sh
           module use /home/ubuntu/spack-stack/modulefiles
 
-          export ENVNAME=ue-oneapi-ifx-2024.2.0
+          export ENVNAME=ue-oneifx-2024.2.0
           export ENVDIR=$PWD/envs/${ENVNAME}
           ls -l ${ENVDIR}/install/modulefiles/Core
 

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -8,7 +8,7 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-    - ewok-env +ecflow +cylc
+    - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
     - jedi-fv3-env


### PR DESCRIPTION
### Summary

This PR fixes the CI build errors on the Ubuntu CI runners by:
1. Turning off the `cylc` variant in the `skylab-dev` template. We wanted to keep one CI build for `cylc`, even though the Skylab environment doesn't require it at the moment. But with the increasing complexity of Python dependencies, this is getting too hard. Note that #1410 will allow us to build `cylc` again (because we can finally pin `py-cython` to a newer version). I haven't decided yet how to exactly do that in the context of CI and for releases of spack-stack, but likely it will be a separate environment (config template) altogether (deferred to #1410).
2. Shorten the path for the Intel OneAPI ifx build. The CI build now fails, because the full path to the install location in the build environment is 2 characters too long (I don't know why it worked beforehand; maybe it was extracting the problematic packages from the buildcache instead of building them from source). Instead of `oneapi-ifx`, we use `oneifx` as the name of the build environment (it makes zero difference, other than shortening the path by four characters).

### Testing

- [x]  CI

### Applications affected

None

### Systems affected

Ubuntu CI builds

### Dependencies

n/a

### Issue(s) addressed

None created - the CI build failures were first noted in https://github.com/JCSDA/spack-stack/pull/1432#issuecomment-2558774088, therefore this PR should be merged before #1432 so that all CI tests pass.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
