### PR TITLE
Update wgrib2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-#  url = https://github.com/jcsda/spack
-#  branch = release/1.9.0
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = g2c_update_feb25
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+#  url = https://github.com/jcsda/spack
+#  branch = release/1.9.0
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = g2c_update_feb25
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -234,7 +234,7 @@ modules:
         environment:
           set:
             'WGRIB2_INC': '{prefix}/include'
-            'WGRIB2_LIB': '{prefix}/lib/libwgrib2.a'
+            'WGRIB2_LIB': '{prefix}/lib64/libwgrib2.so'
             'WGRIB2': '{prefix}/bin/wgrib2'
       wrf-io:
         environment:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -236,7 +236,7 @@ modules:
         environment:
           set:
             'WGRIB2_INC': '{prefix}/include'
-            'WGRIB2_LIB': '{prefix}/lib/libwgrib2.a'
+            'WGRIB2_LIB': '{prefix}/lib64/libwgrib2.so'
             'WGRIB2': '{prefix}/bin/wgrib2'
       wrf-io:
         environment:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -291,7 +291,7 @@ packages:
   # See macOS site config for wgrib2 version/variant overrides
   wgrib2:
     require:
-    - '@3.5.0'
+    - '@3.6.0'
   wrf-io:
     require: '@1.2.0'
   zstd:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -104,7 +104,7 @@ packages:
     require:
     - '@3.5.1'
   g2c:
-    require: '@1.9.0'
+    require: '@2.1.0'
   g2tmpl:
     require:
     - '@1.13.0'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -104,7 +104,7 @@ packages:
     require:
     - '@3.5.1'
   g2c:
-    require: '@1.6.4'
+    require: '@1.9.0'
   g2tmpl:
     require:
     - '@1.13.0'

--- a/configs/sites/tier2/macos.default/packages.yaml
+++ b/configs/sites/tier2/macos.default/packages.yaml
@@ -11,5 +11,4 @@ packages:
     buildable: false
   wgrib2:
     require::
-    - '@3.4.0'
     - '~openmp'


### PR DESCRIPTION
### Summary

Update wgrib2 from static to dynamic library and default version from 3.5.0 to 3.6.0
Update to point to latest spack.

### Testing

Installed 1.9.0 with new wgrib2 on Hera.

### Applications affected

All using wgrib2

### Systems affected

All

### Dependencies

https://github.com/JCSDA/spack/pull/522

### Issue(s) addressed

Closes issue #1515 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
