### PR TITLE
Fix openssl / tar for hercules / orion, openmpi prefix for ursa

### DIFF
--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -79,11 +79,10 @@ packages:
     externals:
     - spec: m4@1.4.19
       prefix: /usr
-  # Don't use, issues with py-cryptography
-  #openssl:
-  #  externals:
-  #  - spec: openssl@3.0.1
-  #    prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@3.0.1
+      prefix: /usr
   pkgconf:
     externals:
     - spec: pkgconf@1.7.3
@@ -96,10 +95,10 @@ packages:
     externals:
     - spec: subversion@1.14.1
       prefix: /usr
-  tar:
-    externals:
-    - spec: tar@1.34
-      prefix: /usr
+  #tar:
+  #  externals:
+  #  - spec: tar@1.34
+  #    prefix: /usr
   texinfo:
     externals:
     - spec: texinfo@6.7

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -90,11 +90,10 @@ packages:
     externals:
     - spec: openssh@8.7p1
       prefix: /usr
-  # Don't use, issues with py-cryptography
-  #openssl:
-  #  externals:
-  #  - spec: openssl@3.0.1
-  #    prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@3.0.1
+      prefix: /usr
   perl:
     externals:
     - spec: perl@5.32.1~cpanm+opcode+open+shared+threads
@@ -111,10 +110,10 @@ packages:
     externals:
     - spec: subversion@1.14.1
       prefix: /usr
-  tar:
-    externals:
-    - spec: tar@1.34
-      prefix: /usr
+  #tar:
+  #  externals:
+  #  - spec: tar@1.34
+  #    prefix: /usr
   wget:
     externals:
     - spec: wget@1.21.1

--- a/configs/sites/tier1/ursa/compilers.yaml
+++ b/configs/sites/tier1/ursa/compilers.yaml
@@ -31,3 +31,18 @@ compilers:
     modules: []
     environment: {}
     extra_rpaths: []
+
+- compiler:
+    spec: gcc@12.4.0
+    paths:
+      cc: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gcc
+      cxx: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/g++
+      f77: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gfortran
+      fc: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gfortran
+    flags: {}
+    operating_system: rocky9
+    target: x86_64
+    modules:
+    - gcc/12.4.0
+    environment: {}
+    extra_rpaths: []

--- a/configs/sites/tier1/ursa/packages_gcc.yaml
+++ b/configs/sites/tier1/ursa/packages_gcc.yaml
@@ -8,7 +8,7 @@ packages:
   openmpi:
     externals:
     - spec: openmpi@4.1.6~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java+legacylaunchers~lustre~memchecker~openshmem~orterunprefix+pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm
-      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-auzmzlihoo7n6g254nqkguxtzrdzkyqv
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-2dkf6t23iyw4xodxruh72yvmrhhvyoms
       modules:
       - openmpi/4.1.6
   gcc-runtime:

--- a/configs/sites/tier1/ursa/packages_gcc.yaml
+++ b/configs/sites/tier1/ursa/packages_gcc.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [gcc@11.4.1]
+    compiler:: [gcc@12.4.0]
     providers:
       mpi:: [openmpi@4.1.6]
   mpi:
@@ -13,6 +13,5 @@ packages:
       - openmpi/4.1.6
   gcc-runtime:
     externals:
-    - spec: gcc-runtime@11.4.1%gcc@11.4.1
+    - spec: gcc-runtime@12.4.0%gcc@12.4.0
       prefix: /usr
-


### PR DESCRIPTION
### Summary

- **_hercules_** and **_orion_**
  - use system `openssl`
  - build `tar`

- **_ursa_**
  - update `prefix` for `openmpi/4.1.6` for `GCC`

### Testing

Full `stack` build / `UFS WM` regression testing

### Applications affected

`UFS WM` in the sense that all regression tests now pass for `oneAPI` and `GCC`

### Systems affected

- **_hercules_**
- **_orion_**
- **_ursa_**

### Dependencies

None

### Issue(s) addressed

Fixes #1669 

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
