### PR TITLE
spack-stack-1.9.2rc3 updates (WCOSS2/NCO)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-1.9.2rc1
+  url = https://github.com/AlexanderRichert-NOAA/spack
+  branch = 192rc2
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "spack"]
   path = spack
   url = https://github.com/jcsda/spack
-  branch = spack-stack-1.9.2rc2
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/AlexanderRichert-NOAA/spack
-  branch = 192rc2
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "spack"]
   path = spack
   url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+  branch = spack-stack-1.9.2rc2
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -94,10 +94,6 @@
       require:
       - any_of: ['@0.29.36']
         when: '%intel'
-    py-numpy::
-      require::
-      - '^[virtuals=lapack,blas] openblas'
-      - '@1.26'
     py-pandas:
       'require:': ~excel #   minimize dependencies
     py-scipy:

--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -71,6 +71,8 @@
     gsibec:
       require::
       - '@1.2.1 ~mkl'
+    icu4c:
+      require: ['%gcc']
     libffi:
       require:
       - any_of: ['@3.3']
@@ -92,7 +94,7 @@
       require:
       - any_of: ['@0.29.36']
         when: '%intel'
-    py-numpy:
+    py-numpy::
       require::
       - '^[virtuals=lapack,blas] openblas'
       - '@1.26'

--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -114,4 +114,4 @@
     crtm:                                                     
       require: ['@2.4.0.1 +fix']
     scotch:
-      require: ['@7.0.7 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']
+      require:: ['@7.0.7 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']

--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -116,4 +116,4 @@
     crtm:                                                     
       require: ['@2.4.0.1 +fix']
     scotch:
-      require: ['@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']
+      require: ['@7.0.7 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -3,7 +3,7 @@ packages:
     ### Set compilers & MPI provider for metamodule generation. 
     # 
     all: 
-      compiler:: [intel@19.1.3.304,gcc]
+      compiler:: [intel@19.1.3.304]
       providers:
         mpi:: [cray-mpich]
     #

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -33,5 +33,8 @@ packages:
       - 'cflags="-no-ipo" cxxflags="-no-ipo"'
       - '^boost %gcc'
       - '%intel'
-    py-numpy:
-      require: ['%gcc']
+    py-numpy::
+      require::
+      - '^[virtuals=lapack,blas] openblas'
+      - '@1.26'
+      - '%gcc'

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -4,8 +4,8 @@ packages:
     # 
     all: 
       compiler:: [intel@19.1.3.304,gcc]
-    providers:
-      mpi:: [cray-mpich]
+      providers:
+        mpi:: [cray-mpich]
     #
     ### External packages.
     # 

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -1,9 +1,11 @@
 packages:
     #
-    ### Set compiler. 
+    ### Set compilers & MPI provider for metamodule generation. 
     # 
     all: 
-      compiler:: [intel@19.1.3.304]
+      compiler:: [intel@19.1.3.304,gcc]
+    providers:
+      mpi:: [cray-mpich]
     #
     ### External packages.
     # 
@@ -25,6 +27,11 @@ packages:
     harfbuzz:
       require: ['%gcc']
     ecflow:
-      require:: ['@5.11.4', '+ui', '^boost %gcc', '%intel']
+      require::
+      - '@5.11.4'
+      - '+ui'
+      - 'cflags="-no-ipo" cxxflags="-no-ipo"'
+      - '^boost %gcc'
+      - '%intel'
     py-numpy:
       require: ['%gcc']

--- a/configs/sites/tier1/wcoss2/packages_oneapi.yaml
+++ b/configs/sites/tier1/wcoss2/packages_oneapi.yaml
@@ -3,7 +3,7 @@ packages:
   ### Set compilers & MPI provider for metamodule generation.
   #
   all:
-    compiler:: [oneapi@2024.2.1,gcc]
+    compiler:: [oneapi@2024.2.1]
     providers:
       mpi:: [cray-mpich]
   gcc-runtime:

--- a/configs/sites/tier1/wcoss2/packages_oneapi.yaml
+++ b/configs/sites/tier1/wcoss2/packages_oneapi.yaml
@@ -1,6 +1,11 @@
 packages:
+  #
+  ### Set compilers & MPI provider for metamodule generation.
+  #
   all:
-    compiler:: [oneapi@2024.2.1]
+    compiler:: [oneapi@2024.2.1,gcc]
+    providers:
+      mpi:: [cray-mpich]
   gcc-runtime:
     require: '%gcc@12.1.0'
   cray-mpich:
@@ -31,8 +36,6 @@ packages:
     require: ['@9.4.1']
   libtiff:
     require: ['build_system=cmake']
-  icu4c:
-    require: ['%gcc']
   ninja:
     require: ['~re2c %gcc']
   pixman:

--- a/configs/sites/tier1/wcoss2/packages_oneapi.yaml
+++ b/configs/sites/tier1/wcoss2/packages_oneapi.yaml
@@ -46,3 +46,7 @@ packages:
     require: ['%gcc']
   zlib-ng:
     require: ['cflags="-static-intel"', 'cxxflags="-static-intel"']
+  py-numpy::
+    require::
+    - '^[virtuals=lapack,blas] openblas'
+    - '@1.26'

--- a/configs/templates/nco/spack.yaml
+++ b/configs/templates/nco/spack.yaml
@@ -25,7 +25,7 @@ spack:
   - eckit
   - ecmwf-atlas
   - eigen
-  - esmf
+  - esmf@8.8.0
   - fckit
   - fms
   - g2
@@ -53,7 +53,7 @@ spack:
   - libxml2
   - libxrender
   - madis
-  - mapl
+  - mapl@2.53.4 ^esmf@8.8.0
   - mbedtls
   - met
   - metis


### PR DESCRIPTION
### Summary

This is another round of WCOSS2/NCO-related updates for the upcoming 1.9.2rc3 tag.

### Testing

Tested up through and including module loads on Acorn (based on google doc)

### Applications affected

EMC/NCO apps

### Systems affected

WCOSS2

### Dependencies

https://github.com/JCSDA/spack/pull/550

### Issue(s) addressed

https://github.com/NOAA-EMC/WCOSS2-requests/issues/40

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
