### PR TITLE
Avoid full rust dependency in cylc environments

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -131,16 +131,6 @@ jobs:
               echo "jedi-ufs-env ..."
               spack install --fail-fast --source --no-check-signature jedi-ufs-env 2>&1 | tee log.install.gnu-11.4.0-buildcache.jedi-ufs-env
               spack buildcache create -u /home/ubuntu/spack-stack/build-cache/ jedi-ufs-env
-
-            elif [[ "${TEMPLATE}" == *"cylc-dev"* ]]; then
-              # Workaround for not being able to install rust from build-cache, see 
-              # https://github.com/spack/spack/issues/48971
-              echo "rust dependencies ..."
-              spack install --verbose --source --no-check-signature --only=dependencies rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.001.rust-dependencies
-
-              # rust from source
-              echo "rust (from source) ..."
-              spack install --verbose --source --no-cache rust 2>&1 | tee log.install.gnu-11.4.0-buildcache.${TEMPLATE}.002.rust
             fi
 
             # the rest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/py-maturin_py-rpds-py_rust-bootstrap
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/py-maturin_py-rpds-py_rust-bootstrap
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -223,6 +223,8 @@ packages:
   py-cartopy:
     require: '+plotting'
   # Avoid full rust dependency: version 43+ requires py-maturin
+  # DH* 20250214 No longer needed?
+  # https://github.com/JCSDA/spack-stack/pull/1519
   py-cryptography:
     require: '@:42 +rust_bootstrap'
   # Pin py-cython to avoid duplicate packages
@@ -243,6 +245,8 @@ packages:
   # https://github.com/JCSDA/spack-stack/issues/1276
   py-matplotlib:
     require: '@3.7.4'
+  py-maturin:
+    require: '+rust_bootstrap'
   # https://github.com/Unidata/netcdf4-python/issues/1389
   # https://github.com/Unidata/netcdf4-python/issues/1389#issuecomment-2599760051
   py-netcdf4:
@@ -251,6 +255,8 @@ packages:
   py-numpy:
     require:
     - '@1.26'
+  py-rpds-py:
+    require: '+rust_bootstrap'
   # To avoid duplicate packages
   py-ruamel-yaml:
     require: '@0.17.16'


### PR DESCRIPTION
### Summary

This PR enables a newly added `rust-bootstrap` variant for `py-maturin` and `py-rpds-py` to avoid a dependency on the full rust package in the Cylc environment.

### Testing

I tested the `rust-bootstrap` variants in the context of building a Cylc environment (`py-cylc-flow@8.3.6`, `py-cylc-rose@1.4.2`, `py-cylc-uiserver@1.5.1`). I was able to run `cylc tui`, `cylc gui`, and a full Cylc workflow for an NWP model.

CI testing for https://github.com/JCSDA/spack-stack/pull/1519/commits/308f9319ef8675313a9d1347acd492a89b3bec08

### Applications affected

Cylc environments (template `cylc-dev`)

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/517

### Issue(s) addressed

n/a

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
