### PR TITLE
Updates for discover 1.9.0 configs

### DIFF
--- a/configs/sites/tier1/discover-scu17/compilers.yaml
+++ b/configs/sites/tier1/discover-scu17/compilers.yaml
@@ -38,6 +38,44 @@ compilers:
         I_MPI_ADJUST_BARRIER: '9'
     extra_rpaths: []
 - compiler:
+    spec: oneapi@=2024.2.0
+    paths:
+      cc: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/icx
+      cxx: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/icpx
+      f77: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/ifort
+      fc: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/ifort
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - comp/intel/2024.2.0
+    environment:
+      prepend_path:
+        PATH: '/usr/local/other/gcc/11.4.0/bin'
+        CPATH: '/usr/local/other/gcc/11.4.0/include'
+        LD_LIBRARY_PATH: '/usr/local/intel/oneapi/2024/compiler/2024.2/lib/:/usr/local/other/gcc/11.4.0/lib64'
+      set:
+        # https://github.com/JCSDA/spack-stack/issues/1011
+        I_MPI_SHM_HEAP_VSIZE: '512'
+        PSM2_MEMORY: 'large'
+        # https://github.com/JCSDA/spack-stack/issues/1012
+        I_MPI_EXTRA_FILESYSTEM: '1'
+        I_MPI_EXTRA_FILESYSTEM_FORCE: 'gpfs'
+        I_MPI_FABRICS: 'ofi'
+        I_MPI_OFI_PROVIDER: 'psm3'
+        I_MPI_ADJUST_SCATTER: '2'
+        I_MPI_ADJUST_SCATTERV: '2'
+        I_MPI_ADJUST_GATHER: '2'
+        I_MPI_ADJUST_GATHERV: '3'
+        I_MPI_ADJUST_ALLGATHER: '3'
+        I_MPI_ADJUST_ALLGATHERV: '3'
+        I_MPI_ADJUST_ALLREDUCE: '12'
+        I_MPI_ADJUST_REDUCE: '10'
+        I_MPI_ADJUST_BCAST: '11'
+        I_MPI_ADJUST_REDUCE_SCATTER: '4'
+        I_MPI_ADJUST_BARRIER: '9'
+    extra_rpaths: []
+- compiler:
     spec: gcc@=12.3.0
     paths:
       cc: /usr/local/other/gcc/12.3.0/bin/gcc

--- a/configs/sites/tier1/discover-scu17/packages_intel.yaml
+++ b/configs/sites/tier1/discover-scu17/packages_intel.yaml
@@ -15,3 +15,8 @@ packages:
     externals:
     - spec: intel-oneapi-mkl@2023.2.0%intel@2021.10.0
       prefix: /usr/local/intel/oneapi/2021
+  wget:
+    buildable: False
+    externals:
+    - spec: wget@1.20.3
+      prefix: /usr

--- a/configs/sites/tier1/discover-scu17/packages_oneapi.yaml
+++ b/configs/sites/tier1/discover-scu17/packages_oneapi.yaml
@@ -1,0 +1,21 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.0,gcc@11.4.0]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.13]
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.0
+      prefix: /usr/local/intel/oneapi/2024
+      modules:
+      - mpi/impi/2021.13
+  intel-oneapi-mkl:
+    externals:
+    - spec: intel-oneapi-mkl@2024.2.0
+      prefix: /usr/local/intel/oneapi/2024
+  intel-oneapi-runtime:
+    externals:
+    - spec: intel-oneapi-runtime@2024.2.0%oneapi@2024.2.0
+      prefix: /usr/local/intel/oneapi/2024


### PR DESCRIPTION
### Summary

Adding packages_oneapi.yaml for discover-scu17. Also in order to build the old intel classic, I needed to use an external wget. 

### Testing

These configurations were used to successfully build spack-stack 1.9.0 on discover-scu17 for Intel classic, oneAPI, and GNU. 

### Systems affected

Discover

### Dependencies

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
