### PR TITLE
release/1.9.0: Add crtm@3.1.1 to unified-dev and skylab-dev templates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/cherry_pick_crtm311_from_spackdev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -24,6 +24,7 @@ spack:
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
+    - crtm@v3.1.1-build1
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -30,6 +30,7 @@ spack:
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
+    - crtm@v3.1.1-build1
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none


### PR DESCRIPTION
### Summary

Update submodule pointer for spack for the update described in https://github.com/JCSDA/spack/pull/501 and add `crtm@3.1.1-build1` to `unified-dev` and `skylab-dev` templates.

### Testing

- [x] CI

### Applications affected

None immediately (new version of CRTM isn't used yet).

### Systems affected

None.

### Dependencies

- [ ]  waiting on https://github.com/JCSDA/spack/pull/501

### Issue(s) addressed

Closes #1185 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
