### PR TITLE
Update FIND command for Nautilus in util/weekly_build/sites/nautilus.sh

### DIFF
--- a/util/weekly_build/sites/nautilus.sh
+++ b/util/weekly_build/sites/nautilus.sh
@@ -17,4 +17,4 @@ umask 0022
 SPACK_STACK_URL=https://github.nrlmry.navy.mil/JCSDA/spack-stack
 SPACK_STACK_BRANCH=ci
 KEEP_WEEKLY_BUILD_DIR="YES"
-FIND_CMD="find"
+FIND_CMD="lfs find"


### PR DESCRIPTION
### Summary

All in the title. On Lustre, we should use `lfs find` instead of just `find` to avoid overloading the Lustre filesystem.

### Testing

Not needed

### Applications affected

None

### Systems affected

Nautilus

### Dependencies

None

### Issue(s) addressed

None created

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
