### PR TITLE
Update setup.sh: add export SPACK_DISABLE_LOCAL_CONFIG=true

### DIFF
--- a/.github/workflows/macos-ci-aarch64.yaml
+++ b/.github/workflows/macos-ci-aarch64.yaml
@@ -63,6 +63,8 @@ jobs:
           export ENVDIR=$PWD/envs/${ENVNAME}
           spack stack create env --site macos.default --template unified-dev --name ${ENVNAME} --compiler apple-clang
           spack env activate ${ENVDIR}
+
+          unset SPACK_DISABLE_LOCAL_CONFIG
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
@@ -83,7 +85,8 @@ jobs:
           # Find compilers
           spack compiler find --scope system
 
-          export -n SPACK_SYSTEM_CONFIG_PATH
+          export SPACK_DISABLE_LOCAL_CONFIG=true
+          unset SPACK_SYSTEM_CONFIG_PATH
 
           # For buildcaches
           spack config add config:install_tree:padded_length:200

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -65,6 +65,8 @@ jobs:
             export ENVDIR=$PWD/envs/${ENVNAME}
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler gcc
             spack env activate ${ENVDIR}
+
+            unset SPACK_DISABLE_LOCAL_CONFIG
             export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
             # Find external packages
@@ -82,7 +84,8 @@ jobs:
             # Find compilers
             spack compiler find --scope system
 
-            export -n SPACK_SYSTEM_CONFIG_PATH
+            export SPACK_DISABLE_LOCAL_CONFIG=true
+            unset SPACK_SYSTEM_CONFIG_PATH
 
             # For buildcaches
             spack config add config:install_tree:padded_length:200

--- a/.github/workflows/ubuntu-ci-x86_64-intel.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-intel.yaml
@@ -54,6 +54,8 @@ jobs:
           export ENVDIR=$PWD/envs/${ENVNAME}
           spack stack create env --site linux.default --template unified-dev --name ${ENVNAME} --compiler intel
           spack env activate ${ENVDIR}
+
+          unset SPACK_DISABLE_LOCAL_CONFIG
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
@@ -98,16 +100,12 @@ jobs:
           echo "    - spec: intel-oneapi-mpi@2021.10.0%intel@2021.10.0 +classic-names" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "      prefix: /opt/intel/oneapi" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
-          # Add external Intel MKL and oneAPI runtime
+          # Add external Intel MKL
           echo "" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "  intel-oneapi-mkl:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "    externals:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "    - spec: intel-oneapi-mkl@2023.2.0%intel@2021.10.0" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "      prefix: /opt/intel/oneapi" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
-          #echo "  intel-oneapi-runtime:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
-          #echo "    externals:" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
-          #echo "    - spec: intel-oneapi-runtime@2023.2.0%oneapi@2024.2.0" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
-          #echo "      prefix: /opt/intel/oneapi" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
           # Add external qt@5 to build ecflow
           echo "" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
@@ -117,7 +115,8 @@ jobs:
           echo "    - spec: qt@5.15.3" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "      prefix: /usr" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
-          export -n SPACK_SYSTEM_CONFIG_PATH
+          export SPACK_DISABLE_LOCAL_CONFIG=true
+          unset SPACK_SYSTEM_CONFIG_PATH
 
           # For buildcaches
           spack config add config:install_tree:padded_length:200

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -54,6 +54,8 @@ jobs:
           export ENVDIR=$PWD/envs/${ENVNAME}
           spack stack create env --site linux.default --template unified-dev --name ${ENVNAME} --compiler oneapi
           spack env activate ${ENVDIR}
+
+          unset SPACK_DISABLE_LOCAL_CONFIG
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
@@ -107,7 +109,8 @@ jobs:
           echo "    - spec: intel-oneapi-runtime@2024.2.0%oneapi@2024.2.0" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "      prefix: /opt/intel/oneapi" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
-          export -n SPACK_SYSTEM_CONFIG_PATH
+          export SPACK_DISABLE_LOCAL_CONFIG=true  
+          unset SPACK_SYSTEM_CONFIG_PATH
 
           # For buildcaches
           spack config add config:install_tree:padded_length:200

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -54,6 +54,8 @@ jobs:
           export ENVDIR=$PWD/envs/${ENVNAME}
           spack stack create env --site linux.default --template unified-dev --name ${ENVNAME} --compiler oneapi
           spack env activate ${ENVDIR}
+
+          unset SPACK_DISABLE_LOCAL_CONFIG
           export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 
           # Find external packages
@@ -107,7 +109,8 @@ jobs:
           echo "    - spec: intel-oneapi-runtime@2024.2.0%oneapi@2024.2.0" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
           echo "      prefix: /opt/intel/oneapi" >> ${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml
 
-          export -n SPACK_SYSTEM_CONFIG_PATH
+          export SPACK_DISABLE_LOCAL_CONFIG=true
+          unset SPACK_SYSTEM_CONFIG_PATH
 
           # For buildcaches
           spack config add config:install_tree:padded_length:200

--- a/doc/source/NewSiteConfigs.rst
+++ b/doc/source/NewSiteConfigs.rst
@@ -231,10 +231,11 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
    cd envs/unified-env.mymacos/
    spack env activate [-p] .
 
-3. Still in the environment directory, temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``site``
+3. Still in the environment directory, temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``site`` und unset ``SPACK_DISABLE_LOCAL_CONFIG``.
 
 .. code-block:: console
    
+   unset SPACK_DISABLE_LOCAL_CONFIG
    export SPACK_SYSTEM_CONFIG_PATH="$PWD/site"
 
 4. Find external packages, add to site config's ``packages.yaml``. If an external's bin directory hasn't been added to ``$PATH``, need to prefix command.
@@ -312,10 +313,11 @@ Remember to activate the ``lua`` module environment and have MacTeX in your sear
 .. note::
   Apple is aware of this issue (Apple ticket number FB13208302) and working on a solution, so this is a temporary workaround that will be removed once the linker/loader issues are repaired.
 
-6. Do **not** forget to unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable!
+6. Do **not** forget to unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable and restore the ``SPACK_DISABLE_LOCAL_CONFIG`` variable!
 
 .. code-block:: console
 
+   export SPACK_DISABLE_LOCAL_CONFIG=true
    unset SPACK_SYSTEM_CONFIG_PATH
 
 7. Set default compiler and MPI library (make sure to use the correct ``apple-clang`` version for your system and the desired ``openmpi`` version)
@@ -523,10 +525,11 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
    cd envs/unified-env.mylinux/
    spack env activate [-p] .
 
-3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mylinux/site``
+3. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/unified-env.mylinux/site`` and unset ``SPACK_DISABLE_LOCAL_CONFIG``
 
 .. code-block:: console
 
+   unset SPACK_DISABLE_LOCAL_CONFIG
    export SPACK_SYSTEM_CONFIG_PATH="$PWD/site"
 
 4. Find external packages, add to site config's ``packages.yaml``. If an external's bin directory hasn't been added to ``$PATH``, need to prefix command.
@@ -555,10 +558,11 @@ It is recommended to increase the stacksize limit by using ``ulimit -S -s unlimi
 
    spack compiler find --scope system
 
-6. Do **not** forget to unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable!
+6. Do **not** forget to unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable and restore the ``SPACK_DISABLE_LOCAL_CONFIG`` variable!
 
 .. code-block:: console
 
+   export SPACK_DISABLE_LOCAL_CONFIG=true
    unset SPACK_SYSTEM_CONFIG_PATH
 
 7. Set default compiler and MPI library (make sure to use the correct ``gcc`` version for your system and the desired ``openmpi`` version)
@@ -714,10 +718,11 @@ Optionally, to run code that may use the CUDA runtime libraries, also install:
    cd envs/jedi-mpas-nvidia-env/
    spack env activate [-p] .
 
-6. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/jedi-mpas-nvidia-env/site``
+6. Temporarily set environment variable ``SPACK_SYSTEM_CONFIG_PATH`` to modify site config files in ``envs/jedi-mpas-nvidia-env/site`` and unset ``SPACK_DISABLE_LOCAL_CONFIG``
 
 .. code-block:: console
 
+   unset SPACK_DISABLE_LOCAL_CONFIG
    export SPACK_SYSTEM_CONFIG_PATH="$PWD/site"
 
 7. Find external packages, add to site config's ``packages.yaml``. If an external's bin directory hasn't been added to ``$PATH``, need to prefix command.
@@ -741,10 +746,11 @@ Optionally, to run code that may use the CUDA runtime libraries, also install:
 
    spack compiler find --scope system
 
-9. Unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable
+9. Unset the ``SPACK_SYSTEM_CONFIG_PATH`` environment variable and restore the ``SPACK_DISABLE_LOCAL_CONFIG`` variable
 
 .. code-block:: console
 
+   export SPACK_DISABLE_LOCAL_CONFIG=true
    unset SPACK_SYSTEM_CONFIG_PATH
 
 10. Add the following block to ``envs/jedi-mpas-nvidia-env/spack.yaml`` (pay attention to the correct indendation, it should be at the same level as ``specs:``):

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ source ${SPACK_STACK_DIR:?}/spack/share/spack/setup-env.sh
 echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
 # Avoid using ~/.spack directory for caching, bootstrap, etc.
 if [ "$(uname)" != "Darwin" ]; then
+  export SPACK_DISABLE_LOCAL_CONFIG=true
   export SPACK_USER_CACHE_PATH=$SPACK_ROOT/user_cache
   echo "Changing bootstrap path to $(spack bootstrap root '$spack/bootstrap')"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -7,12 +7,11 @@ echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 
 source ${SPACK_STACK_DIR:?}/spack/share/spack/setup-env.sh
 echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
+
 # Avoid using ~/.spack directory for caching, bootstrap, etc.
-if [ "$(uname)" != "Darwin" ]; then
-  export SPACK_DISABLE_LOCAL_CONFIG=true
-  export SPACK_USER_CACHE_PATH=$SPACK_ROOT/user_cache
-  echo "Changing bootstrap path to $(spack bootstrap root '$spack/bootstrap')"
-fi
+export SPACK_DISABLE_LOCAL_CONFIG=true
+export SPACK_USER_CACHE_PATH=$SPACK_ROOT/user_cache
+echo "Changing bootstrap path to $(spack bootstrap root '$spack/bootstrap')"
 
 # Get the current hash of the spack-stack code
 export SPACK_STACK_HASH=`git rev-parse --short HEAD`


### PR DESCRIPTION
### Summary

Update `setup.sh`: add `export SPACK_DISABLE_LOCAL_CONFIG=true` to completely isolate the spack-stack environments from user spack configurations. This requires additional steps to unset and restore the environment variable when creating new site configurations. Further, remove the exception for macOS (no longer needed, see https://github.com/JCSDA/spack-stack/pull/1545#issuecomment-2704598741 below for more information)

### Testing

- [x] Tested on NRL systems and @climbfuji's devbox
- [x] CI

### Applications affected

None

### Systems affected

"All" (not really), but at least air-gapped systems where the spack bootstrap mirror needs to be used every time from now on.

### Dependencies

n/a

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1544

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
