### PR TITLE
release/1.9.0: Pin py-numpy version to 1.26 for Orion  Intel configuration

### DIFF
--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -30,4 +30,5 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
+    - '@1.26'
     - '^openblas'


### PR DESCRIPTION
### Summary

This PR pins the Orion Intel version for py-numpy to 1.26. This prevents unwanted duplicate packages during the concretize step.

### Testing

- [ ] Orion, Intel build
- [ ] Orion, Intel jedi-bundle

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.
UFS, JEDI, etc.

### Systems affected

Orion, only for the Intel environment

### Dependencies

None

### Issue(s) addressed

Fixes #1477 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
