### PR TITLE
Replace esmf@8.9.0b05 with esmf@8.9.0b08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/manual_update_esmf_from_spack_dev_20250507
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/esmf890b08
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/esmf890b08
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/manual_update_esmf_from_spack_dev_20250507
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -134,8 +134,8 @@ modules:
           ^esmf@8.7.0+debug snapshot=none: 'esmf-8.7.0-debug'
           ^esmf@8.8.0~debug snapshot=none: 'esmf-8.8.0'
           ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
-          ^esmf@8.9.0b05~debug snapshot=b05: 'esmf-8.9.0b05'
-          ^esmf@8.9.0b05+debug snapshot=b05: 'esmf-8.9.0b05-debug'
+          ^esmf@8.9.0b08~debug snapshot=b08: 'esmf-8.9.0b08'
+          ^esmf@8.9.0b08+debug snapshot=b08: 'esmf-8.9.0b08-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -132,8 +132,8 @@ modules:
           ^esmf@8.7.0+debug snapshot=none: 'esmf-8.7.0-debug'
           ^esmf@8.8.0~debug snapshot=none: 'esmf-8.8.0'
           ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
-          ^esmf@8.9.0b05~debug snapshot=b05: 'esmf-8.9.0b05'
-          ^esmf@8.9.0b05+debug snapshot=b05: 'esmf-8.9.0b05-debug'
+          ^esmf@8.9.0b08~debug snapshot=b08: 'esmf-8.9.0b08'
+          ^esmf@8.9.0b08+debug snapshot=b08: 'esmf-8.9.0b08-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@ packages:
   esmf:
     require:
     - '~xerces ~pnetcdf +shared +external-parallelio'
-    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0b05 snapshot=b05']
+    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0b08 snapshot=b08']
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc ^esmf@=8.9.0b05 snapshot=b05
+      - neptune-env +espc ^esmf@=8.9.0b08 snapshot=b08
       # Comment out for Cole and Tusk or any other air-gapped system:
-      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.9.0b05 snapshot=b05
+      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.9.0b08 snapshot=b08
 
   specs:
     - matrix:


### PR DESCRIPTION
### Summary

Replace esmf@8.9.0b05 with esmf@8.9.0b08 (in spack, add esmf@8.9.0b08 and update the ESMF `package.py` from spack develop as of 2025/05/07).

### Testing

- [x] CI

### Applications affected

NEPTUNE

### Systems affected

None

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/537
- [x] waiting on https://github.com/JCSDA/spack/pull/538

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1631

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
