### PR TITLE
weekly builds: add option to skip source fetch

### DIFF
--- a/util/weekly_build/04_SpackInstall.sh
+++ b/util/weekly_build/04_SpackInstall.sh
@@ -31,9 +31,11 @@ for compiler in $COMPILERS; do
       mirrorpath=$(spack mirror list | awk "{if (\$1==\"$SOURCE_CACHE\") print \$NF}")
     fi
     mirrorpath=${mirrorpath#file://}
-    spack_wrapper log.fetch mirror create --dependencies \
+    if [ "$SKIP_FETCH" != YES ]; then
+      spack_wrapper log.fetch mirror create --dependencies \
         --directory ${mirrorpath?"Source mirror path could not be determined. Check site's mirrors.yaml."} \
         ${PACKAGES_TO_INSTALL:---all}
+    fi
     # Just install the packages we're testing (+dependencies):
     if [[ ! -z "${PACKAGES_TO_TEST}" ]]; then
       spack_install_wrapper log.install-and-test install $INSTALL_OPTS --test root $PACKAGES_TO_TEST

--- a/util/weekly_build/sites/acorn.sh
+++ b/util/weekly_build/sites/acorn.sh
@@ -4,12 +4,18 @@ TEMPLATES=${TEMPLATES:-"unified-dev"}
 function spack_install_wrapper {
   logfile=$1
   shift 2
+  spack fetch --missing ${PACKAGES_TO_INSTALL} &> log.fetch
   if [[ " $* " =~ " global-workflow-env " ]]; then
     spack config add "config:build_stage:${SPACK_ENV:?}/stage"
     spack install $INSTALL_OPTS gh
   fi
   spack config add 'config:build_stage:$tempdir/$user/spack-stage'
-  /opt/pbs/bin/qsub -N spack-build-cache-$RUNID-A -j oe -A NCEPLIBS-DEV -l "select=1:ncpus=12:mem=20GB,walltime=05:00:00" -q dev -V -Wblock=true -- ${SPACK_STACK_DIR}/util/parallel_install.sh 2 6 $*
+  if [[ " $* " =~ "-env " ]]; then # for the "real" install step
+    walltime=03:30:00
+  else # when running test step
+    walltime=01:00:00
+  fi
+  /opt/pbs/bin/qsub -N spack-build-cache-$RUNID -j oe -A NCEPLIBS-DEV -l "select=1:ncpus=12:mem=24GB,walltime=$walltime" -q dev -V -Wblock=true -- ${SPACK_STACK_DIR}/util/parallel_install.sh 2 6 $*
   return $?
 }
 function alert_cmd {
@@ -22,3 +28,4 @@ PADDED_LENGTH=140
 TEST_UFSWM=OFF
 BATCHACCOUNT=NCEPLIBS-DEV
 FIND_CMD="find"
+SKIP_FETCH=YES


### PR DESCRIPTION
### Summary

This PR adds the option to skip source fetching with `spack mirror create`, and on Acorn uses `spack fetch` inside spack_install_wrapper() instead. Defaults to current behavior.

### Testing

Tested on Acorn

### Applications affected

weekly builds

### Systems affected

Acorn (others will keep current behavior)

### Dependencies

none

### Issue(s) addressed

Related to #1574

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
