### PR TITLE
Update neptune-dev template: use esmf@8.9.0b11

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -138,6 +138,8 @@ modules:
           ^esmf@8.9.0b08+debug snapshot=b08: 'esmf-8.9.0b08-debug'
           ^esmf@8.9.0b09~debug snapshot=b09: 'esmf-8.9.0b09'
           ^esmf@8.9.0b09+debug snapshot=b09: 'esmf-8.9.0b09-debug'
+          ^esmf@8.9.0b11~debug snapshot=b11: 'esmf-8.9.0b11'
+          ^esmf@8.9.0b11+debug snapshot=b11: 'esmf-8.9.0b11-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -136,6 +136,8 @@ modules:
           ^esmf@8.9.0b08+debug snapshot=b08: 'esmf-8.9.0b08-debug'
           ^esmf@8.9.0b09~debug snapshot=b09: 'esmf-8.9.0b09'
           ^esmf@8.9.0b09+debug snapshot=b09: 'esmf-8.9.0b09-debug'
+          ^esmf@8.9.0b11~debug snapshot=b11: 'esmf-8.9.0b11'
+          ^esmf@8.9.0b11+debug snapshot=b11: 'esmf-8.9.0b11-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@ packages:
   esmf:
     require:
     - '~xerces ~pnetcdf +shared +external-parallelio'
-    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0b09 snapshot=b09']
+    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0b11 snapshot=b11']
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc ^esmf@=8.9.0b09 snapshot=b09
+      - neptune-env +espc ^esmf@=8.9.0b11 snapshot=b11
       # Comment out for Cole and Tusk or any other air-gapped system:
-      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.9.0b09 snapshot=b09
+      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.9.0b11 snapshot=b11
 
   specs:
     - matrix:


### PR DESCRIPTION
### Summary

All in the title. spack PR was already merged (https://github.com/JCSDA/spack/pull/551)

### Testing

- [x] CI

### Applications affected

NEPTUNE

### Systems affected

None

### Dependencies

- [x] https://github.com/JCSDA/spack/pull/551

### Issue(s) addressed

None

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
