### PR TITLE
Gaea updates for 1.9.1 release

### DIFF
--- a/configs/sites/tier1/gaea-c5/compilers.yaml
+++ b/configs/sites/tier1/gaea-c5/compilers.yaml
@@ -1,38 +1,44 @@
 compilers:
 - compiler:
-    spec: intel@2023.1.0
+    spec: intel@2023.2.0
     paths:
       cc: cc
       cxx: CC
       f77: ftn
       fc: ftn
-    flags: {}
+    flags:
+      cflags: "-gcc-name=/usr/bin/gcc-12"
+      cxxflags: "-gxx-name=/usr/bin/g++-12 -gcc-name=/usr/bin/gcc-12 -static-libstdc++"
+      fflags: "-gcc-name=/usr/bin/gcc-12"
     operating_system: sles15
     modules:
-    - PrgEnv-intel/8.3.3
-    - intel-classic/2023.1.0
-    - craype/2.7.20
+    - PrgEnv-intel/8.5.0
+    - intel-classic/2023.2.0
+    - craype/2.7.30
+    - libfabric/1.20.1
     environment:
       prepend_path:
-        PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
-        CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
-        LD_LIBRARY_PATH: '/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib:/usr/lib64/gcc/x86_64-suse-linux/12'
       set:
+        #CRAYPE_LINK_TYPE: 'dynamic'
         # OpenSUSE on Gaea C5 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
         # which confuses some packages.
         CONFIG_SITE: ''
     extra_rpaths: []
 - compiler:
-    spec: gcc@12.2.0
+    spec: gcc@12.3.0
     paths:
-      cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
-      cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
-      f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-      fc:  /opt/cray/pe/gcc/12.2.0/bin/gfortran
+      cc: /usr/bin/gcc-12
+      cxx: /usr/bin/g++-12
+      f77: /usr/bin/gfortran-12
+      fc:  /usr/bin/gfortran-12
     flags: {}
     operating_system: sles15
     modules:
-    - gcc/12.2.0
+    - PrgEnv-gnu/8.5.0
+    - gcc-native/12.3
+    - craype/2.7.30
+    - libfabric/1.20.1 
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/gaea-c5/compilers.yaml
+++ b/configs/sites/tier1/gaea-c5/compilers.yaml
@@ -20,7 +20,6 @@ compilers:
       prepend_path:
         LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib:/usr/lib64/gcc/x86_64-suse-linux/12'
       set:
-        #CRAYPE_LINK_TYPE: 'dynamic'
         # OpenSUSE on Gaea C5 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
         # which confuses some packages.

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -26,7 +26,7 @@ packages:
       prefix: /usr
   binutils:
     externals:
-    - spec: binutils@2.41-150100.7.46.1
+    - spec: binutils@2.43-150100.7.49.1
       prefix: /usr
   cmake:
     buildable: false

--- a/configs/sites/tier1/gaea-c5/packages.yaml
+++ b/configs/sites/tier1/gaea-c5/packages.yaml
@@ -1,44 +1,17 @@
 packages:
+  # For addressing https://github.com/JCSDA/spack-stack/issues/1355
+  #   Use system zlib instead of spack-built zlib-ng
   all:
-    compiler:: [intel@2023.1.0] # todo: add gcc here
     providers:
-      mpi:: [cray-mpich@8.1.25]
-      # Remove the next three lines to switch to intel-oneapi-mkl
-      blas:: [openblas]
-      fftw-api:: [fftw]
-      lapack:: [openblas]
-
-### MPI, Python, MKL
-  mpi:
+      zlib-api:: [zlib]
+  zlib-api:
     buildable: False
-  cray-mpich:
+  zlib:
+    buildable: False
     externals:
-    - spec: cray-mpich@8.1.25%intel@2023.1.0~wrappers
-      prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
-      modules:
-      - craype-network-ofi
-      - cray-mpich/8.1.25
-  intel-oneapi-mkl:
-    # Remove buildable: False and configure+uncomment externals section below to use intel-oneapi-mkl
-    buildable: False
-    #externals:
-    #- spec: intel-oneapi-mkl@2022.0.2%intel@2023.1.0
-    #  prefix: /apps/oneapi
+    - spec: zlib@1.2.13
+      prefix: /usr
 
-### Modification of common packages
-  # DH* Remove this section to switch to intel-oneapi-mkl
-  ectrans:
-    require::
-    - '@1.2.0 ~mkl +fftw'
-  gsibec:
-    require::
-    - '@1.2.1 ~mkl'
-  py-numpy:
-    require::
-    - '^openblas'
-  # *DH
-
-### All other external packages listed alphabetically
   autoconf:
     externals:
     - spec: autoconf@2.69
@@ -53,33 +26,24 @@ packages:
       prefix: /usr
   binutils:
     externals:
-    - spec: binutils@2.37.20211103
+    - spec: binutils@2.41-150100.7.46.1
       prefix: /usr
-  # Don't use, it's missing the headers
-  #bzip2:
-  #  externals:
-  #  - spec: bzip2@1.0.6
-  #    prefix: /usr
   cmake:
     buildable: false
     externals:
-    - spec: cmake@3.23.1
-      modules: [cmake/3.23.1]
+    - spec: cmake@3.27.9
+      modules: [cmake/3.27.9]
   coreutils:
     externals:
     - spec: coreutils@8.32
       prefix: /usr
   cpio:
     externals:
-    - spec: cpio@2.12
+    - spec: cpio@2.13
       prefix: /usr
   diffutils:
     externals:
     - spec: diffutils@3.6
-      prefix: /usr
-  dos2unix:
-    externals:
-    - spec: dos2unix@7.4.0
       prefix: /usr
   file:
     externals:
@@ -108,8 +72,8 @@ packages:
   git:
     buildable: false
     externals:
-    - spec: git@2.35.2
-      modules: [git/2.35.2]
+    - spec: git@2.42.0
+      modules: [git/2.42.0]
   git-lfs:
     buildable: false
     externals:
@@ -125,7 +89,7 @@ packages:
       prefix: /usr
   groff:
     externals:
-    - spec: groff@1.22.3
+    - spec: groff@1.22.4
       prefix: /usr
   hwloc:
     externals:
@@ -134,14 +98,11 @@ packages:
   # This package is currently incomplete (no headers), but still works
   krb5:
     externals:
-    - spec: krb5@1.16.3
-      #prefix: /usr/lib/mit
+    - spec: krb5@1.20.1
       prefix: /usr
   libfuse:
     externals:
     - spec: libfuse@2.9.7
-      prefix: /usr
-    - spec: libfuse@3.6.1
       prefix: /usr
   libtirpc:
     variants: ~gssapi
@@ -154,13 +115,6 @@ packages:
     externals:
     - spec: libxml2@2.9.7
       prefix: /usr
-  # This package is currently incomplete (no headers) and doesn't work
-  # for us. But it's only needed to build libxaw, for which we can use
-  # the existing (incomplete) installation in /usr, see above
-  #libxpm:
-  #  externals:
-  #  - spec: libxpm@4.11.0
-  #    prefix: /usr
   lustre:
     externals:
     - spec: lustre@2.15.0.2_rc2_cray_113_g62287d0
@@ -172,9 +126,9 @@ packages:
   mysql:
     buildable: False
     externals:
-    - spec: mysql@8.0.31
-      prefix: /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/mysql-8.0.31
-      modules: [mysql/8.0.31]
+    - spec: mysql@8.0.36
+      prefix: /ncrc/proj/epic/spack-stack/mysql-8.0.36
+      modules: [mysql/8.0.36]
   ncurses:
     externals:
     - spec: ncurses@6.1.20180317+termlib abi=6
@@ -196,13 +150,14 @@ packages:
     externals:
     - spec: qt@5.15.2
       prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
+      modules: [qt/5.15.2]
   rdma-core:
     externals:
     - spec: rdma-core@37.0
       prefix: /usr
   rsync:
     externals:
-    - spec: rsync@3.1.3
+    - spec: rsync@3.2.3
       prefix: /usr
   ruby:
     externals:
@@ -212,21 +167,9 @@ packages:
     externals:
     - spec: sed@4.4
       prefix: /usr
-  slurm:
-    externals:
-    - spec: slurm@21.08.8
-      prefix: /usr
-  subversion:
-    externals:
-    - spec: subversion@1.10.6
-      prefix: /usr
   tar:
     externals:
     - spec: tar@1.34
-      prefix: /usr
-  texinfo:
-    externals:
-    - spec: texinfo@6.5
       prefix: /usr
   wget:
     externals:

--- a/configs/sites/tier1/gaea-c5/packages_intel.yaml
+++ b/configs/sites/tier1/gaea-c5/packages_intel.yaml
@@ -1,0 +1,37 @@
+packages:
+  all:
+    compiler:: [intel@2023.2.0]
+    providers:
+      mpi:: [cray-mpich@8.1.30]
+      # Remove the next three lines to switch to intel-oneapi-mkl
+      blas:: [openblas]
+      fftw-api:: [fftw]
+      lapack:: [openblas]
+
+### MPI, Python, MKL
+  mpi:
+    buildable: False
+  cray-mpich:
+    externals:
+    - spec: cray-mpich@8.1.30%intel@2023.2.0~wrappers
+      prefix: /opt/cray/pe/mpich/8.1.30/ofi/intel/2022.1
+      modules:
+      - craype-network-ofi
+      - cray-mpich/8.1.30
+  intel-oneapi-mkl:
+    buildable: False
+
+### Modification of common packages
+  bison:
+    require:
+    - '%gcc'
+  ectrans:
+    require::
+    - '@1.2.0 ~mkl +fftw'
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'

--- a/configs/sites/tier1/gaea-c6/compilers.yaml
+++ b/configs/sites/tier1/gaea-c6/compilers.yaml
@@ -20,7 +20,7 @@ compilers:
       prepend_path:
         LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib:/usr/lib64/gcc/x86_64-suse-linux/12'
       set:
-        # OpenSUSE on Gaea C5 sets CONFIG_SITE so
+        # OpenSUSE on Gaea C6 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
         # which confuses some packages.
         CONFIG_SITE: ''

--- a/configs/sites/tier1/gaea-c6/compilers.yaml
+++ b/configs/sites/tier1/gaea-c6/compilers.yaml
@@ -20,7 +20,6 @@ compilers:
       prepend_path:
         LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib:/usr/lib64/gcc/x86_64-suse-linux/12'
       set:
-        #CRAYPE_LINK_TYPE: 'dynamic'
         # OpenSUSE on Gaea C5 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
         # which confuses some packages.

--- a/configs/sites/tier1/gaea-c6/compilers.yaml
+++ b/configs/sites/tier1/gaea-c6/compilers.yaml
@@ -6,19 +6,22 @@ compilers:
       cxx: CC
       f77: ftn
       fc: ftn
+    flags:
+      cflags: "-gcc-name=/usr/bin/gcc-12"
+      cxxflags: "-gxx-name=/usr/bin/g++-12 -gcc-name=/usr/bin/gcc-12 -static-libstdc++"
+      fflags: "-gcc-name=/usr/bin/gcc-12"
     operating_system: sles15
     modules:
     - PrgEnv-intel/8.5.0
     - intel-classic/2023.2.0
     - craype/2.7.30
     - libfabric/1.20.1
-    flags:
-      cflags: "-gcc-name=/usr/bin/gcc-12"
-      cxxflags: "-gxx-name=/usr/bin/g++-12 -gcc-name=/usr/bin/gcc-12 -static-libstdc++"
-      fflags: "-gcc-name=/usr/bin/gcc-12"
     environment:
+      prepend_path:
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib:/usr/lib64/gcc/x86_64-suse-linux/12'
       set:
-        # OpenSUSE on Gaea C6 sets CONFIG_SITE so
+        #CRAYPE_LINK_TYPE: 'dynamic'
+        # OpenSUSE on Gaea C5 sets CONFIG_SITE so
         # Automake-based builds are installed in lib64
         # which confuses some packages.
         CONFIG_SITE: ''
@@ -33,6 +36,9 @@ compilers:
     flags: {}
     operating_system: sles15
     modules:
-    - gcc-native-mixed/12.3
+    - PrgEnv-gnu/8.5.0
+    - gcc-native/12.3
+    - craype/2.7.30
+    - libfabric/1.20.1 
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -106,6 +106,7 @@ packages:
       prefix: /usr
   libtirpc:
     variants: ~gssapi
+  # This package is currently incomplete (no headers), but still works
   libxaw:
     externals:
     - spec: libxaw@1.10.13
@@ -149,6 +150,7 @@ packages:
     externals:
     - spec: qt@5.15.2
       prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
+      modules: [qt/5.15.2]
   rdma-core:
     externals:
     - spec: rdma-core@37.0

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -127,7 +127,7 @@ packages:
     buildable: False
     externals:
     - spec: mysql@8.0.36
-      prefix: /ncrc/proj/epic/spack-stack/mysql-8.0.36
+      prefix: /ncrc/proj/epic/spack-stack/c6/installs/mysql/8.0.36
       modules: [mysql/8.0.36]
   ncurses:
     externals:
@@ -147,10 +147,11 @@ packages:
     - spec: pkg-config@0.29.2
       prefix: /usr
   qt:
+    buildable: False
     externals:
-    - spec: qt@5.15.2
-      prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
-      modules: [qt/5.15.2]
+    - spec: qt@5.12.6
+      prefix: /ncrc/proj/epic/spack-stack/c6/installs/qt5/qt-5.12.6/qtbase
+      modules: [qt/5.12.6]
   rdma-core:
     externals:
     - spec: rdma-core@37.0

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -1,43 +1,17 @@
 packages:
+  # For addressing https://github.com/JCSDA/spack-stack/issues/1355
+  #   Use system zlib instead of spack-built zlib-ng
   all:
-    compiler:: [intel@2023.2.0] # todo: add gcc here
     providers:
-      mpi:: [cray-mpich@8.1.29]
-      # Remove the next three lines to switch to intel-oneapi-mkl
-      blas:: [openblas]
-      fftw-api:: [fftw]
-      lapack:: [openblas]
-
-### MPI, Python, MKL
-  mpi:
+      zlib-api:: [zlib]
+  zlib-api:
     buildable: False
-  cray-mpich:
+  zlib:
+    buildable: False
     externals:
-    - spec: cray-mpich@8.1.29%intel@2023.2.0~wrappers
-      modules:
-      - craype-network-ofi
-      - cray-mpich/8.1.29
-  intel-oneapi-mkl:
-    # Remove buildable: False and configure+uncomment externals section below to use intel-oneapi-mkl
-    buildable: False
-    #externals:
-    #- spec: intel-oneapi-mkl@2022.0.2%intel@2023.2.0
-    #  prefix: /apps/oneapi
+    - spec: zlib@1.2.13
+      prefix: /usr
 
-### Modification of common packages
-  # DH* Remove this section to switch to intel-oneapi-mkl
-  ectrans:
-    require::
-    - '@1.2.0 ~mkl +fftw'
-  gsibec:
-    require::
-    - '@1.2.1 ~mkl'
-  py-numpy:
-    require::
-    - '^openblas'
-  # *DH
-
-### All other external packages listed alphabetically
   autoconf:
     externals:
     - spec: autoconf@2.69
@@ -52,8 +26,13 @@ packages:
       prefix: /usr
   binutils:
     externals:
-    - spec: binutils@2.41
+    - spec: binutils@2.41-150100.7.46.1
       prefix: /usr
+  cmake:
+    buildable: false
+    externals:
+    - spec: cmake@3.27.9
+      modules: [cmake/3.27.9]
   coreutils:
     externals:
     - spec: coreutils@8.32
@@ -65,10 +44,6 @@ packages:
   diffutils:
     externals:
     - spec: diffutils@3.6
-      prefix: /usr
-  dos2unix:
-    externals:
-    - spec: dos2unix@7.4.0
       prefix: /usr
   file:
     externals:
@@ -118,38 +93,27 @@ packages:
       prefix: /usr
   hwloc:
     externals:
-    - spec: hwloc@2.9.0
+    - spec: hwloc@2.6.0a1
       prefix: /usr
   # This package is currently incomplete (no headers), but still works
   krb5:
     externals:
     - spec: krb5@1.20.1
-      #prefix: /usr/lib/mit
       prefix: /usr
   libfuse:
     externals:
     - spec: libfuse@2.9.7
       prefix: /usr
-    - spec: libfuse@3.10.5
-      prefix: /usr
   libtirpc:
     variants: ~gssapi
-  # This package is currently incomplete (no headers), but still works
   libxaw:
     externals:
     - spec: libxaw@1.10.13
       prefix: /usr
   libxml2:
     externals:
-    - spec: libxml2@2.10.3
+    - spec: libxml2@2.9.7
       prefix: /usr
-  # This package is currently incomplete (no headers) and doesn't work
-  # for us. But it's only needed to build libxaw, for which we can use
-  # the existing (incomplete) installation in /usr, see above
-  #libxpm:
-  #  externals:
-  #  - spec: libxpm@4.11.0
-  #    prefix: /usr
   lustre:
     externals:
     - spec: lustre@2.15.0.2_rc2_cray_113_g62287d0
@@ -162,14 +126,15 @@ packages:
     buildable: False
     externals:
     - spec: mysql@8.0.36
-      prefix: /autofs/ncrc-svm1_proj/epic/spack-stack/mysql-8.0.36
+      prefix: /ncrc/proj/epic/spack-stack/mysql-8.0.36
+      modules: [mysql/8.0.36]
   ncurses:
     externals:
     - spec: ncurses@6.1.20180317+termlib abi=6
       prefix: /usr
   openjdk:
     externals:
-    - spec: openjdk@11.0.22
+    - spec: openjdk@11.0.16_8-suse-150000.3.83.1-x8664
       prefix: /usr
   perl:
     externals:
@@ -186,7 +151,7 @@ packages:
       prefix: /ncrc/proj/epic/spack-stack/qt-5.15.2/5.15.2/gcc_64
   rdma-core:
     externals:
-    - spec: rdma-core@42.0
+    - spec: rdma-core@37.0
       prefix: /usr
   rsync:
     externals:
@@ -199,14 +164,6 @@ packages:
   sed:
     externals:
     - spec: sed@4.4
-      prefix: /usr
-  slurm:
-    externals:
-    - spec: slurm@24.05.0
-      prefix: /usr
-  subversion:
-    externals:
-    - spec: subversion@1.14.1
       prefix: /usr
   tar:
     externals:

--- a/configs/sites/tier1/gaea-c6/packages_intel.yaml
+++ b/configs/sites/tier1/gaea-c6/packages_intel.yaml
@@ -1,0 +1,37 @@
+packages:
+  all:
+    compiler:: [intel@2023.2.0]
+    providers:
+      mpi:: [cray-mpich@8.1.30]
+      # Remove the next three lines to switch to intel-oneapi-mkl
+      blas:: [openblas]
+      fftw-api:: [fftw]
+      lapack:: [openblas]
+
+### MPI, Python, MKL
+  mpi:
+    buildable: False
+  cray-mpich:
+    externals:
+    - spec: cray-mpich@8.1.30%intel@2023.2.0~wrappers
+      prefix: /opt/cray/pe/mpich/8.1.30/ofi/intel/2022.1
+      modules:
+      - craype-network-ofi
+      - cray-mpich/8.1.30
+  intel-oneapi-mkl:
+    buildable: False
+
+### Modification of common packages
+  bison:
+    require:
+    - '%gcc'
+  ectrans:
+    require::
+    - '@1.2.0 ~mkl +fftw'
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  py-numpy:
+    require::
+    - '@1.26'
+    - '^openblas'

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -58,7 +58,7 @@ packages:
       prefix: /usr
   flex:
     externals:
-    - sec: flex@2.6.4
+    - spec: flex@2.6.4
       prefix: /usr
   gawk:
     externals:

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -41,6 +41,13 @@ packages:
     externals:
     - spec: doxygen@1.11.0+graphviz~mscgen
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/doxygen-1.11.0-dbhxblaakcrhvmlrbgixvapnagjb2vkx
+  ecflow:
+    buildable: False
+    externals:
+    - spec: ecflow@5.11.4
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/ecflow-5.11.4-a5ggcmayx6yesbqgbacifgvkstamchoy
+      modules:
+      - ecflow/5.11.4
   file:
     externals:
     - spec: file@5.39
@@ -51,7 +58,7 @@ packages:
       prefix: /usr
   flex:
     externals:
-    - spec: flex@2.6.4
+    - sec: flex@2.6.4
       prefix: /usr
   gawk:
     externals:
@@ -106,10 +113,22 @@ packages:
     externals:
     - spec: openjdk@1.8.0.412.b08-2
       prefix: /usr
+  openssl:
+      buildable: False
+      externals:
+      - spec: openssl@3.0.7
+        prefix: /usr
   pkg-config:
     externals:
     - spec: pkg-config@1.7.3
       prefix: /usr
+  qt:
+    buildable: False
+    externals:
+    - spec: qt@5.15.14
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/qt-5.15.14-at4e3ixmq44lwb7mn2gqjcd3gbg5omjq
+      modules:
+      - qt/5.15.14
   rsync:
     externals:
     - spec: rsync@3.2.3

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -462,10 +462,9 @@ The following is required for building new spack environments with Intel on this
 .. code-block:: console
 
    # These modules should be loaded by default, if not load (swap) with:
-   module load PrgEnv-intel/8.3.3
-   module load intel-classic/2023.1.0
-   module load cray-mpich/8.1.25
-   module load python/3.9.12
+   module load PrgEnv-intel/8.5.0
+   module load intel-classic/2023.2.0
+   module load cray-mpich/8.1.30
 
 
 .. note::
@@ -490,10 +489,9 @@ The following is required for building new spack environments with Intel on this
 .. code-block:: console
 
    # These modules should be loaded by default, if not load (swap) with:
-   module load PrgEnv-intel/8.3.3
+   module load PrgEnv-intel/8.5.0
    module load intel-classic/2023.2.0
-   module load cray-mpich/8.1.25
-   module load python/3.9.12
+   module load cray-mpich/8.1.30
 
 
 .. note::


### PR DESCRIPTION
### Summary

Updates for `gaea-c5` and `gaea-c6` for `spack-stack-1.9.1`

_**NOTE**_: `oneAPI@2024.2.x` compilers not available on `gaea` hosts; stack is built with `Intel Classic compilers 2021.10.0`

### Testing

`UFS WM` regression testing passes with branch / upcoming PR for updates to `GOCART`

### Applications affected

n/a

### Systems affected

- `gaea-c5`
- `gaea-c6`

### Dependencies

None

### Issue(s) addressed

Updates #1485

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
