### PR TITLE
Update site configs and NRL batch install scripts for Bounty (LLVM), Atlantis (LLVM), Blueback

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -74,11 +74,15 @@ packages:
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"
+    - any_of: ['+python']
+      when: "%gcc"
+    - any_of: ['+python']
+      when: "%intel"
+    - any_of: ['+python']
+      when: "%oneapi"
     - any_of: ['~python']
       when: "%clang"
-      message: "Disable python variant for ESMF because mpi4py doesn't build with clang"    #- any_of: ['']
-    prefer:
-    - '+python'
+      message: "Disable python variant for ESMF because mpi4py doesn't build with clang" 
   # To avoid duplicate packages (concretizer bug?)
   expat:
     require:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -74,13 +74,11 @@ packages:
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"
+    - any_of: ['~python']
+      when: "%clang"
+      message: "Disable python variant for ESMF because mpi4py doesn't build with clang"    #- any_of: ['']
+    prefer:
     - '+python'
-    #- any_of: ['']
-    #  when: "%gcc"
-    #  message: "Extra ESMF compile options for GCC"
-    #- any_of: ['']
-    #  when: "%apple-clang"
-    #  message: "Extra ESMF compile options for GCC"
   # To avoid duplicate packages (concretizer bug?)
   expat:
     require:

--- a/configs/sites/tier1/blueback/compilers.yaml
+++ b/configs/sites/tier1/blueback/compilers.yaml
@@ -10,13 +10,13 @@ compilers::
     operating_system: sles15
     target: x86_64
     modules:
-    - PrgEnv-gnu/8.5.0
+    - PrgEnv-gnu/8.6.0
     - gcc-native/13.2
-    - cray-libsci/24.07.0
-    - libfabric/1.20.1
+    - cray-libsci/25.03.0
+    - libfabric/1.22.0
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/GNU/12.3/x86_64/lib'
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.22.0/lib64:/opt/cray/pe/libsci/25.03.0/GNU/13.2/x86_64/lib'
       set:
         CONFIG_SITE: ''
         CRAY_CPU_TARGET: x86-genoa
@@ -32,13 +32,13 @@ compilers::
     operating_system: sles15
     target: x86_64
     modules:
-    - PrgEnv-intel/8.5.0
+    - PrgEnv-intel/8.6.0
     - intel-oneapi/2024.2
-    - cray-libsci/24.07.0
-    - libfabric/1.20.1
+    - cray-libsci/25.03.0
+    - libfabric/1.22.0
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib'
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.22.0/lib64:/opt/cray/pe/libsci/25.03.0/INTEL/2025.0/x86_64/lib'
       set:
         CONFIG_SITE: ''
         CRAY_CPU_TARGET: x86-genoa
@@ -54,15 +54,15 @@ compilers::
     operating_system: sles15
     target: x86_64
     modules:
-    - PrgEnv-intel/8.5.0
+    - PrgEnv-intel/8.6.0
     - intel-oneapi/2025.0
-    - cray-libsci/24.07.0
-    - libfabric/1.20.1
+    - cray-libsci/25.03.0
+    - libfabric/1.22.0
     environment:
       prepend_path:
         # The Cray compiler module does not include llvm-ar and other tools in the path
         PATH: '/p/app/intel/oneapi-combined/compiler/2025.0/bin/compiler'
-        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.20.1/lib64:/opt/cray/pe/libsci/24.07.0/INTEL/2023.2/x86_64/lib'
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.22.0/lib64:/opt/cray/pe/libsci/25.03.0/INTEL/2025.0/x86_64/lib'
       set:
         CONFIG_SITE: ''
         CRAY_CPU_TARGET: x86-genoa

--- a/configs/sites/tier1/blueback/packages_gcc.yaml
+++ b/configs/sites/tier1/blueback/packages_gcc.yaml
@@ -11,3 +11,7 @@ packages:
       modules:
       - cray-mpich/8.1.32
       - craype-network-ofi
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@13.3.0
+      prefix: /usr

--- a/configs/sites/tier1/blueback/packages_gcc.yaml
+++ b/configs/sites/tier1/blueback/packages_gcc.yaml
@@ -2,12 +2,12 @@ packages:
   all:
     compiler:: [gcc@13.3.0]
     providers:
-      mpi:: [cray-mpich@8.1.30]
+      mpi:: [cray-mpich@8.1.32]
   mpi:
     buildable: False
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.30%gcc@13.3.0 ~wrappers
+    - spec: cray-mpich@8.1.32%gcc@13.3.0 ~wrappers
       modules:
-      - cray-mpich/8.1.30
+      - cray-mpich/8.1.32
       - craype-network-ofi

--- a/configs/sites/tier1/blueback/packages_oneapi.yaml
+++ b/configs/sites/tier1/blueback/packages_oneapi.yaml
@@ -2,18 +2,18 @@ packages:
   all:
     compiler:: [oneapi@2024.2.1, oneapi@2025.0.4, gcc@13.3.0]
     providers:
-      mpi:: [cray-mpich@8.1.30]
+      mpi:: [cray-mpich@8.1.32]
   mpi:
     buildable: False
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.30~wrappers%oneapi@2024.2.1
+    - spec: cray-mpich@8.1.32~wrappers%oneapi@2024.2.1
       modules:
-      - cray-mpich/8.1.30
+      - cray-mpich/8.1.32
       - craype-network-ofi
-    - spec: cray-mpich@8.1.30~wrappers%oneapi@2025.0.4
+    - spec: cray-mpich@8.1.32~wrappers%oneapi@2025.0.4
       modules:
-      - cray-mpich/8.1.30
+      - cray-mpich/8.1.32
       - craype-network-ofi
   intel-oneapi-mkl:
     externals:

--- a/configs/sites/tier1/blueback/packages_oneapi.yaml
+++ b/configs/sites/tier1/blueback/packages_oneapi.yaml
@@ -33,3 +33,7 @@ packages:
       prefix: /p/app/intel/oneapi-combined
     - spec: intel-oneapi-runtime@2025.0.4%oneapi@2025.0.4
       prefix: /p/app/intel/oneapi-combined
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@13.3.0
+      prefix: /usr

--- a/configs/sites/tier1/blueback/packages_oneapi.yaml
+++ b/configs/sites/tier1/blueback/packages_oneapi.yaml
@@ -33,7 +33,3 @@ packages:
       prefix: /p/app/intel/oneapi-combined
     - spec: intel-oneapi-runtime@2025.0.4%oneapi@2025.0.4
       prefix: /p/app/intel/oneapi-combined
-  gcc-runtime:
-    externals:
-    - spec: gcc-runtime@13.3.0
-      prefix: /usr

--- a/configs/sites/tier2/bounty/compilers.yaml
+++ b/configs/sites/tier2/bounty/compilers.yaml
@@ -26,12 +26,12 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: oneapi@=2025.0.0
+    spec: oneapi@=2025.1.1
     paths:
-      cc: /opt/intel/oneapi/compiler/2025.0/bin/icx
-      cxx: /opt/intel/oneapi/compiler/2025.0/bin/icpx
-      f77: /opt/intel/oneapi/compiler/2025.0/bin/ifx
-      fc: /opt/intel/oneapi/compiler/2025.0/bin/ifx
+      cc: /opt/intel/oneapi/compiler/2025.1/bin/icx
+      cxx: /opt/intel/oneapi/compiler/2025.1/bin/icpx
+      f77: /opt/intel/oneapi/compiler/2025.1/bin/ifx
+      fc: /opt/intel/oneapi/compiler/2025.1/bin/ifx
     flags: {}
     operating_system: almalinux9
     target: x86_64
@@ -39,33 +39,33 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@=20.1.4
+    spec: clang@=20.1.5
     paths:
-      cc: /home/dom/prod/llvm-20.1.4/view/bin/clang
-      cxx: /home/dom/prod/llvm-20.1.4/view/bin/clang++
-      f77: /home/dom/prod/llvm-20.1.4/view/bin/flang-new
-      fc: /home/dom/prod/llvm-20.1.4/view/bin/flang-new
+      cc: /home/dom/prod/llvm-20.1.5/bin/clang
+      cxx: /home/dom/prod/llvm-20.1.5/bin/clang++
+      f77: /home/dom/prod/llvm-20.1.5/bin/flang-new
+      fc: /home/dom/prod/llvm-20.1.5/bin/flang-new
     flags: {}
     operating_system: almalinux9
     target: x86_64
     modules: []
     environment:
       append_path:
-        LD_LIBRARY_PATH: /home/dom/prod/llvm-20.1.4/view/lib
-    extra_rpaths: [/home/dom/prod/llvm-20.1.4/view/lib]
-- compiler:
-    spec: aocc@=5.0.0
-    paths:
-      cc: /home/dom/prod/aocc-5.0.0/bin/clang
-      cxx: /home/dom/prod/aocc-5.0.0/bin/clang++
-      f77: /home/dom/prod/aocc-5.0.0/bin/flang
-      fc: /home/dom/prod/aocc-5.0.0/bin/flang
-    flags: {}
-    operating_system: almalinux9
-    target: x86_64
-    modules: []
-    environment: {}
-      #append_path:
-        # For libquadmath etc
-        # NEEDED? LD_LIBRARY_PATH: /usr/lib/gcc/x86_64-redhat-linux/11
-    extra_rpaths: []
+        LD_LIBRARY_PATH: /home/dom/prod/llvm-20.1.5/lib
+    extra_rpaths: [/home/dom/prod/llvm-20.1.5/lib]
+#- compiler:
+#    spec: aocc@=5.0.0
+#    paths:
+#      cc: /home/dom/prod/aocc-5.0.0/bin/clang
+#      cxx: /home/dom/prod/aocc-5.0.0/bin/clang++
+#      f77: /home/dom/prod/aocc-5.0.0/bin/flang
+#      fc: /home/dom/prod/aocc-5.0.0/bin/flang
+#    flags: {}
+#    operating_system: almalinux9
+#    target: x86_64
+#    modules: []
+#    environment: {}
+#      #append_path:
+#        # For libquadmath etc
+#        # NEEDED? LD_LIBRARY_PATH: /usr/lib/gcc/x86_64-redhat-linux/11
+#    extra_rpaths: []

--- a/configs/sites/tier2/bounty/packages_clang.yaml
+++ b/configs/sites/tier2/bounty/packages_clang.yaml
@@ -1,5 +1,5 @@
 packages:
   all:
-    compiler:: [clang@19.1.4]
+    compiler:: [clang@20.1.5]
     providers:
-      mpi:: [openmpi@5.0.5]
+      mpi:: [openmpi@5.0.6]

--- a/configs/sites/tier2/bounty/packages_gcc.yaml
+++ b/configs/sites/tier2/bounty/packages_gcc.yaml
@@ -2,4 +2,8 @@ packages:
   all:
     compiler:: [gcc@13.3.1]
     providers:
-      mpi:: [openmpi@5.0.5]
+      mpi:: [openmpi@5.0.6]
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@13.3.1%gcc@13.3.1
+      prefix: /opt/rh/gcc-toolset-13/root/usr

--- a/configs/sites/tier2/bounty/packages_oneapi.yaml
+++ b/configs/sites/tier2/bounty/packages_oneapi.yaml
@@ -1,19 +1,23 @@
 packages:
   all:
-    compiler:: [oneapi@2025.0.0, gcc@11.5.0]
+    compiler:: [oneapi@2025.1.1, gcc@11.5.0]
     providers:
-      mpi:: [intel-oneapi-mpi@2021.14]
+      mpi:: [intel-oneapi-mpi@2021.15]
   mpi:
     buildable: False
   intel-oneapi-mpi:
     externals:
-    - spec: intel-oneapi-mpi@2021.14%oneapi@2025.0.0
+    - spec: intel-oneapi-mpi@2021.15%oneapi@2025.1.1
       prefix: /opt/intel/oneapi
   intel-oneapi-mkl:
     externals:
-    - spec: intel-oneapi-mkl@2025.0%oneapi@2025.0.0
+    - spec: intel-oneapi-mkl@2025.1%oneapi@2025.1.1
       prefix: /opt/intel/oneapi
   intel-oneapi-runtime:
     externals:
-    - spec: intel-oneapi-runtime@2025.0.0%oneapi@2025.0.0
+    - spec: intel-oneapi-runtime@2025.1.1%oneapi@2025.1.1
       prefix: /opt/intel/oneapi
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@13.3.1%gcc@13.3.1
+      prefix: /opt/rh/gcc-toolset-13/root/usr

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -413,6 +413,12 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       atlantis)
         umask 0022
         module purge
+        case ${compiler} in
+          clang@=20.1.5)
+	    module use /gpfs/neptune/spack-stack/llvm-20.1.5/modulefiles
+	    module use /gpfs/neptune/spack-stack/openmpi-5.0.6/llvm-20.1.5/modulefiles
+	    ;;
+	esac
         ;;
       blueback)
         # Check if snapshot to restore default environment exists, then restore

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -105,7 +105,7 @@ SPACK_STACK_BATCH_HOST=${SPACK_STACK_BATCH_HOST//[0-9]/}
 
 case ${SPACK_STACK_BATCH_HOST} in
   atlantis)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.0.3" "intel@=2021.6.0" "gcc@=11.2.0")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.0.3" "gcc@=11.2.0" "clang@=20.1.5")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="lmod"
     SPACK_STACK_BOOTSTRAP_MIRROR="/neptune_diagnostics/spack-stack/bootstrap-mirror"
@@ -126,7 +126,7 @@ case ${SPACK_STACK_BATCH_HOST} in
     SPACK_STACK_CARGO_MIRROR="/p/work1/heinzell/spack-stack/cargo-mirror"
     ;;
   narwhal)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.0" "intel@=2021.10.0" "gcc@=12.2.0")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.0" "gcc@=12.2.0")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/bootstrap-mirror"
@@ -154,7 +154,7 @@ case ${SPACK_STACK_BATCH_HOST} in
     SPACK_STACK_CARGO_MIRROR="/home/dom/prod/spack-cargo-mirror"
     ;;
   bounty)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2025.0.0" "gcc@=13.3.1" "aocc@=5.0.0" "clang@=19.1.4")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2025.1.1" "gcc@=13.3.1" "clang@=20.1.5")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/home/dom/prod/spack-bootstrap-mirror"
@@ -363,21 +363,12 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     if [[ "${template}" == "cylc-dev" && ! "${compiler_name}" == "gcc" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
-    # unified-env not with intel
-    elif [[ "${template}" == "unified-dev" &&  "${compiler_name}" == "intel" ]]; then
-      echo "Skipping template ${template} with compiler ${compiler}"
-      continue
-    # With oneapi@2025.1.x, cannot build unified-dev (odc build error):
-    # https://github.com/ecmwf/odc/issues/37
-    elif [[ "${compiler_name}" == "oneapi" && "${compiler_version}" == "2025.1"* && ! "${template}" == "neptune-dev" ]]; then
-      echo "Skipping template ${template} with compiler ${compiler}"
-      continue
     # With clang, only neptune-dev
     elif [[ "${compiler_name}" == "clang" && ! "${template}" == "neptune-dev" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
-    # With aocc, only neptune-dev
-    elif [[ "${compiler_name}" == "aocc" && ! "${template}" == "neptune-dev" ]]; then
+    # FMS compiler ICE: https://github.com/NOAA-GFDL/FMS/issues/1680
+    elif [[ "${compiler_name}" == "oneapi" && "${compiler_version}" == "2025.1"* && "${template}" == "unified-dev" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
     fi
@@ -441,38 +432,38 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
         case ${compiler} in
           oneapi@=2024.2.1)
             module purge
-            module load PrgEnv-intel/8.5.0
+            module load PrgEnv-intel/8.6.0
             module unload intel
             module load intel-oneapi/2024.2
             module unload cray-mpich
             module unload craype-network-ofi
-            module load libfabric/1.20.1
+            module load libfabric/1.22.0
             module unload cray-libsci
-            module load cray-libsci/24.07.0
+            module load cray-libsci/25.03.0
             ;;
           oneapi@=2025.0.4)
             module purge
-            module load PrgEnv-intel/8.5.0
+            module load PrgEnv-intel/8.6.0
             module unload intel
             module load intel-oneapi/2025.0
             module unload cray-mpich
             module unload craype-network-ofi
-            module load libfabric/1.20.1
+            module load libfabric/1.22.0
             module unload cray-libsci
-            module load cray-libsci/24.07.0
+            module load cray-libsci/25.03.0
             ;;
           gcc@=13.3.0)
             module purge
-            module load PrgEnv-gnu/8.5.0
+            module load PrgEnv-gnu/8.6.0
             module unload gcc
             # Confusing: the module is called gcc-native/13.2,
             # but the actual version of the compiler is 13.3
             module load gcc-native/13.2
             module unload cray-mpich
             module unload craype-network-ofi
-            module load libfabric/1.20.1
+            module load libfabric/1.22.0
             module unload cray-libsci
-            module load cray-libsci/24.07.0
+            module load cray-libsci/25.03.0
             ;;
           *)
             echo "ERROR, compiler ${compiler} not configured for resetting environment"
@@ -548,17 +539,6 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
             module load PrgEnv-intel/8.4.0
             module unload intel
             module load intel/2024.2
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.12.1.2.2.1
-            module unload cray-libsci
-            module load cray-libsci/23.05.1.4
-            ;;
-          intel@=2021.10.0)
-            module purge
-            module load PrgEnv-intel/8.4.0
-            module unload intel
-            module load intel-classic/2023.2.0
             module unload cray-mpich
             module unload craype-network-ofi
             module load libfabric/1.12.1.2.2.1


### PR DESCRIPTION
### Summary

1. Update site configs for Bounty and Blueback. The Blueback updates are necessary because of the OS upgrade during the extended downtime in May; the Bounty changes are for the update of the LLVM 20.1.5 compilers. On Bounty, I also updated the Intel oneAPI compilers from 2025.0.0 to the latest available release 2025.1.1.
2. In `configs/common/packages.yaml`, build ESMF with `~python` for LLVM clang, and with `+python` for all other compilers (no change for compilers other than LLVM clang).
3. In the NRL batch install script, corresponding changes are made, and the Intel Classic compilers are removed for good.

### Testing

- [x] Built all possible environments on all threee systems using the `util/nrl/batch_install.sh` script.

### Applications affected

None

### Systems affected

Bounty, Atlantis, Blueback

### Dependencies

None

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1655

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
