### PR TITLE
Bug fix in configs/sites/tier1/atlantis/packages_gcc.yaml: must load slurm before openmpi on Atlantis/GCC

### DIFF
--- a/configs/sites/tier1/atlantis/packages_gcc.yaml
+++ b/configs/sites/tier1/atlantis/packages_gcc.yaml
@@ -9,6 +9,7 @@ packages:
     buildable: False
     externals:
     - spec: openmpi@4.1.5%gcc@=11.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+      # Note: slurm must be loaded before openmpi on Atlantis
       modules:
-      - openmpi/mlnx/gcc/64/4.1.5a1
       - slurm
+      - openmpi/mlnx/gcc/64/4.1.5a1


### PR DESCRIPTION
### Summary

All in the title. There is a weird error if slurm isn't loaded before openmpi (maybe the dependency not configured correctly in the openmpi module).

### Testing

Tested on Atlantis. No CI testing required.

### Applications affected

None

### Systems affected

Atlantis

### Dependencies

n/a

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
