### PR TITLE
Update develop from release/1.9.0 (except selected site configs and NCO changes)

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -169,7 +169,7 @@ packages:
   magics:
     require: "@4.15.3:"
   mapl:
-    require: '@2.53.0 ~shared ~f2py'
+    require: '@2.53 ~shared ~f2py'
     variants: '+pflogger'
   met:
     require:
@@ -285,9 +285,11 @@ packages:
   py-versioneer:
     require: '@0.28'
   qt:
-    require: '@5'
+    require:
+    - '@5'
   scotch:
-    require: '@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps'
+    require:
+    - '@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps'
   sfcio:
     require: '@1.4.2'
   shumlib:

--- a/configs/common/packages_oneapi.yaml
+++ b/configs/common/packages_oneapi.yaml
@@ -33,3 +33,6 @@ packages:
   qt:
     require:
     - '%gcc'
+  scotch:
+    require:
+    - '%gcc'

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -48,7 +48,7 @@
     w3emc@2.10.0,
     nco,
     esmf@8.8.0,
-    mapl@2.53.0,
+    mapl@2.53.4,
     zlib-ng,
     zstd,
     odc@1.6.1,

--- a/configs/sites/tier1/ursa/compilers.yaml
+++ b/configs/sites/tier1/ursa/compilers.yaml
@@ -8,6 +8,7 @@ compilers:
       fc: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2024.2.1-oqhstbmawnrsdw472p4pjsopj547o6xs/compiler/2024.2/bin/ifort
     flags: {}
     operating_system: rocky9
+    target: x86_64
     modules:
     - intel-oneapi-compilers/2024.2.1
     environment:
@@ -26,6 +27,7 @@ compilers:
       fc:  /usr/bin/gfortran
     flags: {}
     operating_system: rocky9
+    target: x86_64
     modules: []
     environment: {}
     extra_rpaths: []

--- a/configs/sites/tier1/ursa/packages_gcc.yaml
+++ b/configs/sites/tier1/ursa/packages_gcc.yaml
@@ -8,7 +8,7 @@ packages:
   openmpi:
     externals:
     - spec: openmpi@4.1.6~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java+legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm
-      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-auzmzlihoo7n6g254nqkguxtzrdzkyqv
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-2dkf6t23iyw4xodxruh72yvmrhhvyoms
       modules:
       - openmpi/4.1.6
   gcc-runtime:

--- a/configs/sites/tier1/ursa/packages_gcc.yaml
+++ b/configs/sites/tier1/ursa/packages_gcc.yaml
@@ -8,17 +8,11 @@ packages:
   openmpi:
     externals:
     - spec: openmpi@4.1.6~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java+legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm
-      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-2dkf6t23iyw4xodxruh72yvmrhhvyoms
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-auzmzlihoo7n6g254nqkguxtzrdzkyqv
       modules:
       - openmpi/4.1.6
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@11.4.1%gcc@11.4.1
+      prefix: /usr
 
-  ectrans:
-    require::
-    - '~mkl +fftw'
-  gsibec:
-    require::
-    - '~mkl'
-  py-numpy:
-    require::
-    - '@1.26'
-    - '^openblas'

--- a/configs/sites/tier1/ursa/packages_oneapi.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [oneapi@2024.2.1]
+    compiler:: [oneapi@2024.2.1,gcc@11.4.1]
     providers:
       mpi:: [intel-oneapi-mpi@2021.13]
       # Change as appropriate to switch to intel-oneapi-mkl
@@ -16,22 +16,20 @@ packages:
       modules:
       - intel-oneapi-mpi/2021.13.1
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-ss72gbndvat3oz22sa6lhmlbjkeabrn4
-
+  intel-oneapi-mkl:
+    externals:
+    - spec: intel-oneapi-mkl@2024.2.1%oneapi@2024.2.1
+      modules:
+      - intel-oneapi-mkl/2024.2.1
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-mkl-2024.2.1-srqwrbzwo2k7hxuuhlrxttburs5jvlat
   intel-oneapi-runtime:
     externals:
     - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2024.2.1-oqhstbmawnrsdw472p4pjsopj547o6xs/compiler/2024.2
       modules:
       - compiler-rt/2024.2.1
+  gcc-runtime:
+    externals:
+    - spec: gcc-runtime@11.4.1%gcc@11.4.1
+      prefix: /usr
 
-  # If using intel-oneapi-mkl, make appropriate changes below
-  ectrans:
-    require::
-    - '~mkl +fftw'
-  gsibec:
-    require::
-    - '~mkl'
-  py-numpy:
-    require::
-    - '@1.26'
-    - '^openblas'

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -28,7 +28,7 @@ spack:
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1
-    - mapl@2.53.0 ^esmf@8.8.0
+    - mapl@2.53.4 ^esmf@8.8.0
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -34,7 +34,7 @@ spack:
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1
-    - mapl@2.53.0 ^esmf@8.8.0
+    - mapl@2.53.4 ^esmf@8.8.0
 
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none


### PR DESCRIPTION
### Summary

This PR:
- advances the submodule pointer for `spack` to the head of `spack-stack-dev`. The changes there are recent updates for `scotch`, `mapl`, `qt`, and `crtm-fix` that were merged from the `release/1.9.0` branch in our spack fork to `spack-stack-dev` (https://github.com/jcsda/spack/pull/549, https://github.com/JCSDA/spack/pull/550), and a bug fix for the `spack mirror` code from upstream (https://github.com/JCSDA/spack/pull/545).
- merges several updates related to the spack changes above, site config updates for Ursa, and template updates from `release/1.9.0` to `develop`.
- **does not include** changes made for NCO in PRs #1665 and https://github.com/JCSDA/spack-stack/pull/1652, and **does not include** all site configurations. I noticed that there are differences in several site configs between `release/1.9.0` and `develop`, most notably Hercules and Orion. All maintainers should compare the site configs for their sites in `release/1.9.0` to `develop` after this PR is merged and update develop as necessary.

### Testing

- [x] Changes tested extensively (CI, manually) in `release/1.9.0` branch
- [ ] CI **IN PROGRESS - note that the macOS CI runner is still broken and must be skipped**

### Applications affected

All applications using `unified-dev` environment

### Systems affected

Ursa (site config update)

### Dependencies

None

### Issue(s) addressed

Part of the spack-stack-1.9 release process (merge changes from release branch back to develop)

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
