### PR TITLE
Remove parallel-netcdf dependency except for jedi-mpas-env/unified-dev/skylab-dev

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -51,7 +51,7 @@ jobs:
           # Set up spack-stack
           source ./setup.sh
 
-          declare -a TEMPLATES=("unified-dev" "skylab-dev" "cylc-dev")
+          declare -a TEMPLATES=("unified-dev" "skylab-dev" "cylc-dev" "neptune-dev")
           for TEMPLATE in "${TEMPLATES[@]}"; do
             if [[ "${TEMPLATE}" == *"unified-dev"* ]]; then
               export ENVNAME=ue-gcc-11.4.0-buildcache
@@ -59,6 +59,8 @@ jobs:
               export ENVNAME=se-gcc-11.4.0-buildcache
             elif [[ "${TEMPLATE}" == *"cylc-dev"* ]]; then
               export ENVNAME=ce-gcc-11.4.0-buildcache
+            elif [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
+              export ENVNAME=ne-gcc-11.4.0-buildcache
             fi
             echo "Creating environment ${ENVNAME} from template ${TEMPLATE}"
 

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -99,6 +99,11 @@ jobs:
             # Add additional variants for MET packages, different from config/common/packages.yaml
             spack config add "packages:met:variants:+python +grib2 +graphics +lidar2nc +modis"
 
+            # Turn off variant xnrl for neptune-python-env because xnrl is not publicly available
+            if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
+              sed -i 's/+xnrl/~xnrl/g' ${ENVDIR}/spack.yaml
+            fi
+
             # Concretize and check for duplicates
             spack concretize 2>&1 | tee log.concretize.gnu-11.4.0-buildcache
             ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -d log.concretize.gnu-11.4.0-buildcache -i fms -i crtm -i crtm-fix -i esmf -i mapl

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -211,7 +211,8 @@ packages:
   p4est:
     require: '@2.8.7'
   parallelio:
-    require: '@2.6.2 +pnetcdf'
+    require:
+    - '@2.6.2'
   parallel-netcdf:
     require: '@1.12.3'
   pflogger:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -22,3 +22,8 @@ spack:
       - neptune-python-env%intel
       # Same for LLVM compilers
       - neptune-python-env%clang
+  packages:
+    # Avoid duplicate builds of parallelio +pnetcdf and ~pnetcdf
+    parallelio:
+      require:
+      - '~pnetcdf'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -41,3 +41,8 @@ spack:
     exclude:
     # py-torch in ai-env doesn't build with Intel
     - ai-env%intel
+  packages:
+    # Avoid duplicate builds of parallelio +pnetcdf and ~pnetcdf
+    parallelio:
+      require:
+      - '+pnetcdf'

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -59,3 +59,8 @@ spack:
     # Skip neptune-python-env with Intel Classic due to problems
     # with new versions of py-numpy, py-scipy, ...
     - neptune-python-env%intel
+  packages:
+    # Avoid duplicate builds of parallelio +pnetcdf and ~pnetcdf
+    parallelio:
+      require:
+      - '+pnetcdf'

--- a/spack-ext/repos/spack-stack/packages/base-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/base-env/package.py
@@ -32,7 +32,6 @@ class BaseEnv(BundlePackage):
     depends_on("hdf5", type="run")
     depends_on("netcdf-c", type="run")
     depends_on("netcdf-fortran", type="run")
-    depends_on("parallel-netcdf", type="run")
     depends_on("parallelio", type="run")
     depends_on("nccmp", type="run")
 

--- a/spack-ext/repos/spack-stack/packages/jedi-mpas-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/jedi-mpas-env/package.py
@@ -17,6 +17,8 @@ class JediMpasEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
+    depends_on("parallel-netcdf", type="run")
+    depends_on("parallelio +pnetcdf", type="run")
     depends_on("metis", type="run")
     depends_on("jasper", type="run")
 


### PR DESCRIPTION
### Summary

Remove `parallel-netcdf` dependency from `base-env`. Instead, add it to `jedi-mpas-env` and enable the variant `+pnetcdf` for `parallelio` in `jedi-mpas-env` (the default for this variant is `~pnetcdf`).

This means that environments using template `neptune-dev` concretize without `parallel-netcdf`, but any template that includes `jedi-mpas-env` (e.g. `unified-dev`, `skylab-dev`) concretize with `parallel-netcdf`.

I added `neptune-dev` as an additional template to the Ubuntu GNU runner, but had to disable the `xnrl` variant since this package isn't publicly available. For `neptune-dev`, parallel-netcdf is removed, for `unified-dev` and `skylab-dev`, it is included as before.

### Testing

I tested this on my laptop and I also confirmed that the CI builds behave as expected (see https://github.com/JCSDA/spack-stack/actions/runs/14740976173/job/41378625127?pr=1621)

### Applications affected

None - NEPTUNE doesn't use `parallel-netcdf`, and the other environments in use will still have it.

### Systems affected

None

### Dependencies

None

### Issue(s) addressed

Closes #1613 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
