### PR TITLE
Update selected packages from spack develop 2025/01/13 (add esmf@8.8.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_selected_pks_from_spack_develop_20250113
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_selected_pks_from_spack_develop_20250113
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -132,8 +132,8 @@ modules:
           ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0~debug snapshot=none: 'esmf-8.7.0'
           ^esmf@8.7.0+debug snapshot=none: 'esmf-8.7.0-debug'
-          ^esmf@8.8.0b10~debug snapshot=b10: esmf-8.8.0b10
-          ^esmf@8.8.0b10+debug snapshot=b10: esmf-8.8.0b10-debug
+          ^esmf@8.8.0~debug snapshot=none: 'esmf-8.8.0'
+          ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -134,8 +134,8 @@ modules:
           ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
           ^esmf@8.7.0~debug snapshot=none: 'esmf-8.7.0'
           ^esmf@8.7.0+debug snapshot=none: 'esmf-8.7.0-debug'
-          ^esmf@8.8.0b10~debug snapshot=b10: esmf-8.8.0b10
-          ^esmf@8.8.0b10+debug snapshot=b10: esmf-8.8.0b10-debug
+          ^esmf@8.8.0~debug snapshot=none: 'esmf-8.8.0'
+          ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -64,7 +64,7 @@ packages:
   esmf:
     require:
     - '~xerces ~pnetcdf +shared +external-parallelio'
-    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0b10 snapshot=b10']
+    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none']
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,8 +8,8 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc                           ^esmf@=8.8.0b10
-      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.8.0b10
+      - neptune-env +espc                           ^esmf@=8.8.0
+      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.8.0
 
   specs:
     - matrix:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,11 +14,11 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.8.0b10
+    - jedi-neptune-env      ^esmf@=8.8.0
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env           ^esmf@=8.8.0b10
-    - neptune-python-env    ^esmf@=8.8.0b10
+    - neptune-env           ^esmf@=8.8.0
+    - neptune-python-env    ^esmf@=8.8.0
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)
@@ -27,7 +27,7 @@ spack:
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
-    - esmf@=8.8.0b10 snapshot=b10
+    - esmf@=8.8.0 snapshot=none
 
   specs:
   - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -17,12 +17,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.8.0b10
+    - jedi-neptune-env      ^esmf@=8.8.0
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.6.1
     - jedi-um-env
-    - neptune-env           ^esmf@=8.8.0b10
-    - neptune-python-env    ^esmf@=8.8.0b10
+    - neptune-env           ^esmf@=8.8.0
+    - neptune-python-env    ^esmf@=8.8.0
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.6.1
     - ufs-weather-model-env ^esmf@=8.6.1
@@ -33,7 +33,7 @@ spack:
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
-    - esmf@=8.8.0b10 snapshot=b10
+    - esmf@=8.8.0 snapshot=none
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5


### PR DESCRIPTION
### Summary

This PR updates the submodule pointer for the changes described in https://github.com/JCSDA/spack-stack/pull/1450, most notably the addition of the new release `esmf@8.8.0`. Corresponding changes are made in all files referencing the previous beta snapshot `esmf@8.8.0b10` in `configs/**`.

### Testing

- [x] CI

### Applications affected

NEPTUNE / NEPTUNE-JEDI

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack-stack/pull/1450

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1451

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
