### PR TITLE
crtm & wgrib2 version updates

### DIFF
--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -11,9 +11,9 @@ spack:
     - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
-    - global-workflow-env   ^esmf@=8.6.1
+    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1
     - gmao-swell-env
-    - gsi-env
+    - gsi-env ^crtm@=3.1.1-build1
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
@@ -24,16 +24,10 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.6.1
-    - ufs-weather-model-env ^esmf@=8.6.1
+    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=3.1.1-build1
 
-    # Various crtm tags (list all to avoid duplicate packages)
-    - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
-
-    # Various esmf tags (list all to avoid duplicate packages)
-    - esmf@=8.6.1 snapshot=none
-    - esmf@=8.8.0 snapshot=none
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5

--- a/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/global-workflow-env/package.py
@@ -47,7 +47,7 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("met")
     depends_on("metplus")
     depends_on("gsi-ncdiag")
-    depends_on("crtm@2.4.0.1")
+    depends_on("crtm")
     depends_on("py-wxflow", when="+python")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/gsi-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gsi-env/package.py
@@ -29,7 +29,7 @@ class GsiEnv(BundlePackage):
     depends_on("sfcio")
     depends_on("nemsio")
     depends_on("wrf-io")
-    depends_on("crtm@2.4.0.1")
+    depends_on("crtm")
     depends_on("ncio")
     depends_on("gsi-ncdiag")
 

--- a/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-srw-app-env/package.py
@@ -27,7 +27,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("esmf")
     depends_on("fms")
     depends_on("bacio")
-    depends_on("crtm@2.4.0.1")
+    depends_on("crtm")
     depends_on("g2")
     depends_on("g2tmpl")
     depends_on("ip")

--- a/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufs-weather-model-env/package.py
@@ -28,7 +28,7 @@ class UfsWeatherModelEnv(BundlePackage):
 
     depends_on("fms", type="run")
     depends_on("bacio", type="run")
-    depends_on("crtm@2.4.0.1", type="run")
+    depends_on("crtm", type="run")
     depends_on("g2", type="run")
     depends_on("g2tmpl", type="run")
     depends_on("ip", type="run")


### PR DESCRIPTION
### Summary

This PR updates the wgrib2 version to 2.5.0, and uses crtm@3.1.1-build1 for Global Workflow, GSI, SRW, and UWM.

### Testing

Tested concretization and compiling wgrib2 & crtm@3.1.1-build1.

### Applications affected

Pretty everything EMC...

### Systems affected

all

### Dependencies

none

### Issue(s) addressed

Fixes #1185
Addresses #967

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
