### PR TITLE
Update Blueback compilers.yaml: add missing path to `llvm-ar` etc.

### DIFF
--- a/configs/sites/tier1/blueback/compilers.yaml
+++ b/configs/sites/tier1/blueback/compilers.yaml
@@ -60,6 +60,8 @@ compilers::
     - libfabric/1.20.1
     environment:
       prepend_path:
+        # The Cray compiler module does not include llvm-ar and other tools in the path
+        PATH: '/p/app/intel/oneapi-combined/compiler/2025.0/bin/compiler'
         LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib'
       set:
         CONFIG_SITE: ''


### PR DESCRIPTION
### Summary

The Intel oneAPI compiler module on Blueback does not include the path to `llvm-ar` etc. This and other utilities in subdirectory `compiler` are required for linking when using interprocedural optimization (`-flto`, formerly known as `-ipo`).

### Testing

Tested on Blueback (manually). No CI testing required.

### Applications affected

None

### Systems affected

Blueback

### Dependencies

None

### Issue(s) addressed

Link the issues addressed or resolved by this PR (use `Fixes #???` for fully resolved issues)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
