### PR TITLE
Update `spack stack setup-meta-modules` to directly set compilers in MPI meta modules

### DIFF
--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -695,7 +695,7 @@ def setup_meta_modules():
 
                     # Compiler wrapper environment variables
                     if "intel" in mpi_name and compiler_name == "oneapi":
-                        substitutes["MPICC"] = os.path.join("mpiicx")
+                        substitutes["MPICC"]  = os.path.join("mpiicx")
                         substitutes["MPICXX"] = os.path.join("mpiicpx")
                         if "ifx" in SUBSTITUTES_SAVE["FC"] and not "ifort" in SUBSTITUTES_SAVE["FC"]:
                             substitutes["MPIF77"] = os.path.join("mpiifx")
@@ -706,15 +706,20 @@ def setup_meta_modules():
                         else:
                             raise Exception(f"For {mpi_name}, cannot determine MPI wrapper from FC={SUBSTITUTES_SAVE['FC']}")
                     elif "intel" in mpi_name and compiler_name == "intel":
-                        substitutes["MPICC"] = os.path.join("mpiicc")
+                        substitutes["MPICC"]  = os.path.join("mpiicc")
                         substitutes["MPICXX"] = os.path.join("mpiicpc")
                         substitutes["MPIF77"] = os.path.join("mpiifort")
                         substitutes["MPIF90"] = os.path.join("mpiifort")
                     else:
-                        substitutes["MPICC"] = os.path.join("mpicc")
+                        substitutes["MPICC"]  = os.path.join("mpicc")
                         substitutes["MPICXX"] = os.path.join("mpic++")
                         substitutes["MPIF77"] = os.path.join("mpif77")
                         substitutes["MPIF90"] = os.path.join("mpif90")
+                    # Also set the direct compiler environment variables
+                    substitutes["CC"]  = SUBSTITUTES_SAVE["CC"]
+                    substitutes["CXX"] = SUBSTITUTES_SAVE["CXX"]
+                    substitutes["F77"] = SUBSTITUTES_SAVE["F77"]
+                    substitutes["FC"]  = SUBSTITUTES_SAVE["FC"]
 
                     # Spack mpi+compiler module hierarchy
                     modulepath = os.path.join(

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi
@@ -28,11 +28,11 @@ setenv {MPI_F77} {@MPIF77@}
 setenv {MPI_F90} {@MPIF90@}
 
 # intel specific mpi wrapper environment variables
-setenv {I_MPI_CC}  $env(CC)
-setenv {I_MPI_CXX} $env(CXX)
-setenv {I_MPI_F77} $env(F77)
-setenv {I_MPI_F90} $env(FC)
-setenv {I_MPI_FC}  $env(FC)
+setenv {I_MPI_CC}  {@CC@}
+setenv {I_MPI_CXX} {@CXX@}
+setenv {I_MPI_F77} {@F77@}
+setenv {I_MPI_F90} {@FC@}
+setenv {I_MPI_FC}  {@FC@}
 
 # compiler flags and other environment variables
 @COMPFLAGS@

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
@@ -32,11 +32,11 @@ setenv("MPI_F77", "@MPIF77@")
 setenv("MPI_F90", "@MPIF90@")
 
 -- intel specific mpi wrapper environment variables
-setenv("I_MPI_CC",  os.getenv("CC"))
-setenv("I_MPI_CXX", os.getenv("CXX"))
-setenv("I_MPI_F77", os.getenv("F77"))
-setenv("I_MPI_F90", os.getenv("FC"))
-setenv("I_MPI_FC",  os.getenv("FC"))
+setenv("I_MPI_CC",  "@CC@")
+setenv("I_MPI_CXX", "@CXX@")
+setenv("I_MPI_F77", "@F77@")
+setenv("I_MPI_F90", "@FC@")
+setenv("I_MPI_FC",  "@FC@")
 
 -- compiler flags and other environment variables
 @COMPFLAGS@


### PR DESCRIPTION
### Summary

In `spack-ext/lib/jcsda-emc/spack-stack/stack`, update `meta_modules.py` and `templates/{mpi,mpi.lua}`: set compiler paths in MPI meta modules directly using `SUBSTITUTES_SAVE`, not using environment variables. This wasn't possible in the past, but when `SUBSTITUTES_SAVE` was introduced a few months back for an unrelated bug fix, that change could have been made as well.

### Testing

- [x]  CI
- [x] Built a minimal environment on my laptop that had `parallel-netcdf`. Looked at the MPI meta module and verified the `CC`, `CXX`, `FC`, `F77`, `F90` variables are set correctly.

### Applications affected

All using MPI

### Systems affected

All

### Dependencies

n/a

### Issue(s) addressed

Replaces https://github.com/JCSDA/spack-stack/pull/1465

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
