### PR TITLE
Fix .gitmodules and submodule pointer for spack to point back to JCSDA spack-stack-dev after met/metplus update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/met12_metplus6
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
### Summary

All in the title. I verified that the code in the spack submodule is identical between what it was pointing to before and after the fix.

### Testing

- [ ] CI

### Applications affected

None

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
