### PR TITLE
Bump ip from 5.1.0 to 5.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/ip530
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/ip530
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -139,7 +139,7 @@ packages:
   hdf-eos2:
     require: '@2.20v1.00'
   ip:
-    require: '@5.1.0 precision=4,d,8'
+    require: '@5.3.0 precision=4,d,8'
   ip2:
     require: '@1.1.2'
   jasper:

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -24,7 +24,7 @@
     gsibec@1.2.1,
     hdf@4.2.15,
     hdf5@1.14.3,
-    ip@5.1.0,
+    ip@5.3.0,
     jasper@2.0.32,
     jedi-cmake@1.4.0,
     libpng@1.6.37,


### PR DESCRIPTION
### Summary

For develop, bump ip from 5.1.0 to 5.3.0. Requires a submodule pointer update for the changes in https://github.com/JCSDA/spack/pull/525

### Testing

- [x] CI
- [x] Local test with downstream neptune cmake build to verify that OpenMP and LAPACK dependencies are not creeping in as they did previously

### Applications affected

UFS, SCM, NEPTUNE

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/525

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1550

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
