### PR TITLE
Fix mvapich2 in hercules compilers.yaml

### DIFF
--- a/configs/sites/hercules/compilers.yaml
+++ b/configs/sites/hercules/compilers.yaml
@@ -29,4 +29,4 @@ compilers:
     modules:
     - gcc/12.2.0
     environment: {}
-    extra_rpaths: []
+    extra_rpaths: [/opt/slurm/lib/]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -200,7 +200,7 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+#intersphinx_mapping = {'https://docs.python.org/': None}
 
 # -- Options for todo extension ----------------------------------------------
 


### PR DESCRIPTION
### Summary

For whatever reason when I try to compile an MPI-based package on Hercules with GCC, it fails because it can't find libpmi2.so.0, which lives at /opt/slurm/lib/libpmi2.so.0. This PR fixes it by adding /opt/slurm/lib/ to extra_rpaths for hercules/gcc.

### Testing

Tested on Hercules with 1.6.0.

### Applications affected

all

### Systems affected

Hercules

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
