### PR TITLE
Update Nautilus site config: oneapi@2025.0.0 -> oneapi@2025.1.1

### DIFF
--- a/configs/sites/tier1/nautilus/compilers.yaml
+++ b/configs/sites/tier1/nautilus/compilers.yaml
@@ -60,29 +60,29 @@ compilers:
         CPATH: '/p/app/projects/NEPTUNE/spack-stack/oneapi-2024.2.1/compiler/2024.2/opt/compiler/include/intel64'
     extra_rpaths: []
 - compiler:
-    spec: oneapi@2025.0.0
+    spec: oneapi@2025.1.1
     paths:
-      cc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0/compiler/2025.0/bin/icx
-      cxx: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0/compiler/2025.0/bin/icpx
-      f77: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0/compiler/2025.0/bin/ifx
-      fc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0/compiler/2025.0/bin/ifx
+      cc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1/compiler/2025.1/bin/icx
+      cxx: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1/compiler/2025.1/bin/icpx
+      f77: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1/compiler/2025.1/bin/ifx
+      fc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1/compiler/2025.1/bin/ifx
     flags: {}
     operating_system: rhel8
     target: x86_64
     modules:
     - slurm
-    - tbb/2022.0
-    - compiler-rt/2025.0.0
-    - umf/0.9.0
-    - compiler-intel-llvm/2025.0.0
+    - tbb/2022.1
+    - compiler-rt/2025.1.1
+    - umf/0.10.0
+    - compiler-intel-llvm/2025.1.1
     environment:
       prepend_path:
         PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
         CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
         LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
-        MODULEPATH: '/p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0/modulefiles'
+        MODULEPATH: '/p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1/modulefiles'
       append_path:
-        CPATH: '/p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0/compiler/2025.0/opt/compiler/include/intel64'
+        CPATH: '/p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1/compiler/2025.1/opt/compiler/include/intel64'
     extra_rpaths: []
 - compiler:
     spec: gcc@11.2.1

--- a/configs/sites/tier1/nautilus/packages_oneapi.yaml
+++ b/configs/sites/tier1/nautilus/packages_oneapi.yaml
@@ -1,8 +1,8 @@
 packages:
   all:
-    compiler:: [oneapi@2024.2.1, oneapi@2025.0.0, gcc@11.2.1]
+    compiler:: [oneapi@2024.2.1, oneapi@2025.1.1, gcc@11.2.1]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.13, intel-oneapi-mpi@2021.14]
+      mpi:: [intel-oneapi-mpi@2021.13, intel-oneapi-mpi@2021.15]
   mpi:
     buildable: False
   intel-oneapi-mpi:
@@ -11,30 +11,30 @@ packages:
       prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.2.1
       modules:
       - mpi/2021.13
-    - spec: intel-oneapi-mpi@2021.14%oneapi@2025.0.0
-      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0
+    - spec: intel-oneapi-mpi@2021.15%oneapi@2025.1.1
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1
       modules:
-      - mpi/2021.14
+      - mpi/2021.15
   intel-oneapi-mkl:
     externals:
     - spec: intel-oneapi-mkl@2024.2%oneapi@2024.2.1
       prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.2.1
       modules:
       - mkl/2024.2
-    - spec: intel-oneapi-mkl@2025.0%oneapi@2025.0.0
-      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0
+    - spec: intel-oneapi-mkl@2025.1%oneapi@2025.1.1
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1
       modules:
-      - mkl/2025.0
+      - mkl/2025.1
   intel-oneapi-tbb:
     externals:
     - spec: intel-oneapi-tbb@2021.13%oneapi@2024.2.1
       prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.2.1
       modules:
       - tbb/2021.13
-    - spec: intel-oneapi-tbb@2022.0%oneapi@2025.0.0
-      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0
+    - spec: intel-oneapi-tbb@2022.1%oneapi@2025.1.1
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1
       modules:
-      - tbb/2022.0
+      - tbb/2022.1
   intel-oneapi-runtime:
     externals:
     - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
@@ -42,8 +42,8 @@ packages:
       modules:
       - tbb/2021.13
       - compiler-rt/2024.2.1
-    - spec: intel-oneapi-runtime@2025.0.0%oneapi@2025.0.0
-      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.0.0
+    - spec: intel-oneapi-runtime@2025.1.1%oneapi@2025.1.1
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2025.1.1
       modules:
-      - tbb/2022.0
-      - compiler-rt/2025.0.0
+      - tbb/2022.1
+      - compiler-rt/2025.1.1

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -369,7 +369,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
     # With oneapi@2025.1.x, cannot build unified-dev (odc build error - reported upstream but need new tag)
-    elif [[ "${compiler_name}" == "clang" && "${compiler_version}" == "2025.1"* && ! "${template}" == "neptune-dev" ]]; then
+    elif [[ "${compiler_name}" == "oneapi" && "${compiler_version}" == "2025.1"* && ! "${template}" == "neptune-dev" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
     # With clang, only neptune-dev

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -133,7 +133,7 @@ case ${SPACK_STACK_BATCH_HOST} in
     SPACK_STACK_CARGO_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/cargo-mirror"
     ;;
   nautilus)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.0.0" "intel@=2021.5.0" "gcc@=11.2.1")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.1.1" "gcc@=11.2.1")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/bootstrap-mirror"
@@ -366,6 +366,10 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       continue
     # unified-env not with intel
     elif [[ "${template}" == "unified-dev" &&  "${compiler_name}" == "intel" ]]; then
+      echo "Skipping template ${template} with compiler ${compiler}"
+      continue
+    # With oneapi@2025.1.x, cannot build unified-dev (odc build error - reported upstream but need new tag)
+    elif [[ "${compiler_name}" == "clang" && "${compiler_version}" == "2025.1"* && ! "${template}" == "neptune-dev" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
     # With clang, only neptune-dev

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -368,7 +368,8 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     elif [[ "${template}" == "unified-dev" &&  "${compiler_name}" == "intel" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
-    # With oneapi@2025.1.x, cannot build unified-dev (odc build error - reported upstream but need new tag)
+    # With oneapi@2025.1.x, cannot build unified-dev (odc build error):
+    # https://github.com/ecmwf/odc/issues/37
     elif [[ "${compiler_name}" == "oneapi" && "${compiler_version}" == "2025.1"* && ! "${template}" == "neptune-dev" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue


### PR DESCRIPTION
### Summary

1. Update Nautilus site config: bump oneAPI from 2025.0.0 to 2025.1.1
2. Update `util/nrl/batch_install.sh` accordingly and remove the deprecated Intel Classic build

### Testing

- [x] `util/nrl/batch_install.sh` run on Nautilus
    - [x] Follow-up testing with NEPTUNE
- [x] No CI testing needed (CI not affected by these changes)

### Applications affected

NEPTUNE on Nautilus

### Systems affected

Nautilus

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
