### PR TITLE
Fixing mpi.lua to get and set env. variables correctly after unloading or reloading the module

### DIFF
--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
@@ -32,11 +32,19 @@ setenv("MPI_F77", "@MPIF77@")
 setenv("MPI_F90", "@MPIF90@")
 
 -- intel specific mpi wrapper environment variables
-setenv("I_MPI_CC",  os.getenv("CC"))
-setenv("I_MPI_CXX", os.getenv("CXX"))
-setenv("I_MPI_F77", os.getenv("F77"))
-setenv("I_MPI_F90", os.getenv("FC"))
-setenv("I_MPI_FC",  os.getenv("FC"))
+local i_mpi_cc = os.getenv("CC")
+local i_mpi_cxx = os.getenv("CXX")
+local i_mpi_f77 = os.getenv("F77") or ""
+local i_mpi_f90 = os.getenv("FC")
+local i_mpi_fc = os.getenv("FC")
+
+if i_mpi_cc and i_mpi_cxx and i_mpi_f90 and i_mpi_fc then
+  setenv("I_MPI_CC", i_mpi_cc)
+  setenv("I_MPI_CXX", i_mpi_cxx)
+  setenv("I_MPI_F77", i_mpi_f77)
+  setenv("I_MPI_F90", i_mpi_f90)
+  setenv("I_MPI_FC",  i_mpi_fc)
+end
 
 -- compiler flags and other environment variables
 @COMPFLAGS@


### PR DESCRIPTION
### Summary

Environmental variables I_MPI_CC, I_MPI_CXX, I_MPI_F77, I_MPI_F90, I_MPI_FC are set correctly and do not produce error when module is unloaded or reloaded.

Error reporting when reloading or unloading the module:

```
Lmod Warning:  Syntax error in file:
/Users/Natalie/spack-stack/spack-stack-1.8.0/envs/ufs-srw-env/install/modulefiles/apple-clang/15.0.0/stack-openmpi/5.0.3.lua
 with command: setenv, one or more arguments are not strings.

While processing the following module(s):
    Module fullname           Module Filename
    ---------------           ---------------
    stack-openmpi/5.0.3       /Users/Natalie/spack-stack/spack-stack-1.8.0/envs/ufs-srw-env/install/modulefiles/apple-clang/15.0.0/stack-openmpi/5.0.3.lua
    ufs_macosx.gnu  /Users/Natalie/UFS-WM/ufs-weather-model/modulefiles/ufs_macosx.gnu.lua

```

### Steps to reproduce the error:

This error is seen in spack-stack-1.8.0 and later when openmpi is used. The spack-stack-1.6.0 that is currently used by UFS-WM and UFS-SRW does not have this issue, as module templates had different syntax at that time. 

1. Reproduce the error on Hera with Gnu compiler:
```
module use /contrib/spack-stack/spack-stack-1.8.0/envs/mapl-2.40.3-gcc-9.2.0/install/modulefiles/Core
module load stack-gcc
module load stack-openmpi
module load stack-openmpi
```

After loading stack-openmpi for the second time, the following error appears that is repeated 5 times:
```
Lmod Warning:  Syntax error in file:
/contrib/spack-stack/spack-stack-1.8.0/envs/mapl-2.40.3-gcc-9.2.0/install/modulefiles/gcc/9.2.0/stack-openmpi/4.1.6.lua
 with command: setenv, one or more arguments are not strings.

While processing the following module(s):
    Module fullname      Module Filename
    ---------------      ---------------
    stack-openmpi/4.1.6  /contrib/spack-stack/spack-stack-1.8.0/envs/mapl-2.40.3-gcc-9.2.0/install/modulefiles/gcc/9.2.0/stack-openmpi/4.1.6.lua
```

Similar error appears when the module is unloaded using `module unload stack-openmpi`. The module is still unloaded, however. 

2. Reproduce this error on Orion with Gnu compiler:

```
module use /apps/contrib/spack-stack/spack-stack-1.8.0/envs/ue-gcc-12.2.0/install/modulefiles/Core
module load stack-gcc/12.2.0
module load stack-openmpi/4.1.4
module load stack-openmpi/4.1.4
```
or `module unload stack-openmpi/4.1.4` in the last line. The error message:
```
Lmod Warning:  Syntax error in file:
/apps/contrib/spack-stack/spack-stack-1.8.0/envs/ue-gcc-12.2.0/install/modulefiles/gcc/12.2.0/stack-openmpi/4.1.4.lua
 with command: setenv, one or more arguments are not strings.

While processing the following module(s):
    Module fullname      Module Filename
    ---------------      ---------------
    stack-openmpi/4.1.4  /apps/contrib/spack-stack/spack-stack-1.8.0/envs/ue-gcc-12.2.0/install/modulefiles/gcc/12.2.0/stack-openmpi/4.1.4.lua

```


### Testing

Tested a modified modulefile as part of spack-stack-1.8.0 installation on MacOS, errors are not produced when unloading or reloading, during the development work. No errors reported when the module is loaded single time during the actual production runs or workflow.

### Applications affected

All UFS applications that use openmpi and may do development work involving multiple loading/unloading of the openmpi file

### Systems affected

Any system that uses openmpi. Example to reproduce errors on Hera:

```
module use /contrib/spack-stack/spack-stack-1.8.0/envs/mapl-2.40.3-gcc-9.2.0/install/modulefiles/Core
module load stack-gcc
module load stack-openmpi
module load stack-openmpi
```
After loading the stack-openmpi for the second time, the following error appears:
```
Lmod Warning:  Syntax error in file:
/contrib/spack-stack/spack-stack-1.8.0/envs/mapl-2.40.3-gcc-9.2.0/install/modulefiles/gcc/9.2.0/stack-openmpi/4.1.6.lua
 with command: setenv, one or more arguments are not strings.

While processing the following module(s):
    Module fullname      Module Filename
    ---------------      ---------------
    stack-openmpi/4.1.6  /contrib/spack-stack/spack-stack-1.8.0/envs/mapl-2.40.3-gcc-9.2.0/install/modulefiles/gcc/9.2.0/stack-openmpi/4.1.6.lua

```
(this message is repeated 5 times)

Attempt to unload the module 
```
module unload stack-openmpi
```
produces the same error messages. The modules however are successfully unloaded.



### Dependencies


### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.

### Contributors

@DavidHuber-NOAA  - suggesting a modulefile fix for a similar issue in PR https://github.com/ufs-community/ufs-weather-model/pull/2551