### PR TITLE
Bug fixes and documentation updates for bootstrapping spack on air-gapped systems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/bootstrap_airgapped_spack_stack_dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/bootstrap_airgapped_spack_stack_dev
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

Update submodule pointer for spack for the changes in https://github.com/JCSDA/spack/pull/506 (Bug fixes for bootstrapping spack on air-gapped systems), and documentation updates for creating bootstrap mirrors for air-gapped systems.

### Testing

Tested on Narwhal (create bootstrap mirror) and Tusk (air-gapped; use bootstrap mirror).

### Applications affected

None

### Systems affected

Air-gapped systems

### Dependencies

- [x]  waiting on https://github.com/JCSDA/spack/pull/506

### Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1428

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
