### PR TITLE
require +python for esmf

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -71,14 +71,13 @@ packages:
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"
+    - '+python'
     #- any_of: ['']
     #  when: "%gcc"
     #  message: "Extra ESMF compile options for GCC"
     #- any_of: ['']
     #  when: "%apple-clang"
     #  message: "Extra ESMF compile options for GCC"
-    prefer:
-    - '+python'
   # To avoid duplicate packages (concretizer bug?)
   expat:
     require:


### PR DESCRIPTION
### Summary

This PR changes the +python setting from a 'prefer' to a 'require' in common/packages.yaml (discussed in https://github.com/JCSDA/spack-stack/issues/1485)

### Testing

Tested on Acorn

### Applications affected

Most/all

### Systems affected

All

### Dependencies

none

### Issue(s) addressed

none

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
