### PR TITLE
release/1.9.0: Update .github/workflows/ubuntu-ci-x86_64-gnu.yaml from develop (cannot cherry-pick 58ab975)

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -131,6 +131,16 @@ jobs:
               echo "jedi-ufs-env ..."
               spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-ufs-env
               spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
+
+            elif [[ "${TEMPLATE}" == *"cylc-dev"* ]]; then
+              # Workaround for not being able to install rust from build-cache, see 
+              # https://github.com/spack/spack/issues/48971
+              echo "rust dependencies ..."
+              spack install --verbose --source --no-check-signature --only=dependencies rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.001.rust-dependencies
+
+              # rust from source
+              echo "rust (from source) ..."
+              spack install --verbose --source --no-cache rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.002.rust
             fi
 
             # the rest


### PR DESCRIPTION
### Summary

This PR updates `.github/workflows/ubuntu-ci-x86_64-gnu.yaml` from develop using the following procedure, since we cannot cherry-pick 58ab975 (it was merged as part of a squashed merge):
```
 1002  git clone -b release/1.9.0 --recurse-submodules https://github.com/jcsda/spack-stack spst-fix-gnu-ci-rel190
 1003  cd spst-fix-gnu-ci-rel190
 1006  git diff origin/develop origin/release/1.9.0
 1007  git diff origin/develop origin/release/1.9.0 .github/workflows/
 1008  git checkout origin/develop -- .github/workflows/ubuntu-ci-x86_64-gnu.yaml
 1011  git status
 1012  git commit -m "Update .github/workflows/ubuntu-ci-x86_64-gnu.yaml from develop (cannot cherry-pick 58ab975)"
 1013  git checkout -b bugfix/rel190_gnuci
 1014  git remote add dom https://github.com/climbfuji/spack-stack
 1015  git push dom bugfix/rel190_gnuci
```

### Testing

- [ ] CI

### Applications affected

None

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

Failing CI tests for Ubuntu GNU, branch `release/1.9.0`.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
