### PR TITLE
Add py-arch and py-regionmask to neptune-python-env

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -131,6 +131,16 @@ jobs:
               echo "jedi-ufs-env ..."
               spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-ufs-env
               spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+
+            elif [[ "${TEMPLATE}" == *"cylc-dev"* ]]; then
+              # Workaround for not being able to install rust from build-cache, see 
+              # https://github.com/spack/spack/issues/48971
+              echo "rust dependencies ..."
+              spack install --verbose --source --no-check-signature --only=dependencies rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.001.rust-dependencies
+
+              # rust from source
+              echo "rust (from source) ..."
+              spack install --verbose --source --no-cache rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.002.rust
             fi
 
             # the rest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_pyarch_pyregionmask_spack_stack_dev
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/update_pyarch_pyregionmask_spack_stack_dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -264,6 +264,9 @@ packages:
   # To avoid duplicate packages
   py-urllib3:
     require: '@1.26.12'
+  # To avoid duplicate packages
+  py-versioneer:
+    require: '@0.28'
   qt:
     require: '@5'
   scotch:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,7 +8,7 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc                           ^esmf@=8.8.0
+      - neptune-env +espc ^esmf@=8.8.0
       # Comment out for Cole and Tusk or any other air-gapped system:
       - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.8.0
 

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -52,3 +52,6 @@ spack:
     - ai-env%oneapi
     - jedi-tools-env%intel
     - jedi-tools-env%oneapi
+    # Skip neptune-python-env with Intel Classic due to problems
+    # with new versions of py-numpy, py-scipy, ...
+    - neptune-python-env%intel

--- a/spack-ext/repos/spack-stack/packages/neptune-python-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-python-env/package.py
@@ -25,6 +25,7 @@ class NeptunePythonEnv(BundlePackage):
     # Enable the Python variant for ESMF
     depends_on("esmf +python", type="run")
 
+    depends_on("py-arch", type="run")
     depends_on("py-h5py", type="run")
     depends_on("py-netcdf4", type="run")
     depends_on("py-pandas", type="run")
@@ -32,6 +33,7 @@ class NeptunePythonEnv(BundlePackage):
     depends_on("py-pybind11", type="run")
     depends_on("py-pyhdf", type="run")
     depends_on("py-pyyaml", type="run")
+    depends_on("py-regionmask", type="run")
     depends_on("py-scipy", type="run")
     depends_on("py-xarray", type="run")
     depends_on("py-pytest", type="run")


### PR DESCRIPTION
### Summary

Add py-arch and py-regionmask to neptune-python-env. These don't build with the deprecated Intel Classic compilers, therefore excluding `neptune-python-env` for Intel Classic.

Includes a workaround for a spack binary-cache bug (https://github.com/spack/spack/issues/48971) in Ubuntu GNU GitHub workflow.

### Testing

- [x] CI

I also installed the updated `python-dev` template on my laptop with:
- [x] `gcc@13.3.0`: built environment, tested `py-arch` and `py-regionmask`
- [x] `oneapi@2024.2.1` built environment, tested `py-arch` and `py-regionmask`

### Applications affected

NEPTUNE

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/516

### Issue(s) addressed

Resolves #1286 
Resolves #1293

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
