### PR TITLE
Fix wrong intel-oneapi-runtime version in Atlantis packages_oneapi.yaml, bump bacio from 2.4.1 to 2.6.0 in JEDI CI container specs

### DIFF
--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -5,7 +5,7 @@
     ewok-env@1.0.0,
     jedi-fv3-env@1.0.0,
     jedi-mpas-env@1.0.0,
-    bacio@2.4.1,
+    bacio@2.6.0,
     bison@3.8.2,
     bufr@12.1.0,
     bufr-query@0.0.4,

--- a/configs/sites/tier1/atlantis/packages_oneapi.yaml
+++ b/configs/sites/tier1/atlantis/packages_oneapi.yaml
@@ -45,7 +45,7 @@ packages:
       - intel-oneapi-2024.2.1
       - tbb/2021.13
       - compiler-rt/2024.2.1
-    - spec: intel-oneapi-runtime@2025.0.0%oneapi@2025.0.0
+    - spec: intel-oneapi-runtime@2025.0.3%oneapi@2025.0.3
       prefix: /gpfs/neptune/spack-stack/oneapi-2025.0.3
       modules:
       - tbb/2022.0


### PR DESCRIPTION
### Summary

This PR
1. Fixes the wrong version of `intel-oneapi-runtime` in `configs/sites/tier1/packages_oneapi.yaml`. See https://github.com/JCSDA/spack-stack/issues/1594 for more information.
2. Bumps `bacio` from 2.4.1 to 2.6.0 in `configs/containers/specs/jedi-ci.yaml` to fix https://github.com/JCSDA/spack-stack/issues/1595

### Testing

- [x] Atlantis: Built NEPTUNE and unified environments, updated buildcaches, compiled NEPTUNE and verified the warning is gone
- [x] JEDI CI container: https://github.com/JCSDA/spack-stack/actions/runs/14264572119
- [x] Usual CI tests (not affected by these changes)

### Applications affected

None

### Systems affected

Atlantis, JEDI CI containers

### Dependencies

n/a

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1594
Closes https://github.com/JCSDA/spack-stack/issues/1595

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
