### PR TITLE
release/1.9: Add NOAA cloud machines to 1.9.1, add mapl-esmf combinations explicitly to unified-dev and skylab-dev templates

### DIFF
--- a/configs/sites/tier1/noaa-aws/compilers.yaml
+++ b/configs/sites/tier1/noaa-aws/compilers.yaml
@@ -1,30 +1,48 @@
 compilers:
 - compiler:
-    spec: intel@2021.10.0
+    spec: intel@2021.5.0
     paths:
-      cc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icc
-      cxx: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icpc
-      f77: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
-      fc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+      cc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icc
+      cxx: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icpc
+      f77: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+      fc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+    flags: {}
     operating_system: rocky8
-    target: x86_64
     modules:
-    - intel/2023.2.0
+    - intel/2022.1.2
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-13.2.0/lib64'
-    flags: {}
+        PATH: '/apps/gnu/gcc-9.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-9.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-9.2.0/include'
     extra_rpaths: []
 - compiler:
-    spec: gcc@9.2.0
+    spec: gcc@13.2.0
     paths:
-      cc: /apps/gnu/gcc-9.2.0/bin/gcc
-      cxx: /apps/gnu/gcc-9.2.0/bin/g++
-      f77: /apps/gnu/gcc-9.2.0/bin/gfortran
-      fc: /apps/gnu/gcc-9.2.0/bin/gfortran
+      cc: /apps/gnu/gcc-13.2.0/bin/gcc
+      cxx: /apps/gnu/gcc-13.2.0/bin/g++
+      f77: /apps/gnu/gcc-13.2.0/bin/gfortran
+      fc:  /apps/gnu/gcc-13.2.0/bin/gfortran
     flags: {}
     operating_system: rocky8
     modules:
-    - gnu/9.2.0
+    - gnu/13.2.0
     environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2024.2.1
+    paths:
+      cc: /apps/oneapi/compiler/2024.2/bin/icx
+      cxx: /apps/oneapi/compiler/2024.2/bin/icpx
+      f77: /apps/oneapi/compiler/2024.2/bin/ifort
+      fc: /apps/oneapi/compiler/2024.2/bin/ifort
+    flags: {}
+    operating_system: rocky8
+    modules:
+    - intel/2024.2.1
+    environment:
+      prepend_path:
+        PATH: '/apps/gnu/gcc-13.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-13.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-13.2.0/include'
     extra_rpaths: []

--- a/configs/sites/tier1/noaa-aws/packages.yaml
+++ b/configs/sites/tier1/noaa-aws/packages.yaml
@@ -49,7 +49,7 @@ packages:
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.21
+    - spec: groff@1.22.3
       prefix: /usr
   hwloc:
     externals:
@@ -112,5 +112,3 @@ packages:
     externals:
     - spec: zip@3.0
       prefix: /usr
-  zlib:
-     require: [~shared]

--- a/configs/sites/tier1/noaa-aws/packages_gcc.yaml
+++ b/configs/sites/tier1/noaa-aws/packages_gcc.yaml
@@ -1,13 +1,13 @@
 packages:
   all:
-    compiler:: [gcc@9.2.0]
+    compiler:: [gcc@13.2.0]
     providers:
-      mpi:: [openmpi@3.1.4]
+      mpi:: [openmpi@4.1.6]
   mpi:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0
-      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
+    - spec: openmpi@4.1.6~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java+legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm
       modules:
-      - openmpi/3.1.4
+      - gnu/13.2.0
+      - openmpi/4.1.6

--- a/configs/sites/tier1/noaa-aws/packages_oneapi.yaml
+++ b/configs/sites/tier1/noaa-aws/packages_oneapi.yaml
@@ -1,0 +1,43 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.1]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.13]
+      # Remove the next three lines to switch to intel-oneapi-mkl
+      blas:: [openblas]
+      fftw-api:: [fftw]
+      lapack:: [openblas]
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
+      modules:
+      - intel/2024.2.1
+      - impi/2024.2.1
+      prefix: /apps/oneapi
+  intel-oneapi-mkl:
+    # Remove buildable: False and uncomment externals section below to use intel-oneapi-mkl
+    buildable: False
+    #externals:
+    #- spec: intel-oneapi-mkl@2022.0.2%intel@2021.5.0
+    #  prefix: /apps/oneapi
+  # DH* Remove this section to switch to intel-oneapi-mkl
+  ectrans:
+    require::
+    - '@1.2.0 ~mkl +fftw'
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'
+  # *DH
+  zlib-ng:
+    require:
+      - '~shared'
+  cdo:
+    require:
+      - '@2.3.0'

--- a/configs/sites/tier1/noaa-azure/compilers.yaml
+++ b/configs/sites/tier1/noaa-azure/compilers.yaml
@@ -1,30 +1,48 @@
 compilers:
 - compiler:
-    spec: intel@2021.10.0
+    spec: intel@2021.5.0
     paths:
-      cc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icc
-      cxx: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icpc
-      f77: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
-      fc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+      cc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icc
+      cxx: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icpc
+      f77: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+      fc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+    flags: {}
     operating_system: rocky8
-    target: x86_64
     modules:
-    - intel/2023.2.0
+    - intel/2022.1.2
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-13.2.0/lib64'
-    flags: {}
+        PATH: '/apps/gnu/gcc-9.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-9.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-9.2.0/include'
     extra_rpaths: []
 - compiler:
-    spec: gcc@9.2.0
+    spec: gcc@13.2.0
     paths:
-      cc: /apps/gnu/gcc-9.2.0/bin/gcc
-      cxx: /apps/gnu/gcc-9.2.0/bin/g++
-      f77: /apps/gnu/gcc-9.2.0/bin/gfortran
-      fc: /apps/gnu/gcc-9.2.0/bin/gfortran
+      cc: /apps/gnu/gcc-13.2.0/bin/gcc
+      cxx: /apps/gnu/gcc-13.2.0/bin/g++
+      f77: /apps/gnu/gcc-13.2.0/bin/gfortran
+      fc:  /apps/gnu/gcc-13.2.0/bin/gfortran
     flags: {}
     operating_system: rocky8
     modules:
-    - gnu/9.2.0
+    - gnu/13.2.0
     environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2024.2.1
+    paths:
+      cc: /apps/oneapi/compiler/2024.2/bin/icx
+      cxx: /apps/oneapi/compiler/2024.2/bin/icpx
+      f77: /apps/oneapi/compiler/2024.2/bin/ifort
+      fc: /apps/oneapi/compiler/2024.2/bin/ifort
+    flags: {}
+    operating_system: rocky8
+    modules:
+    - intel/2024.2.1
+    environment:
+      prepend_path:
+        PATH: '/apps/gnu/gcc-13.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-13.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-13.2.0/include'
     extra_rpaths: []

--- a/configs/sites/tier1/noaa-azure/packages.yaml
+++ b/configs/sites/tier1/noaa-azure/packages.yaml
@@ -108,5 +108,3 @@ packages:
     externals:
     - spec: zip@3.0
       prefix: /usr
-  zlib:
-     require: [~shared]

--- a/configs/sites/tier1/noaa-azure/packages_gcc.yaml
+++ b/configs/sites/tier1/noaa-azure/packages_gcc.yaml
@@ -1,13 +1,13 @@
 packages:
   all:
-    compiler:: [gcc@9.2.0]
+    compiler:: [gcc@13.2.0]
     providers:
-      mpi:: [openmpi@3.1.4]
+      mpi:: [openmpi@4.1.6]
   mpi:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0
-      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
+    - spec: openmpi@4.1.6~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java+legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm
       modules:
-      - openmpi/3.1.4
+      - gnu/13.2.0
+      - openmpi/4.1.6

--- a/configs/sites/tier1/noaa-azure/packages_oneapi.yaml
+++ b/configs/sites/tier1/noaa-azure/packages_oneapi.yaml
@@ -1,0 +1,43 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.1]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.13]
+      # Remove the next three lines to switch to intel-oneapi-mkl
+      blas:: [openblas]
+      fftw-api:: [fftw]
+      lapack:: [openblas]
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
+      modules:
+      - intel/2024.2.1
+      - impi/2024.2.1
+      prefix: /apps/oneapi
+  intel-oneapi-mkl:
+    # Remove buildable: False and uncomment externals section below to use intel-oneapi-mkl
+    buildable: False
+    #externals:
+    #- spec: intel-oneapi-mkl@2022.0.2%intel@2021.5.0
+    #  prefix: /apps/oneapi
+  # DH* Remove this section to switch to intel-oneapi-mkl
+  ectrans:
+    require::
+    - '@1.2.0 ~mkl +fftw'
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'
+  # *DH
+  zlib-ng:
+    require:
+      - '~shared'
+  cdo:
+    require:
+      - '@2.3.0'

--- a/configs/sites/tier1/noaa-gcloud/compilers.yaml
+++ b/configs/sites/tier1/noaa-gcloud/compilers.yaml
@@ -1,30 +1,48 @@
 compilers:
 - compiler:
-    spec: intel@2021.10.0
+    spec: intel@2021.5.0
     paths:
-      cc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icc
-      cxx: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/icpc
-      f77: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
-      fc: /apps/oneapi/compiler/2023.2.0/linux/bin/intel64/ifort
+      cc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icc
+      cxx: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/icpc
+      f77: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+      fc: /apps/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
+    flags: {}
     operating_system: rocky8
-    target: x86_64
     modules:
-    - intel/2023.2.0
+    - intel/2022.1.2
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: '/apps/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-13.2.0/lib64'
-    flags: {}
+        PATH: '/apps/gnu/gcc-9.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-9.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-9.2.0/include'
     extra_rpaths: []
 - compiler:
-    spec: gcc@9.2.0
+    spec: gcc@13.2.0
     paths:
-      cc: /apps/gnu/gcc-9.2.0/bin/gcc
-      cxx: /apps/gnu/gcc-9.2.0/bin/g++
-      f77: /apps/gnu/gcc-9.2.0/bin/gfortran
-      fc: /apps/gnu/gcc-9.2.0/bin/gfortran
+      cc: /apps/gnu/gcc-13.2.0/bin/gcc
+      cxx: /apps/gnu/gcc-13.2.0/bin/g++
+      f77: /apps/gnu/gcc-13.2.0/bin/gfortran
+      fc:  /apps/gnu/gcc-13.2.0/bin/gfortran
     flags: {}
     operating_system: rocky8
     modules:
-    - gnu/9.2.0
+    - gnu/13.2.0
     environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2024.2.1
+    paths:
+      cc: /apps/oneapi/compiler/2024.2/bin/icx
+      cxx: /apps/oneapi/compiler/2024.2/bin/icpx
+      f77: /apps/oneapi/compiler/2024.2/bin/ifort
+      fc: /apps/oneapi/compiler/2024.2/bin/ifort
+    flags: {}
+    operating_system: rocky8
+    modules:
+    - intel/2024.2.1
+    environment:
+      prepend_path:
+        PATH: '/apps/gnu/gcc-13.2.0/bin'
+        LD_LIBRARY_PATH: '/apps/gnu/gcc-13.2.0/lib64'
+        CPATH: '/apps/gnu/gcc-13.2.0/include'
     extra_rpaths: []

--- a/configs/sites/tier1/noaa-gcloud/packages.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages.yaml
@@ -108,5 +108,3 @@ packages:
     externals:
     - spec: zip@3.0
       prefix: /usr
-  zlib:
-     require: [~shared]

--- a/configs/sites/tier1/noaa-gcloud/packages_gcc.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages_gcc.yaml
@@ -1,13 +1,13 @@
 packages:
   all:
-    compiler:: [gcc@9.2.0]
+    compiler:: [gcc@13.2.0]
     providers:
-      mpi:: [openmpi@3.1.4]
+      mpi:: [openmpi@4.1.6]
   mpi:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@3.1.4%gcc@9.2.0
-      prefix: /apps/openmpi/3.1.4/gnu/gcc-9.2.0
+    - spec: openmpi@4.1.6~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java+legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm
       modules:
-      - openmpi/3.1.4
+      - gnu/13.2.0
+      - openmpi/4.1.6

--- a/configs/sites/tier1/noaa-gcloud/packages_oneapi.yaml
+++ b/configs/sites/tier1/noaa-gcloud/packages_oneapi.yaml
@@ -1,0 +1,43 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.1]
+    providers:
+      mpi:: [intel-oneapi-mpi@2021.13]
+      # Remove the next three lines to switch to intel-oneapi-mkl
+      blas:: [openblas]
+      fftw-api:: [fftw]
+      lapack:: [openblas]
+  mpi:
+    buildable: False
+  intel-oneapi-mpi:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
+      modules:
+      - intel/2024.2.1
+      - impi/2024.2.1
+      prefix: /apps/oneapi
+  intel-oneapi-mkl:
+    # Remove buildable: False and uncomment externals section below to use intel-oneapi-mkl
+    buildable: False
+    #externals:
+    #- spec: intel-oneapi-mkl@2022.0.2%intel@2021.5.0
+    #  prefix: /apps/oneapi
+  # DH* Remove this section to switch to intel-oneapi-mkl
+  ectrans:
+    require::
+    - '@1.2.0 ~mkl +fftw'
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'
+  # *DH
+  zlib-ng:
+    require:
+      - '~shared'
+  cdo:
+    require:
+      - '@2.3.0'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -26,6 +26,10 @@ spack:
     - crtm@v2.4.1-jedi
     - crtm@3.1.1-build1
 
+    # Mapl with various esmf tags
+    - mapl@2.53.0 ^esmf@8.6.1
+    - mapl@2.53.0 ^esmf@8.8.0
+
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -35,7 +35,7 @@ spack:
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1
     - mapl@2.53.0 ^esmf@8.8.0
-    
+
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -24,14 +24,18 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.6.1 ^crtm@=3.1.1-build1
-    - ufs-weather-model-env ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.1-build1
+    - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.1-build1
 
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
     - crtm@3.1.1-build1
 
+    # Mapl with various esmf tags
+    - mapl@2.53.0 ^esmf@8.6.1
+    - mapl@2.53.0 ^esmf@8.8.0
+    
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none


### PR DESCRIPTION
### Summary

Added NOAA-Cloud machines to spack-stack@1.9.1
Also added mapl@2.53.0 ^esmf@8.8.0 (will remove develop PR #1530 for this)
Zlib changes will go in separate PR.

### Testing

Installed 1.9.1 on NOAA cloud machines.

### Applications affected

UFS WM, SRW

### Systems affected

All

### Dependencies

None

### Issue(s) addressed

Working toward issue #1485 
Closes #1529 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
