### PR TITLE
wcoss2: remove redundant fckit 'require'

### DIFF
--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -71,8 +71,6 @@
       require:
       - snapshot=none   # make sure spack-stack doesn't accidentally give us a beta snapshot
       - '~python'
-    fckit:
-      'require:': +eckit   # older version needed for older eckit & ecmwf-atlas
     flex:
       require: '@2.6.4'
     gcc-runtime:


### PR DESCRIPTION
### Summary

Remove redundant fckit entry from wcoss2 packages.yaml.

### Testing

Tested on Acorn

### Applications affected

ops

### Systems affected

WCOSS2 (NCO)

### Dependencies

none

### Issue(s) addressed

https://github.com/NOAA-EMC/WCOSS2-requests/issues/29

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
