### PR TITLE
hercules site config for release/1.9.0

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -131,6 +131,15 @@ jobs:
               echo "jedi-ufs-env ..."
               spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-ufs-env
               spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+
+            elif [[ "${TEMPLATE}" == *"cylc-dev"* ]]; then
+              # Workaround for not being able to install rust from build-cache, see 
+              # https://github.com/spack/spack/issues/48971
+              echo "rust dependencies ..."
+              spack install --verbose --source --no-check-signature --only=dependencies rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.001.rust-dependencies
+              # rust from source
+              echo "rust (from source) ..."
+              spack install --verbose --source --no-cache rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.002.rust
             fi
 
             # the rest

--- a/configs/sites/tier1/hercules/compilers.yaml
+++ b/configs/sites/tier1/hercules/compilers.yaml
@@ -1,32 +1,39 @@
 compilers:
 - compiler:
-    spec: intel@2021.9.0
+    spec: oneapi@=2024.2.1
     paths:
-      cc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icc
-      cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icpc
-      f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
-      fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
+      cc: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/icx
+      cxx: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/icpx
+      f77: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort
+      fc: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort
     flags: {}
     operating_system: rocky9
     target: x86_64
     modules:
-    - intel-oneapi-compilers/2023.1.0
+    - spack-managed-x86-64_v3
+    - intel-oneapi-compilers/2024.2.1
     environment:
       set:
         # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
         I_MPI_EXTRA_FILESYSTEM: 'ON'
+        # Override system module settings for FC and F77 (they're set to ifx)
+        F77: '/apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort'
+        FC: '/apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort'
+      prepend_path:
+        PATH: /usr/bin
+        LD_LIBRARY_PATH: /usr/lib:/usr/lib64
+        CPATH: '/usr/include/c++/11:/usr/include/c++/11/x86_64-redhat-linux'
     extra_rpaths: []
+
 - compiler:
-    spec: gcc@12.2.0
+    spec: gcc@11.3.1
     paths:
-      cc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gcc
-      cxx: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/g++
-      f77: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
-      fc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
     flags: {}
     operating_system: rocky9
-    target: x86_64
-    modules:
-    - gcc/12.2.0
+    modules: []
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/hercules/compilers.yaml
+++ b/configs/sites/tier1/hercules/compilers.yaml
@@ -26,14 +26,34 @@ compilers:
     extra_rpaths: []
 
 - compiler:
-    spec: gcc@11.3.1
+    spec: intel@2021.9.0
     paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
+      cc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icc
+      cxx: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/icpc
+      f77: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
+      fc: /apps/spack-managed/gcc-11.3.1/intel-oneapi-compilers-2023.1.0-sb753366rvywq75zeg4ml5k5c72xgj72/compiler/2023.1.0/linux/bin/intel64/ifort
     flags: {}
     operating_system: rocky9
-    modules: []
+    target: x86_64
+    modules:
+    - intel-oneapi-compilers/2023.1.0
+    environment:
+      set:
+        # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
+        I_MPI_EXTRA_FILESYSTEM: 'ON'
+    extra_rpaths: []
+
+- compiler:
+    spec: gcc@12.2.0
+    paths:
+      cc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gcc
+      cxx: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/g++
+      f77: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+      fc: /apps/spack-managed/gcc-11.3.1/gcc-12.2.0-7cu3qahzhsxpauy4jlnsbcqmlbkxbbbo/bin/gfortran
+    flags: {}
+    operating_system: rocky9
+    target: x86_64
+    modules:
+    - gcc/12.2.0
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/hercules/compilers.yaml
+++ b/configs/sites/tier1/hercules/compilers.yaml
@@ -24,7 +24,6 @@ compilers:
         LD_LIBRARY_PATH: /usr/lib:/usr/lib64
         CPATH: '/usr/include/c++/11:/usr/include/c++/11/x86_64-redhat-linux'
     extra_rpaths: []
-
 - compiler:
     spec: intel@2021.9.0
     paths:
@@ -42,7 +41,6 @@ compilers:
         # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
         I_MPI_EXTRA_FILESYSTEM: 'ON'
     extra_rpaths: []
-
 - compiler:
     spec: gcc@12.2.0
     paths:

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -44,6 +44,10 @@ packages:
     externals:
     - spec: gawk@5.1.0
       prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.21
+      prefix: /usr
   git:
     externals:
     - spec: git@2.31.1~tcltk
@@ -66,21 +70,31 @@ packages:
     externals:
     - spec: groff@1.22.4
       prefix: /usr
+  # Don't use, incomplete installation!
+  #libtool:
+  #  externals:
+  #  - spec: libtool@2.4.6
+  #    prefix: /usr
   m4:
     externals:
     - spec: m4@1.4.19
       prefix: /usr
-  mysql:
-    buildable: False
-    externals:
-    - spec: mysql@8.0.31
-      prefix: /work/noaa/epic/role-epic/spack-stack/hercules/mysql-8.0.31
-      modules:
-      - mysql/8.0.31
+  #mysql:
+  #  buildable: False
+  #  externals:
+  #  - spec: mysql@8.0.31
+  #    prefix: /work/noaa/epic/role-epic/spack-stack/hercules/mysql-8.0.31
+  #    modules:
+  #    - mysql/8.0.31
   openssh:
     externals:
     - spec: openssh@8.7p1
       prefix: /usr
+  # Don't use, issues with py-cryptography
+  #openssl:
+  #  externals:
+  #  - spec: openssl@3.0.1
+  #    prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.7.3
@@ -92,6 +106,10 @@ packages:
   subversion:
     externals:
     - spec: subversion@1.14.1
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.34
       prefix: /usr
   texinfo:
     externals:

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -1,4 +1,17 @@
 packages:
+  # For addressing https://github.com/JCSDA/spack-stack/issues/1355
+  #   Use system zlib instead of spack-built zlib-ng
+  all:
+    providers:
+      zlib-api:: [zlib]
+  zlib-api:
+    buildable: False
+  zlib:
+    buildable: False
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr
+
   autoconf:
     externals:
     - spec: autoconf@2.69
@@ -14,10 +27,6 @@ packages:
   coreutils:
     externals:
     - spec: coreutils@8.32
-      prefix: /usr
-  curl:
-    externals:
-    - spec: curl@7.76.1+gssapi+ldap+nghttp2
       prefix: /usr
   diffutils:
     externals:
@@ -72,20 +81,10 @@ packages:
     externals:
     - spec: openssh@8.7p1
       prefix: /usr
-  openssl:
-    externals:
-    - spec: openssl@3.0.1
-      prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.7.3
       prefix: /usr
-  qt:
-    externals:
-    - spec: qt@5.15.14
-      prefix: /apps/contrib/spack-stack-1.1/gcc-11.3.1/qt-5.15.14-mfeuvcidmyqoi2m5i2tfrk6yd7xtk6pt
-      modules:
-      - qt/5.15.14
   sed:
     externals:
     - spec: sed@4.8
@@ -102,3 +101,7 @@ packages:
     externals:
     - spec: wget@1.21.1
       prefix: /usr
+  which:
+    externals:
+      - spec: which@2.21
+        prefix: /usr

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -79,17 +79,6 @@ packages:
     externals:
     - spec: m4@1.4.19
       prefix: /usr
-  #mysql:
-  #  buildable: False
-  #  externals:
-  #  - spec: mysql@8.0.31
-  #    prefix: /work/noaa/epic/role-epic/spack-stack/hercules/mysql-8.0.31
-  #    modules:
-  #    - mysql/8.0.31
-  openssh:
-    externals:
-    - spec: openssh@8.7p1
-      prefix: /usr
   # Don't use, issues with py-cryptography
   #openssl:
   #  externals:

--- a/configs/sites/tier1/hercules/packages_gcc.yaml
+++ b/configs/sites/tier1/hercules/packages_gcc.yaml
@@ -1,14 +1,17 @@
 packages:
   all:
-    compiler:: [gcc@12.2.0]
+    compiler:: [gcc@11.3.1]
     providers:
       mpi:: [openmpi@4.1.4]
   mpi:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@4.1.4%gcc@12.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
-        schedulers=slurm
+    - spec: openmpi@4.1.4%gcc@11.3.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
+      prefix: /apps/spack-managed/gcc-11.3.1/openmpi-4.1.4-zabolhazla2ahsroedlyt2pu4mkp7o3q
       modules:
-      - gcc/12.2.0
       - openmpi/4.1.4
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'

--- a/configs/sites/tier1/hercules/packages_gcc.yaml
+++ b/configs/sites/tier1/hercules/packages_gcc.yaml
@@ -12,7 +12,17 @@ packages:
       modules:
       - gcc/12.2.0
       - openmpi/4.1.4
+
+  ectrans:
+    require::
+    - '~mkl +fftw'
+  gsibec:
+    require::
+    - '~mkl'
   py-numpy:
     require::
     - '@1.26'
     - '^openblas'
+  zlib-ng:
+    require:
+    - '~shared'

--- a/configs/sites/tier1/hercules/packages_gcc.yaml
+++ b/configs/sites/tier1/hercules/packages_gcc.yaml
@@ -7,7 +7,7 @@ packages:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@4.1.4%gcc@11.3.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
+    - spec: openmpi@4.1.4%gcc@12.2.0 ~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java~legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=none romio-filesystem=none schedulers=slurm  
       prefix: /apps/spack-managed/gcc-12.2.0/openmpi-4.1.4-hf3dkf6r56x3klzcgs3u7esgt3fhnk63
       modules:
       - gcc/12.2.0

--- a/configs/sites/tier1/hercules/packages_gcc.yaml
+++ b/configs/sites/tier1/hercules/packages_gcc.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [gcc@11.3.1]
+    compiler:: [gcc@12.2.0]
     providers:
       mpi:: [openmpi@4.1.4]
   mpi:
@@ -8,8 +8,9 @@ packages:
   openmpi:
     externals:
     - spec: openmpi@4.1.4%gcc@11.3.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi+static~wrapper-rpath
-      prefix: /apps/spack-managed/gcc-11.3.1/openmpi-4.1.4-zabolhazla2ahsroedlyt2pu4mkp7o3q
+      prefix: /apps/spack-managed/gcc-12.2.0/openmpi-4.1.4-hf3dkf6r56x3klzcgs3u7esgt3fhnk63
       modules:
+      - gcc/12.2.0
       - openmpi/4.1.4
   py-numpy:
     require::

--- a/configs/sites/tier1/hercules/packages_intel.yaml
+++ b/configs/sites/tier1/hercules/packages_intel.yaml
@@ -30,4 +30,5 @@ packages:
     - '@1.2.1 ~mkl'
   py-numpy:
     require::
+    - '@1.26'
     - '^openblas'

--- a/configs/sites/tier1/hercules/packages_oneapi.yaml
+++ b/configs/sites/tier1/hercules/packages_oneapi.yaml
@@ -13,20 +13,20 @@ packages:
     buildable: False
     externals:
     - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
+      prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-3pv63eugwmse2xpeglxib4dr2oeb42g2
       modules:
       - spack-managed-x86-64_v3
       - intel-oneapi-compilers/2024.2.1
       - intel-oneapi-mpi@2021.13.1
-      prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-3pv63eugwmse2xpeglxib4dr2oeb42g2
 
   intel-oneapi-mkl:
     buildable: False
     externals:
     - spec: intel-oneapi-mkl@2024.2.1
+      prefix: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-mkl-2024.2.1-aeiool3i5jj4newwifvkhow5almp67rt
       modules:
       - spack-managed-x86-64_v3
       - intel-oneapi-mkl/2024.2.1
-      prefix: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-mkl-2024.2.1-aeiool3i5jj4newwifvkhow5almp67rt
 
   intel-oneapi-runtime:
     externals:

--- a/configs/sites/tier1/hercules/packages_oneapi.yaml
+++ b/configs/sites/tier1/hercules/packages_oneapi.yaml
@@ -1,0 +1,52 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.1]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.13]
+      # If using intel-oneapi-mkl, make appropriate changes below
+      blas:: [openblas]
+      fftw-api:: [fftw]
+      lapack:: [openblas]
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
+      modules:
+      - spack-managed-x86-64_v3
+      - intel-oneapi-compilers/2024.2.1
+      - intel-oneapi-mpi@2021.13.1
+      prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-3pv63eugwmse2xpeglxib4dr2oeb42g2
+
+  intel-oneapi-mkl:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mkl@2024.2.1
+      modules:
+      - spack-managed-x86-64_v3
+      - intel-oneapi-mkl/2024.2.1
+      prefix: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-mkl-2024.2.1-aeiool3i5jj4newwifvkhow5almp67rt
+
+  intel-oneapi-runtime:
+    externals:
+    - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
+      prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-runtime-2024.2.1-hl5zgdjaldynq35dq3yotclfy2vblybx
+      modules:
+      - spack-managed-x86-64_v3
+      - intel-oneapi-compilers/2024.2.1
+      - intel-oneapi-runtime/2024.2.1
+
+  ectrans:
+    require::
+    - '@1.5.0 ~mkl +fftw'
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'
+  py-scipy:
+    require:
+      '%gcc'

--- a/configs/sites/tier1/hercules/packages_oneapi.yaml
+++ b/configs/sites/tier1/hercules/packages_oneapi.yaml
@@ -50,3 +50,6 @@ packages:
   py-scipy:
     require:
       '%gcc'
+  zlib-ng:
+    require:
+    - '~shared'


### PR DESCRIPTION
### Summary

Update / add required config files for `tier1` site **hercules**

### Testing

Build / install `unified-dev` environment for `oneAPI` and `GNU` compilers.

Note that `Intel` compilers prior to `v2024.2.1` remain specified, but no stack was built with that compiler.

### Systems affected

**hercules**

### Issue(s) addressed

[spack-stack-1.9.0 release tasks](https://github.com/JCSDA/spack-stack/issues/1485)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
