### PR TITLE
Add external intel-oneapi-runtime to container and Ubuntu site config

### DIFF
--- a/configs/containers/docker-ubuntu-oneapi-impi.yaml
+++ b/configs/containers/docker-ubuntu-oneapi-impi.yaml
@@ -97,6 +97,11 @@ spack:
     icu4c:
       require:
       - '%gcc'
+    intel-oneapi-runtime:
+      buildable: false
+      externals:
+      - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
+        prefix: /opt/intel/oneapi
     intel-oneapi-mkl:
       buildable: false
       externals:

--- a/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
@@ -7,6 +7,11 @@ packages:
       blas:: [openblas]
       fftw-api:: [fftw]
       lapack:: [openblas]
+  intel-oneapi-runtime:
+    buildable: false
+    externals:
+    - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
+      prefix: /opt/intel/oneapi
   intel-oneapi-mpi:
     buildable: False
   intel-oneapi-mkl:


### PR DESCRIPTION
This change adds external intel-oneapi-runtime to container and Ubuntu site config. This has been tested on the container and will be tested on the ubuntu system before this is submitted.


### Systems affected

CI and developer machines.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.  **pending**
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
