### PR TITLE
Update util/weekly_build/03_SetupEnv.sh: exclude crtm-fix from check for duplicates

### DIFF
--- a/util/weekly_build/03_SetupEnv.sh
+++ b/util/weekly_build/03_SetupEnv.sh
@@ -22,7 +22,7 @@ for compiler in $COMPILERS; do
     spack config add "config:install_tree:padded_length:${PADDED_LENGTH:-200}"
     # Check for duplicates and fail before doing the "real" concretization:
     spack_wrapper log.concretize concretize --fresh
-    ${SPACK_STACK_DIR:?}/util/show_duplicate_packages.py log.concretize -d -i crtm -i esmf
+    ${SPACK_STACK_DIR:?}/util/show_duplicate_packages.py log.concretize -d -i crtm-fix -i crtm -i esmf
 #   The following is not working at the moment, for seemingly a couple reasons. Therefore packages with test-only deps cannot be tested.
 #    spack concretize --force --fresh --test all | tee log.concretize_test
   done


### PR DESCRIPTION
### Summary

All in the title. Same as #1497 

### Testing

Not tested (but we know it will work)

### Applications affected

Nightly/weekly automated builds

### Systems affected

All with automated builds

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
