### PR TITLE
release/1.9: Bug fixes for scotch and crtm-fix, update Ursa site config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-1.9.2rc1
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-1.9.2rc1
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/rel19_yetanothercrtmfixbugfix
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-1.9.2rc1
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/rel19_yetanothercrtmfixbugfix
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.9.0
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/scotch_oneapi_conflict
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.9.0
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/scotch_oneapi_conflict
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.9.0
-  url = https://github.com/climbfuji/spack
-  branch = feature/rel190mapl2534
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.9.0
+  url = https://github.com/climbfuji/spack
+  branch = feature/rel190mapl2534
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -265,9 +265,11 @@ packages:
   py-urllib3:
     require: '@1.26.12'
   qt:
-    require: '@5'
+    require:
+    - '@5'
   scotch:
-    require: '@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps'
+    require:
+    - '@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps'
   sfcio:
     require: '@1.4.2'
   shumlib:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -160,7 +160,7 @@ packages:
   magics:
     require: "@4.15.3:"
   mapl:
-    require: '@2.53.0 ~shared ~f2py'
+    require: '@2.53 ~shared ~f2py'
     variants: '+pflogger'
   met:
     require: '@11.1.1 +python +grib2'

--- a/configs/common/packages_oneapi.yaml
+++ b/configs/common/packages_oneapi.yaml
@@ -24,3 +24,6 @@ packages:
   qt:
     require:
     - '%gcc'
+  scotch:
+    require:
+    - '%gcc'

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -48,7 +48,7 @@
     w3emc@2.10.0,
     nco,
     esmf@8.8.0,
-    mapl@2.53.0,
+    mapl@2.53.4,
     zlib-ng,
     zstd,
     odc@1.5.2,

--- a/configs/sites/tier1/ursa/compilers.yaml
+++ b/configs/sites/tier1/ursa/compilers.yaml
@@ -8,6 +8,7 @@ compilers:
       fc: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2024.2.1-oqhstbmawnrsdw472p4pjsopj547o6xs/compiler/2024.2/bin/ifort
     flags: {}
     operating_system: rocky9
+    target: x86_64
     modules:
     - intel-oneapi-compilers/2024.2.1
     environment:
@@ -26,6 +27,7 @@ compilers:
       fc:  /usr/bin/gfortran
     flags: {}
     operating_system: rocky9
+    target: x86_64
     modules: []
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/ursa/packages_gcc.yaml
+++ b/configs/sites/tier1/ursa/packages_gcc.yaml
@@ -11,14 +11,8 @@ packages:
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-auzmzlihoo7n6g254nqkguxtzrdzkyqv
       modules:
       - openmpi/4.1.6
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@11.4.1%gcc@11.4.1
+      prefix: /usr
 
-  ectrans:
-    require::
-    - '~mkl +fftw'
-  gsibec:
-    require::
-    - '~mkl'
-  py-numpy:
-    require::
-    - '@1.26'
-    - '^openblas'

--- a/configs/sites/tier1/ursa/packages_oneapi.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [oneapi@2024.2.1]
+    compiler:: [oneapi@2024.2.1,gcc@11.4.1]
     providers:
       mpi:: [intel-oneapi-mpi@2021.13]
       # Change as appropriate to switch to intel-oneapi-mkl
@@ -16,22 +16,20 @@ packages:
       modules:
       - intel-oneapi-mpi/2021.13.1
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-ss72gbndvat3oz22sa6lhmlbjkeabrn4
-
+  intel-oneapi-mkl:
+    externals:
+    - spec: intel-oneapi-mkl@2024.2.1%oneapi@2024.2.1
+      modules:
+      - intel-oneapi-mkl/2024.2.1
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-mkl-2024.2.1-srqwrbzwo2k7hxuuhlrxttburs5jvlat
   intel-oneapi-runtime:
     externals:
     - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2024.2.1-oqhstbmawnrsdw472p4pjsopj547o6xs/compiler/2024.2
       modules:
       - compiler-rt/2024.2.1
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@11.4.1%gcc@11.4.1
+      prefix: /usr
 
-  # If using intel-oneapi-mkl, make appropriate changes below
-  ectrans:
-    require::
-    - '~mkl +fftw'
-  gsibec:
-    require::
-    - '~mkl'
-  py-numpy:
-    require::
-    - '@1.26'
-    - '^openblas'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -28,7 +28,7 @@ spack:
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1
-    - mapl@2.53.0 ^esmf@8.8.0
+    - mapl@2.53.4 ^esmf@8.8.0
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -34,7 +34,7 @@ spack:
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1
-    - mapl@2.53.0 ^esmf@8.8.0
+    - mapl@2.53.4 ^esmf@8.8.0 
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -34,7 +34,7 @@ spack:
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1
-    - mapl@2.53.4 ^esmf@8.8.0 
+    - mapl@2.53.4 ^esmf@8.8.0
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none


### PR DESCRIPTION
### Summary

1. Update of spack with three changes for release/1.9 (see dependencies below)
2. Update templates/config files for changes in 1.
3. Update ursa site config - builds without duplicates with the spack changes from 1. This introduces the use of MKL as the virtual provider for blas/lapack/fftw when using Intel/oneAPI, but keeps OpenBLAS/FFTW for GNU. Similar to what NRL systems do, what CI uses, and what we should move (back) to on **all** systems before the spack-stack 2.0.x releases.

**Note.** After this is merged, we need a final round of testing with all UFS regression tests. If successful, create release 1.9.2 and merge necessary changes back to develop.

### Testing

- [x] CI
- [x] Built spack-stack on Ursa, testing done by @JessicaMeixner-NOAA with UFS (see https://github.com/ufs-community/ufs-weather-model/pull/2650#issuecomment-2956446274)
- [x] Built spack-stack on Nautilus and confirmed there are no version conflicts

### Applications affected

release/1.9 applications that will use spack-stack-1.9.2 (UFS, JEDI, ...)

### Systems affected

Ursa

### Dependencies

- [x]  Waiting on https://github.com/JCSDA/spack/pull/546
- [x]  Waiting on https://github.com/JCSDA/spack/pull/547
- [x]  Waiting on https://github.com/JCSDA/spack/pull/548

### Issue(s) addressed

@ulmononian @rickgrubin-noaa please add issues here

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
