### PR TITLE
Update container specs (jedi-ci.yaml): hdf5 1.14.3->1.14.5

### DIFF
--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -23,7 +23,7 @@
     g2tmpl@1.13.0,
     gsibec@1.2.1,
     hdf@4.2.15,
-    hdf5@1.14.3,
+    hdf5@1.14.5,
     ip@5.3.0,
     jasper@2.0.32,
     jedi-cmake@1.4.0,


### PR DESCRIPTION
### Summary

Update container specs (jedi-ci.yaml): hdf5 1.14.3->1.14.5. This fixes the broken container builds since #1633 was merged. See, for example https://github.com/JCSDA/spack-stack/actions/runs/14967045254/job/42039225579

### Testing

- [x] Regular CI (not affected by this change)
- [x] Workflow dispatch run for container build that failed 3hrs ago: https://github.com/JCSDA/spack-stack/actions/runs/14971343648/job/42052776280

### Applications affected

JEDI

### Systems affected

JEDI CI containers

### Dependencies

None

### Issue(s) addressed

See above.

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
