### PR TITLE
Update NRL batch_install.sh: exclude crtm-fix from duplicate check list

### DIFF
--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -591,7 +591,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     fi
 
     # Check for duplicate packages
-    ./util/show_duplicate_packages.py -i crtm -i esmf -d log.concretize.${env_name}.001
+    ./util/show_duplicate_packages.py -i crtm-fix -i crtm -i esmf -d log.concretize.${env_name}.001
 
     # Update local source cache if requested
     if [[ "${update_source_cache}" == "true"* ]]; then


### PR DESCRIPTION
### Summary

In spack-stack 1.9.0 and develop, crtm-fix must be excluded when checking for duplicates in the unified environment. That's because there are two versions of crtm included that come with fix files, v2.4 and 3.1.

### Testing

Tested manually on NRL machines

### Applications affected

None

### Systems affected

NRL systems

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
