### PR TITLE
release/1.9.0: Add crtm@3.1.1 to unified-dev and skylab-dev templates, bug fix in depencies for awscli-v2, bump wgrib2 to 3.5.0 and re-enable for all compilers

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -100,7 +100,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.apple-clang-14.0.3-buildcache
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3-buildcache -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3-buildcache -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///Users/ec2-user/spack-stack/source-cache/
@@ -169,7 +169,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.apple-clang-14.0.3
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.apple-clang-14.0.3 -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add binary cache back in
           spack mirror add local-binary file:///Users/ec2-user/spack-stack/build-cache/

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -96,7 +96,7 @@ jobs:
 
             # Concretize and check for duplicates
             spack concretize 2>&1 | tee log.concretize.gnu-11.4.0-buildcache
-            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.gnu-11.4.0-buildcache -i fms -i crtm -i esmf -i mapl
+            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.gnu-11.4.0-buildcache -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
             # Add and update source cache
             spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/
@@ -167,7 +167,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.gnu-11.4.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.gnu-11.4.0 -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.gnu-11.4.0 -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -134,7 +134,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.intel-2021.10.0-buildcache
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2021.10.0-buildcache -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2021.10.0-buildcache -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/
@@ -201,7 +201,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.intel-2021.10.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2021.10.0 -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.intel-2021.10.0 -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -139,7 +139,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.oneifx-2024.2.0-buildcache
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneifx-2024.2.0-buildcache -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneifx-2024.2.0-buildcache -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/
@@ -206,7 +206,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.oneifx-2024.2.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneifx-2024.2.0 -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneifx-2024.2.0 -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -139,7 +139,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize 2>&1 | tee log.concretize.oneapi-2024.2.0-buildcache
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-2024.2.0-buildcache -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-2024.2.0-buildcache -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add and update source cache
           spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/
@@ -206,7 +206,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.oneapi-2024.2.0
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-2024.2.0 -i fms -i crtm -i esmf -i mapl
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.oneapi-2024.2.0 -i fms -i crtm -i crtm-fix -i esmf -i mapl
 
           # Add binary cache back in
           spack mirror add local-binary file:///home/ubuntu/spack-stack/build-cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.9.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/appleclangwgrib2
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.9.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/appleclangwgrib2
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
   url = https://github.com/jcsda/spack
-  #branch = release/1.9.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/awscliv2_crytography
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
   url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+  #branch = release/1.9.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/awscliv2_crytography
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -288,6 +288,7 @@ packages:
     require: '@2.10.0 precision=4,d,8 +extradeps'
   w3nco:
     require: '@2.4.1'
+  # See macOS site config for wgrib2 version/variant overrides
   wgrib2:
     require:
     - '@3.5.0'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -290,7 +290,7 @@ packages:
     require: '@2.4.1'
   wgrib2:
     require:
-    - '@3.1.1'
+    - '@3.5.0'
   wrf-io:
     require: '@1.2.0'
   zstd:

--- a/configs/sites/tier2/macos.default/packages.yaml
+++ b/configs/sites/tier2/macos.default/packages.yaml
@@ -11,5 +11,5 @@ packages:
     buildable: false
   wgrib2:
     require::
-    - '@3.1.1'
+    - '@3.4.0'
     - '~openmp'

--- a/configs/sites/tier2/macos.default/packages.yaml
+++ b/configs/sites/tier2/macos.default/packages.yaml
@@ -9,6 +9,7 @@ packages:
     buildable: false
   libiconv:
     buildable: false
-  #wgrib2:
-  #  require:
-  #  - '~openmp'
+  wgrib2:
+    require::
+    - '@3.1.1'
+    - '~openmp'

--- a/configs/sites/tier2/macos.default/packages.yaml
+++ b/configs/sites/tier2/macos.default/packages.yaml
@@ -9,6 +9,6 @@ packages:
     buildable: false
   libiconv:
     buildable: false
-  wgrib2:
-    require:
-    - '~openmp'
+  #wgrib2:
+  #  require:
+  #  - '~openmp'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -24,7 +24,7 @@ spack:
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
-    - crtm@v3.1.1-build1
+    - crtm@3.1.1-build1
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -24,6 +24,7 @@ spack:
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
+    - crtm@v3.1.1-build1
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -11,9 +11,9 @@ spack:
     - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
-    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=v3.1.1-build1
     - gmao-swell-env
-    - gsi-env ^crtm@=3.1.1-build1
+    - gsi-env ^crtm@=v3.1.1-build1
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
@@ -24,11 +24,17 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=3.1.1-build1
-    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=v3.1.1-build1
+    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=v3.1.1-build1
 
+    # Various crtm tags (list all to avoid duplicate packages)
+    - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
     - crtm@v3.1.1-build1
+
+    # Various esmf tags (list all to avoid duplicate packages)
+    - esmf@=8.6.1 snapshot=none
+    - esmf@=8.8.0 snapshot=none
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -30,6 +30,7 @@ spack:
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
+    - crtm@v3.1.1-build1
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -11,9 +11,9 @@ spack:
     - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
-    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=v3.1.1-build1
+    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1
     - gmao-swell-env
-    - gsi-env ^crtm@=v3.1.1-build1
+    - gsi-env ^crtm@=3.1.1-build1
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
@@ -24,13 +24,13 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=v3.1.1-build1
-    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=v3.1.1-build1
+    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=3.1.1-build1
 
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
-    - crtm@v3.1.1-build1
+    - crtm@3.1.1-build1
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -11,9 +11,9 @@ spack:
     - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
-    - global-workflow-env   ^esmf@=8.6.1
+    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1
     - gmao-swell-env
-    - gsi-env
+    - gsi-env ^crtm@=3.1.1-build1
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
@@ -24,16 +24,10 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.6.1
-    - ufs-weather-model-env ^esmf@=8.6.1
+    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=3.1.1-build1
 
-    # Various crtm tags (list all to avoid duplicate packages)
-    - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
-
-    # Various esmf tags (list all to avoid duplicate packages)
-    - esmf@=8.6.1 snapshot=none
-    - esmf@=8.8.0 snapshot=none
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5

--- a/spack-ext/repos/spack-stack/packages/emc-verif-global-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/emc-verif-global-env/package.py
@@ -29,11 +29,7 @@ class EmcVerifGlobalEnv(BundlePackage):
     depends_on("py-pandas")
     # Test grads
     # depends_on('grads')
-    # Currently, wgrib2 doesn't build with oneapi,
-    # but there isn't a "when not" option in spack yet
-    depends_on("wgrib2", when="%apple-clang")
-    depends_on("wgrib2", when="%gcc")
-    depends_on("wgrib2", when="%intel")
+    depends_on("wgrib2")
     depends_on("python")
     depends_on("prod-util")
     depends_on("met")

--- a/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
@@ -39,11 +39,7 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("landsfcutil")
     depends_on("sigio")
     depends_on("bufr")
-    # Currently, wgrib2 doesn't build with oneapi,
-    # but there isn't a "when not" option in spack yet
-    depends_on("wgrib2", when="%apple-clang")
-    depends_on("wgrib2", when="%gcc")
-    depends_on("wgrib2", when="%intel")
+    depends_on("wgrib2")
     depends_on("met")
     depends_on("metplus")
     depends_on("gsi-ncdiag")

--- a/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
@@ -47,7 +47,7 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("met")
     depends_on("metplus")
     depends_on("gsi-ncdiag")
-    depends_on("crtm@2.4.0.1")
+    depends_on("crtm")
     depends_on("py-wxflow", when="+python")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/gsi-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gsi-env/package.py
@@ -29,7 +29,7 @@ class GsiEnv(BundlePackage):
     depends_on("sfcio")
     depends_on("nemsio")
     depends_on("wrf-io")
-    depends_on("crtm@2.4.0.1")
+    depends_on("crtm")
     depends_on("ncio")
     depends_on("gsi-ncdiag")
 

--- a/spack-ext/repos/spack-stack/packages/nceplibs-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/nceplibs-env/package.py
@@ -36,10 +36,6 @@ class NceplibsEnv(BundlePackage):
     depends_on("w3emc")
     depends_on("w3nco")
     depends_on("wrf-io")
-    # Currently, wgrib2 doesn't build with oneapi,
-    # but there isn't a "when not" option in spack yet
-    depends_on("wgrib2", when="%apple-clang")
-    depends_on("wgrib2", when="%gcc")
-    depends_on("wgrib2", when="%intel")
+    depends_on("wgrib2")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
@@ -41,11 +41,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("sigio")
     depends_on("wrf-io")
     depends_on("w3emc")
-    # Currently, wgrib2 doesn't build with oneapi,
-    # but there isn't a "when not" option in spack yet
-    depends_on("wgrib2", when="%apple-clang")
-    depends_on("wgrib2", when="%gcc")
-    depends_on("wgrib2", when="%intel")
+    depends_on("wgrib2")
     depends_on("gsi-ncdiag")
     depends_on("met")
     depends_on("metplus")

--- a/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
@@ -27,7 +27,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("esmf")
     depends_on("fms")
     depends_on("bacio")
-    depends_on("crtm@2.4.0.1")
+    depends_on("crtm")
     depends_on("g2")
     depends_on("g2tmpl")
     depends_on("ip")

--- a/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-utils-env/package.py
@@ -45,10 +45,6 @@ class UfsUtilsEnv(BundlePackage):
     depends_on("wrf-io")
     depends_on("ncio")
     depends_on("landsfcutil")
-    # Currently, wgrib2 doesn't build with oneapi,
-    # but there isn't a "when not" option in spack yet
-    depends_on("wgrib2", when="%apple-clang")
-    depends_on("wgrib2", when="%gcc")
-    depends_on("wgrib2", when="%intel")
+    depends_on("wgrib2")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
@@ -28,7 +28,7 @@ class UfsWeatherModelEnv(BundlePackage):
 
     depends_on("fms", type="run")
     depends_on("bacio", type="run")
-    depends_on("crtm@2.4.0.1", type="run")
+    depends_on("crtm", type="run")
     depends_on("g2", type="run")
     depends_on("g2tmpl", type="run")
     depends_on("ip", type="run")

--- a/spack-ext/repos/spack-stack/packages/upp-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/upp-env/package.py
@@ -30,12 +30,7 @@ class UppEnv(BundlePackage):
     depends_on("w3emc")
     depends_on("wrf-io")
     depends_on("prod-util")
-    # For testing:
-    # Currently, wgrib2 doesn't build with oneapi,
-    # but there isn't a "when not" option in spack yet
-    depends_on("wgrib2", when="%apple-clang")
-    depends_on("wgrib2", when="%gcc")
-    depends_on("wgrib2", when="%intel")
+    depends_on("wgrib2")
     depends_on("grib-util")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

1. Add crtm@v3.1.1-build1 to templates skylab-dev and unified-dev (new version was added in recently merged PR https://github.com/JCSDA/spack/pull/510)
2. Bump wgrib2 from 3.1.1 to 3.5.0 and re-enable for all compilers in spack-ext packages (new version was added in recently merged PR https://github.com/JCSDA/spack/pull/510). **Note.** wgrib2@3.5.0 doesn't compile on macOS with apple-clang (version 14.0.3 on the CI runner), see https://github.com/NOAA-EMC/wgrib2/issues/312. But 3.4.0 does compile, thereforeuse this version on macOS only
3. Update spack submodule pointer for PR https://github.com/JCSDA/spack/pull/510 and the changes in https://github.com/JCSDA/spack/pull/511 (fix upper bound for py-cryptography in awscli-v2) and https://github.com/JCSDA/spack/pull/513 (bug fix for wgrib2 with apple-clang)

### Testing

- [ ] CI

### Applications affected

All applications using unified-dev or skylab-dev templates

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/511
- [ ] waiting on https://github.com/JCSDA/spack/pull/513

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/967

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
