### PR TITLE
Add missing dependencies to ccpp-scm template, add Python build utilities to base-env

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -31,6 +31,9 @@ packages:
       when: '%intel@2021:'
       message: '2.3.0 is the last version to use C++17, use with Intel Classic'
     - any_of: ['@2.3.0 ~openmp']
+      when: '%gcc@:10'
+      message: 2.3.0 is the last version to use C++17, use with GCC 10 and earlier
+    - any_of: ['@2.3.0 ~openmp']
       when: '%apple-clang@:14'
       message: '2.3.0 is the last version to use C++17, use with Apple Clang 14 and earlier'
     - any_of: ['@2.0.5 ~openmp']

--- a/configs/templates/ccpp-scm/spack.yaml
+++ b/configs/templates/ccpp-scm/spack.yaml
@@ -20,4 +20,5 @@ spack:
   - sp
   - w3emc
   - py-f90nml
-
+  - py-numpy
+  - py-netcdf4

--- a/spack-ext/repos/spack-stack/packages/base-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/base-env/package.py
@@ -38,5 +38,8 @@ class BaseEnv(BundlePackage):
     # Python
     depends_on("python@3.7:", type="run")
     depends_on("py-pip", type="run")
+    depends_on("py-wheel", type="run")
+    depends_on("py-setuptools", type="run")
+    depends_on("py-setuptools-scm", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

1. Add missing dependencies `py-numpy` and `py-netcdf4` to the CCPP SCM template
2. Add essential Python build utilities `py-wheel`, `py-setuptools`, and `py-setuptools-scm` to `base-env`. These packages are already included in our environments, because they are basic build packages for many Python packages we build, but the modules weren't loaded automatically. This update makes sure tha the modules are loaded and available whenever `base-env` is loaded (explicitly or automatically as a dependency).

### Testing

- [x] Built CCPP SCM environment on Atlantis with `%oneapi`, compiled SCM and ran one SCM test case
- [x] CI

### Applications affected

CCPP SCM

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

Resolves #1461 
Resolves #1460

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
