### PR TITLE
release/1.9.0: Update utl/nrl/batch_install.sh: allow duplicates for crtm-fix and mapl

### DIFF
--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -288,7 +288,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     fi
 
     # Check for duplicate packages
-    ./util/show_duplicate_packages.py -i crtm -i esmf -d log.concretize.${env_name}.001
+    ./util/show_duplicate_packages.py -i crtm -i crtm-fix -i esmf -i mapl -d log.concretize.${env_name}.001
 
     # In developer mode, update local source cache
     if [[ "${create_buildcache}" == "true"* ]]; then


### PR DESCRIPTION
### Summary

We need to allow duplicate versions of `mapl` and `crtm-fix` in the NRL batch install script due to the recent (and somewhat less recent) changes in release/1.9.0.

### Testing

Tested on NRL machines (CI testing isn't useful here, since this script isn't run in CI)

### Applications affected

None

### Systems affected

NRL systems

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
