### PR TITLE
Add depends for geos-gcm-env

### DIFF
--- a/spack-ext/repos/spack-stack/packages/geos-gcm-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/geos-gcm-env/package.py
@@ -12,7 +12,7 @@ class GeosGcmEnv(BundlePackage):
     homepage = "https://gmao.gsfc.nasa.gov/GEOS_systems"
     git = "https://github.com/GEOS-ESM/GEOSgcm"
 
-    maintainers("climbfuji", "mathomp4")
+    maintainers("climbfuji", "mathomp4", "Dooruk")
 
     # Current version
     version("1.1.0")

--- a/spack-ext/repos/spack-stack/packages/geos-gcm-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/geos-gcm-env/package.py
@@ -29,5 +29,8 @@ class GeosGcmEnv(BundlePackage):
     depends_on("pflogger", type="run")
     #
     depends_on("py-numpy", type="run")
+    depends_on("py-pyyaml", type="run")
+    depends_on("py-ruamel-yaml", type="run")
+    depends_on("udunits", type="run")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/geos-gcm-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/geos-gcm-env/package.py
@@ -12,10 +12,10 @@ class GeosGcmEnv(BundlePackage):
     homepage = "https://gmao.gsfc.nasa.gov/GEOS_systems"
     git = "https://github.com/GEOS-ESM/GEOSgcm"
 
-    maintainers("climbfuji", "mathomp4", "danholdaway")
+    maintainers("climbfuji", "mathomp4")
 
     # Current version
-    version("1.0.0")
+    version("1.1.0")
 
     depends_on("base-env", type="run")
     depends_on("blas", type="run")


### PR DESCRIPTION
### Summary

This PR adds a few new dependencies for the `geos-gcm-env`:

```python
    depends_on("py-pyyaml", type="run")
    depends_on("py-ruamel-yaml", type="run")
    depends_on("udunits", type="run")
```

I also removed @danholdaway as a maintainer, since, well, he's not really doing that anymore, but I did add @Dooruk just as a back up. (Maybe in the future it can change.)

Note: I also advanced the version but, well, I'm not sure I should be? I'll let @climbfuji let me know if I should have.

### Testing

I've been trying to build a spack stack at NAS and found that when I did my `ml geos-gcm-env` my cmake for GEOSgcm failed because, well, no udunits. I then checked my 


### Applications affected

I think just GEOSgcm. SWELL has its own metamodule.

### Systems affected

I guess...all of them? It's not machine dependent.

### Dependencies

None

### Issue(s) addressed

Closes #1657 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
