### PR TITLE
Update Blueback packages.yaml: remove external flex

### DIFF
--- a/configs/sites/tier1/blueback/packages.yaml
+++ b/configs/sites/tier1/blueback/packages.yaml
@@ -42,10 +42,6 @@ packages:
     externals:
     - spec: findutils@4.8.0
       prefix: /usr
-  flex:
-    externals:
-    - spec: flex@2.6.4+lex
-      prefix: /usr
   gawk:
     externals:
     - spec: gawk@4.2.1


### PR DESCRIPTION
### Summary

Update Blueback packages.yaml: remove external flex to avoid duplicate packages (found when building the unified environment).

### Testing

- [x] Built unified environment with oneAPI compilers on Blueback

### Applications affected

None

### Systems affected

Blueback

### Dependencies

None

### Issue(s) addressed

None created (trivial)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications. **IN PROGRESS**
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
