### PR TITLE
Update to cmake@3.29+, use gcc for cmake with intel/oneapi; update eccodes variants; add cloc and py-pytest

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -40,8 +40,9 @@ packages:
       when: '%intel@:2020'
       message: '2.0.5 is the last version to use C++14, use with Intel Classic 2020 and earlier'
   cmake:
-    version: ['3.27.9']
-    require: '+ownlibs'
+    require:
+    - '@3.29:'
+    - '+ownlibs'
   # Attention - when updating also check the various jcsda-emc-bundles env packages
   crtm:
     require: '+fix'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -49,7 +49,9 @@ packages:
   ecbuild:
     require: '@3.7.2'
   eccodes:
-    require: '@2.33.0 +png +tools'
+    require:
+    - '@2.33.0'
+    - '+netcdf +png +tools'
   ecflow:
     require:
     - '@5.11.4 +ui'

--- a/configs/common/packages_intel.yaml
+++ b/configs/common/packages_intel.yaml
@@ -4,6 +4,9 @@ packages:
       blas: [intel-oneapi-mkl]
       fftw-api: [intel-oneapi-mkl]
       lapack: [intel-oneapi-mkl]
+  cmake:
+    require:
+    - '%gcc'
   ectrans:
     require:
     - '+mkl ~fftw'

--- a/configs/common/packages_oneapi.yaml
+++ b/configs/common/packages_oneapi.yaml
@@ -4,6 +4,9 @@ packages:
       blas: [intel-oneapi-mkl]
       fftw-api: [intel-oneapi-mkl]
       lapack: [intel-oneapi-mkl]
+  cmake:
+    require:
+    - '%gcc'
   ectrans:
     require:
     - '+mkl ~fftw'

--- a/spack-ext/repos/spack-stack/packages/base-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/base-env/package.py
@@ -25,6 +25,7 @@ class BaseEnv(BundlePackage):
     depends_on("git", type="run")
     depends_on("wget", type="run")
     depends_on("curl", type="run")
+    depends_on("cloc", type="run")
 
     # I/O
     depends_on("zlib-api", type="run")

--- a/spack-ext/repos/spack-stack/packages/base-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/base-env/package.py
@@ -41,5 +41,6 @@ class BaseEnv(BundlePackage):
     depends_on("py-wheel", type="run")
     depends_on("py-setuptools", type="run")
     depends_on("py-setuptools-scm", type="run")
+    depends_on("py-pytest", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
### Summary

Several, unrelated updates [submitted in] in separate commits are bundled here:
1. Bump `cmake` to 3.29 or later, and build with `gcc` when the preferred compiler is `intel` or `oneapi`
2. Add variant `+netcdf` to `eccodes`
3. Add `py-pytest` to `base-env`
4. Add `cloc` to base-env`

### Testing

- [x] NEPTUNE standalone environment on my WSL2 dev system with `oneapi@2025.0.0`
- [ ] CI **IN PROGRESS**

### Applications affected

All

### Systems affected

None

### Dependencies

None

### Issue(s) addressed


1. Closes https://github.com/JCSDA/spack-stack/issues/1514 and closes https://github.com/JCSDA/spack-stack/issues/1585
2. Closes https://github.com/JCSDA/spack-stack/issues/1554
3. Closes https://github.com/JCSDA/spack-stack/issues/1493
4. Closes https://github.com/JCSDA/spack-stack/issues/1488

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications. **IN PROGRESS**
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
