### PR TITLE
Automation updates for NRL sites / GitHub actions

### DIFF
--- a/.github/actions/Nightly_00_SetBranchName/action.yaml
+++ b/.github/actions/Nightly_00_SetBranchName/action.yaml
@@ -1,0 +1,17 @@
+name: Nightly 00 Set Branch Name
+
+runs:
+  using: "composite"
+  steps:
+  - name: Nightly 00 Set Branch Name
+    shell: bash
+    run: |
+      if [ "${{ github.event_name }}" == "pull_request" ]; then
+        echo "SPACK_STACK_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+        echo "${{ github.head_ref }}" > SPACK_STACK_BRANCH_SAVE.log
+      elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+        echo "ci" > SPACK_STACK_BRANCH_SAVE.log
+      else
+        echo "Error, cannot determine branch name for github event ${{ github.event_name }}"
+        exit 1
+      fi

--- a/.github/actions/Nightly_02_GetSpackStack/action.yaml
+++ b/.github/actions/Nightly_02_GetSpackStack/action.yaml
@@ -7,5 +7,7 @@ runs:
     shell: bash
     run: |
       RUNID=$(<RUNID_SAVE.log)
+      SPACK_STACK_BRANCH=$(<SPACK_STACK_BRANCH_SAVE.log)
+      echo "Using SPACK_STACK_BRANCH '${SPACK_STACK_BRANCH}'"
       cd util/weekly_build
       ./02_GetSpackStack.sh ${RUNID} ${BASEDIR} ${PLATFORM}

--- a/util/weekly_build/sites/atlantis.sh
+++ b/util/weekly_build/sites/atlantis.sh
@@ -14,7 +14,12 @@ set +e
 module purge
 umask 0022
 
-SPACK_STACK_URL=https://github.nrlmry.navy.mil/JCSDA/spack-stack
-SPACK_STACK_BRANCH=ci
+if [[ "${COMPILERS}" == "clang@=20.1.5" ]]; then
+  module use /gpfs/neptune/spack-stack/llvm-20.1.5/modulefiles
+  module use /gpfs/neptune/spack-stack/openmpi-5.0.6/llvm-20.1.5/modulefiles
+fi
+
+SPACK_STACK_URL=${SPACK_STACK_URL:-https://github.nrlmry.navy.mil/JCSDA/spack-stack}
+SPACK_STACK_BRANCH=${SPACK_STACK_BRANCH:-ci}
 KEEP_WEEKLY_BUILD_DIR="YES"
 FIND_CMD="find"

--- a/util/weekly_build/sites/blueback.sh
+++ b/util/weekly_build/sites/blueback.sh
@@ -14,7 +14,7 @@ set +e
 module purge
 umask 0022
 
-SPACK_STACK_URL=https://github.nrlmry.navy.mil/JCSDA/spack-stack
-SPACK_STACK_BRANCH=ci
+SPACK_STACK_URL=${SPACK_STACK_URL:-https://github.nrlmry.navy.mil/JCSDA/spack-stack}
+SPACK_STACK_BRANCH=${SPACK_STACK_BRANCH:-ci}
 KEEP_WEEKLY_BUILD_DIR="YES"
 FIND_CMD="lfs find"

--- a/util/weekly_build/sites/narwhal.sh
+++ b/util/weekly_build/sites/narwhal.sh
@@ -14,7 +14,7 @@ set +e
 module purge
 umask 0022
 
-SPACK_STACK_URL=https://github.nrlmry.navy.mil/JCSDA/spack-stack
-SPACK_STACK_BRANCH=ci
+SPACK_STACK_URL=${SPACK_STACK_URL:-https://github.nrlmry.navy.mil/JCSDA/spack-stack}
+SPACK_STACK_BRANCH=${SPACK_STACK_BRANCH:-ci}
 KEEP_WEEKLY_BUILD_DIR="YES"
 FIND_CMD="lfs find"

--- a/util/weekly_build/sites/nautilus.sh
+++ b/util/weekly_build/sites/nautilus.sh
@@ -14,7 +14,7 @@ set +e
 module purge
 umask 0022
 
-SPACK_STACK_URL=https://github.nrlmry.navy.mil/JCSDA/spack-stack
-SPACK_STACK_BRANCH=ci
+SPACK_STACK_URL=${SPACK_STACK_URL:-https://github.nrlmry.navy.mil/JCSDA/spack-stack}
+SPACK_STACK_BRANCH=${SPACK_STACK_BRANCH:-ci}
 KEEP_WEEKLY_BUILD_DIR="YES"
 FIND_CMD="lfs find"


### PR DESCRIPTION
### Summary

Cherry-picked from NRL Enterprise GitHub:
1. In `util/weekly_build/sites`, make branch name and url configurable via the environment
2. Update `util/weekly_build/sites/atlantis.sh`: add `module use` for clang compiler

### Testing

Fully tested in NRL GitHub

### Applications affected

None

### Systems affected

NRL systems

### Dependencies

None

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
