### PR TITLE
Up mapl from 2.53.0-esmf-8.6.1 to 2.53.0-esmf-8.8.0

### DIFF
--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -24,14 +24,18 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=3.1.1-build1
-    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.1-build1
+    - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.1-build1
 
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
     - crtm@3.1.1-build1
 
+    # Mapl with various esmf tags
+    - mapl@2.53.0 ^esmf@8.6.1
+    - mapl@2.53.0 ^esmf@8.8.0
+    
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none


### PR DESCRIPTION
### Summary

Recent UFS-WM need MAPL@2.53.0 with ESMF@8.8.0

### Testing

Installed spack-stack on Hera.

### Applications affected

UFS WM and SRW

### Systems affected

All.

### Dependencies

No

### Issue(s) addressed

Closes #1529 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
