### PR TITLE
NRL batch install: use module purge on Cray; fix Narwhal compiler config; add debug variant for neptune-env; esmf@8.9.0b11 with NEPTUNE

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -106,7 +106,7 @@ jobs:
 
             # Concretize and check for duplicates
             spack concretize 2>&1 | tee log.concretize.gnu-11.4.0-buildcache
-            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl
+            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i neptune-env
 
             # Add and update source cache
             spack mirror add local-source file:///home/ubuntu/spack-stack/source-cache/

--- a/configs/sites/tier1/narwhal/compilers.gcc-direct.tmp
+++ b/configs/sites/tier1/narwhal/compilers.gcc-direct.tmp
@@ -1,23 +1,24 @@
 compilers::
-  - compiler:
-      spec: gcc@12.2.0
-      paths:
-        # For cylc-dev, can't use Cray wrappers (https://github.com/spack/spack/issues/48515)
-        cc: /opt/cray/pe/gcc/12.2.0/snos/bin/gcc
-        cxx: /opt/cray/pe/gcc/12.2.0/snos/bin/g++
-        f77: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
-        fc: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      modules:
-      - PrgEnv-gnu/8.4.0
-      - gcc/12.2.0
-      - cray-libsci/23.05.1.4
-      - libfabric/1.12.1.2.2.1
-      environment:
-        prepend_path:
-          LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib'
-        set:
-          CRAYPE_LINK_TYPE: 'dynamic'
-      extra_rpaths:
-      - /opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib
+- compiler:
+    spec: gcc@12.2.0
+    paths:
+      # For cylc-dev, can't use Cray wrappers (https://github.com/spack/spack/issues/48515)
+      cc: /opt/cray/pe/gcc/12.2.0/snos/bin/gcc
+      cxx: /opt/cray/pe/gcc/12.2.0/snos/bin/g++
+      f77: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
+      fc: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - PrgEnv-gnu/8.4.0
+    - gcc/12.2.0
+    - cray-libsci/23.05.1.4
+    - libfabric/1.12.1.2.2.1
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib'
+      set:
+        CRAYPE_LINK_TYPE: 'dynamic'
+    extra_rpaths:
+    - /opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib

--- a/configs/sites/tier1/narwhal/compilers.yaml
+++ b/configs/sites/tier1/narwhal/compilers.yaml
@@ -1,103 +1,107 @@
 compilers::
-  - compiler:
-      spec: intel@2021.10.0
-      paths:
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
-      flags: {}
-      operating_system: sles15
-      modules:
-      - PrgEnv-intel/8.4.0
-      - intel-classic/2023.2.0
-      - cray-libsci/23.05.1.4
-      - libfabric/1.12.1.2.2.1
-      environment:
-        prepend_path:
-          PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
-          CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
-          LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib:/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
-        set:
-          CRAYPE_LINK_TYPE: 'dynamic'
-      extra_rpaths:
-      - /opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib
-  - compiler:
-      spec: oneapi@2024.2.0
-      paths:
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
-      flags: {}
-      operating_system: sles15
-      modules:
-      - PrgEnv-intel/8.4.0
-      - intel/2024.2
-      - cray-libsci/23.05.1.4
-      - libfabric/1.12.1.2.2.1
-      environment:
-        prepend_path:
-          PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
-          CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
-          LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib:/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
-        append_path:
-          CPATH: '/opt/intel/oneapi_2024.2.0.634/compiler/2024.2/opt/compiler/include/intel64'
-        set:
-          CRAYPE_LINK_TYPE: 'dynamic'
-      extra_rpaths:
-      - /opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib
-  - compiler:
-      spec: gcc@10.3.0
-      paths:
-        # Still need Cray wrappers for most environments
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
-        # For cylc-dev, can't use Cray wrappers (https://github.com/spack/spack/issues/48515)
-        #cc: /opt/cray/pe/gcc/10.3.0/snos/bin/gcc
-        #cxx: /opt/cray/pe/gcc/10.3.0/snos/bin/g++
-        #f77: /opt/cray/pe/gcc/10.3.0/snos/bin/gfortran
-        #fc: /opt/cray/pe/gcc/10.3.0/snos/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      modules:
-      - PrgEnv-gnu/8.4.0
-      - gcc/10.3.0
-      - cray-libsci/23.05.1.4
-      - libfabric/1.12.1.2.2.1
-      environment:
-        prepend_path:
-          LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib'
-        set:
-          CRAYPE_LINK_TYPE: 'dynamic'
-      extra_rpaths:
-      - /opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib
-  - compiler:
-      spec: gcc@12.2.0
-      paths:
-        # Still need Cray wrappers for most environments
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
-        # For cylc-dev, can't use Cray wrappers (https://github.com/spack/spack/issues/48515)
-        #cc: /opt/cray/pe/gcc/12.2.0/snos/bin/gcc
-        #cxx: /opt/cray/pe/gcc/12.2.0/snos/bin/g++
-        #f77: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
-        #fc: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      modules:
-      - PrgEnv-gnu/8.4.0
-      - gcc/12.2.0
-      - cray-libsci/23.05.1.4
-      - libfabric/1.12.1.2.2.1
-      environment:
-        prepend_path:
-          LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib'
-        set:
-          CRAYPE_LINK_TYPE: 'dynamic'
-      extra_rpaths:
-      - /opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib
+- compiler:
+    spec: intel@2021.10.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - PrgEnv-intel/8.4.0
+    - intel-classic/2023.2.0
+    - cray-libsci/23.05.1.4
+    - libfabric/1.12.1.2.2.1
+    environment:
+      prepend_path:
+        PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
+        CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib:/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
+      set:
+        CRAYPE_LINK_TYPE: 'dynamic'
+    extra_rpaths:
+    - /opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib
+- compiler:
+    spec: oneapi@2024.2.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - PrgEnv-intel/8.4.0
+    - intel/2024.2
+    - cray-libsci/23.05.1.4
+    - libfabric/1.12.1.2.2.1
+    environment:
+      prepend_path:
+        PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
+        CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib:/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
+      append_path:
+        CPATH: '/opt/intel/oneapi_2024.2.0.634/compiler/2024.2/opt/compiler/include/intel64'
+      set:
+        CRAYPE_LINK_TYPE: 'dynamic'
+    extra_rpaths:
+    - /opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib
+- compiler:
+    spec: gcc@10.3.0
+    paths:
+      # Still need Cray wrappers for most environments
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+      # For cylc-dev, can't use Cray wrappers (https://github.com/spack/spack/issues/48515)
+      #cc: /opt/cray/pe/gcc/10.3.0/snos/bin/gcc
+      #cxx: /opt/cray/pe/gcc/10.3.0/snos/bin/g++
+      #f77: /opt/cray/pe/gcc/10.3.0/snos/bin/gfortran
+      #fc: /opt/cray/pe/gcc/10.3.0/snos/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - PrgEnv-gnu/8.4.0
+    - gcc/10.3.0
+    - cray-libsci/23.05.1.4
+    - libfabric/1.12.1.2.2.1
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib'
+      set:
+        CRAYPE_LINK_TYPE: 'dynamic'
+    extra_rpaths:
+    - /opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib
+- compiler:
+    spec: gcc@12.2.0
+    paths:
+      # Still need Cray wrappers for most environments
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+      # For cylc-dev, can't use Cray wrappers (https://github.com/spack/spack/issues/48515)
+      #cc: /opt/cray/pe/gcc/12.2.0/snos/bin/gcc
+      #cxx: /opt/cray/pe/gcc/12.2.0/snos/bin/g++
+      #f77: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
+      #fc: /opt/cray/pe/gcc/12.2.0/snos/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules:
+    - PrgEnv-gnu/8.4.0
+    - gcc/12.2.0
+    - cray-libsci/23.05.1.4
+    - libfabric/1.12.1.2.2.1
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib'
+      set:
+        CRAYPE_LINK_TYPE: 'dynamic'
+    extra_rpaths:
+    - /opt/cray/pe/libsci/23.05.1.4/GNU/10.3/x86_64/lib

--- a/configs/sites/tier1/nautilus/compilers.yaml
+++ b/configs/sites/tier1/nautilus/compilers.yaml
@@ -1,4 +1,4 @@
-compilers:
+compilers::
 - compiler:
     spec: aocc@4.0.0
     paths:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc ^esmf@=8.9.0b11 snapshot=b11
-      # Comment out for Cole and Tusk or any other air-gapped system:
-      - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.9.0b11 snapshot=b11
+      - neptune-env ~debug +espc ^esmf@=8.9.0b11 snapshot=b11
+      - neptune-env +debug +espc ^esmf@=8.9.0b11 snapshot=b11
+      - neptune-python-env +xnrl ^neptune-env ~debug +espc ^esmf@=8.9.0b11 snapshot=b11
 
   specs:
     - matrix:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,11 +14,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.8.0
-    - jedi-ufs-env          ^esmf@=8.6.1
+    - jedi-neptune-env      ^esmf@=8.9.0b11
+    - jedi-tools-env
+    - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.8.0
-    - neptune-python-env    ^esmf@=8.8.0
+    - neptune-env           ^esmf@=8.9.0b11
+    - neptune-python-env    ^esmf@=8.9.0b11
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)
@@ -33,9 +34,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none
-
-    # Used for building documentation
-    - jedi-tools-env
+    - esmf@=8.9.0b11 snapshot=b11
 
   specs:
   - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -17,12 +17,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.8.0
+    - jedi-neptune-env      ^esmf@=8.9.0b11
     - jedi-tools-env
-    - jedi-ufs-env          ^esmf@=8.6.1
+    - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.8.0
-    - neptune-python-env    ^esmf@=8.8.0
+    - neptune-env           ^esmf@=8.9.0b11
+    - neptune-python-env    ^esmf@=8.9.0b11
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.1-build1
     - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.1-build1
@@ -39,6 +39,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none
+    - esmf@=8.9.0b11 snapshot=b11
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5

--- a/spack-ext/repos/spack-stack/packages/neptune-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-env/package.py
@@ -20,6 +20,7 @@ class NeptuneEnv(BundlePackage):
     version("1.5.0")
 
     variant("espc", default=False, description="Build ESPC dependencies")
+    variant("debug", default=False, description="Build debug version of selected dependencies")
 
     depends_on("base-env", type="run")
 
@@ -32,7 +33,8 @@ class NeptuneEnv(BundlePackage):
     depends_on("p4est", type="run")
     depends_on("w3emc", type="run")
     depends_on("ip", type="run")
-    depends_on("esmf", type="run")
+    depends_on("esmf ~debug", type="run", when="~debug")
+    depends_on("esmf +debug", type="run", when="+debug")
     depends_on("nco", type="run")
     depends_on("mct", type="run")
 

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -313,35 +313,6 @@ fi
 
 ignore_env_exist=${SPACK_STACK_IGNORE_ENV_EXIST:-false}
 
-# For Cray systems, capture the default=current environment (loaded modules)
-# so that it can be restored between building stacks for different compilers
-case ${host} in
-  atlantis)
-    ;;
-  blueback)
-    module_snapshot=${PWD}/spack-stack.default-modules
-    module snapshot -f ${module_snapshot}
-    ;;
-  cole)
-    module_snapshot=${PWD}/spack-stack.default-modules
-    module snapshot -f ${module_snapshot}
-    ;;
-  narwhal)
-    module_snapshot=${PWD}/spack-stack.default-modules
-    module snapshot -f ${module_snapshot}
-    ;;
-  nautilus)
-    ;;
-  tusk)
-    module_snapshot=${PWD}/spack-stack.default-modules
-    module snapshot -f ${module_snapshot}
-    ;;
-  blackpearl)
-    ;;
-  bounty)
-    ;;
-esac
-
 # Loop through all compilers and templates for this host
 for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
 
@@ -415,208 +386,30 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
         module purge
         case ${compiler} in
           clang@=20.1.5)
-	    module use /gpfs/neptune/spack-stack/llvm-20.1.5/modulefiles
-	    module use /gpfs/neptune/spack-stack/openmpi-5.0.6/llvm-20.1.5/modulefiles
-	    ;;
-	esac
+            module use /gpfs/neptune/spack-stack/llvm-20.1.5/modulefiles
+            module use /gpfs/neptune/spack-stack/openmpi-5.0.6/llvm-20.1.5/modulefiles
+            ;;
+        esac
         ;;
       blueback)
-        # Check if snapshot to restore default environment exists, then restore
-        if [[ ! -e ${module_snapshot} ]]; then
-          echo "ERROR, ${module_snapshot} not found for resetting environment"
-          exit 1
-        fi
-        # Unloading modules on Blueback always throws an error:
-        # environment: line 0: unalias: mpirun: not found
-        set +e
-        echo "Please ignore warning 'environment: line 0: unalias: mpirun: not found' ..."
-        module purge
-        module restore -f ${module_snapshot}
-        set -e
         umask 0022
-        set +e
-        case ${compiler} in
-          oneapi@=2024.2.1)
-            module purge
-            module load PrgEnv-intel/8.6.0
-            module unload intel
-            module load intel-oneapi/2024.2
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.22.0
-            module unload cray-libsci
-            module load cray-libsci/25.03.0
-            ;;
-          oneapi@=2025.0.4)
-            module purge
-            module load PrgEnv-intel/8.6.0
-            module unload intel
-            module load intel-oneapi/2025.0
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.22.0
-            module unload cray-libsci
-            module load cray-libsci/25.03.0
-            ;;
-          gcc@=13.3.0)
-            module purge
-            module load PrgEnv-gnu/8.6.0
-            module unload gcc
-            # Confusing: the module is called gcc-native/13.2,
-            # but the actual version of the compiler is 13.3
-            module load gcc-native/13.2
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.22.0
-            module unload cray-libsci
-            module load cray-libsci/25.03.0
-            ;;
-          *)
-            echo "ERROR, compiler ${compiler} not configured for resetting environment"
-            exit 1
-            ;;
-        esac
-        set -e
+        module purge
         ;;
       cole)
-        # Check if snapshot to restore default environment exists, then restore
-        if [[ ! -e ${module_snapshot} ]]; then
-          echo "ERROR, ${module_snapshot} not found for resetting environment"
-          exit 1
-        fi
-        # Unloading modules on Cole always throws an error:
-        # environment: line 0: unalias: mpirun: not found
-        set +e
-        echo "Please ignore warning 'environment: line 0: unalias: mpirun: not found' ..."
-        module purge
-        module restore -f ${module_snapshot}
-        set -e
         umask 0022
-        set +e
-        case ${compiler} in
-          oneapi@=2024.2.1)
-            module purge
-            module use /p/work1/heinzell/spack-stack/oneapi-2024.2.1/modulefiles
-            module load PrgEnv-intel/8.5.0
-            module unload intel
-            module load intel/2024.2.1
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.20.1
-            module unload cray-libsci
-            module load cray-libsci/24.03.0
-            ;;
-          gcc@=12.3.0)
-            module purge
-            module load PrgEnv-gnu/8.5.0
-            module unload gcc
-            module load gcc-native/12.3
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.20.1
-            module unload cray-libsci
-            module load cray-libsci/24.03.0
-            ;;
-          *)
-            echo "ERROR, compiler ${compiler} not configured for resetting environment"
-            exit 1
-            ;;
-        esac
-        set -e
+        module purge
         ;;
       narwhal)
-        # Check if snapshot to restore default environment exists, then restore
-        if [[ ! -e ${module_snapshot} ]]; then
-          echo "ERROR, ${module_snapshot} not found for resetting environment"
-          exit 1
-        fi
-        # Unloading modules on Narwhal always throws an error:
-        # environment: line 0: unalias: mpirun: not found
-        set +e
-        echo "Please ignore warning 'environment: line 0: unalias: mpirun: not found' ..."
-        module purge
-        module restore -f ${module_snapshot}
-        set -e
         umask 0022
-        set +e
-        case ${compiler} in
-          oneapi@=2024.2.0)
-            module purge
-            module load PrgEnv-intel/8.4.0
-            module unload intel
-            module load intel/2024.2
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.12.1.2.2.1
-            module unload cray-libsci
-            module load cray-libsci/23.05.1.4
-            ;;
-          gcc@=12.2.0)
-            module purge
-            module load PrgEnv-gnu/8.4.0
-            module unload gcc
-            module load gcc/12.2.0
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.12.1.2.2.1
-            module unload cray-libsci
-            module load cray-libsci/23.05.1.4
-            ;;
-          *)
-            echo "ERROR, compiler ${compiler} not configured for resetting environment"
-            exit 1
-            ;;
-        esac
-        set -e
+        module purge
         ;;
       nautilus)
         umask 0022
         module purge
         ;;
       tusk)
-        # Check if snapshot to restore default environment exists, then restore
-        if [[ ! -e ${module_snapshot} ]]; then
-          echo "ERROR, ${module_snapshot} not found for resetting environment"
-          exit 1
-        fi
-        # Unloading modules on Tusk always throws an error:
-        # environment: line 0: unalias: mpirun: not found
-        set +e
-        echo "Please ignore warning 'environment: line 0: unalias: mpirun: not found' ..."
-        module purge
-        module restore -f ${module_snapshot}
-        set -e
         umask 0022
-        set +e
-        case ${compiler} in
-          oneapi@=2024.2.0)
-            module purge
-            module load PrgEnv-intel/8.4.0
-            module unload intel
-            module load intel/2024.2
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.12.1.2.2.1
-            module unload cray-libsci
-            module load cray-libsci/23.05.1.4
-            ;;
-          gcc@=12.1.0)
-            module purge
-            module load PrgEnv-gnu/8.4.0
-            module unload gcc
-            module load gcc/12.1.0
-            module unload cray-mpich
-            module unload craype-network-ofi
-            module load libfabric/1.12.1.2.2.1
-            module unload cray-libsci
-            module load cray-libsci/23.05.1.4
-            ;;
-          *)
-            echo "ERROR, compiler ${compiler} not configured for resetting environment"
-            exit 1
-            ;;
-        esac
-        set -e
+        module purge
         ;;
       blackpearl)
         ulimit -s unlimited
@@ -812,30 +605,6 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
   done
 
 done
-
-# Remove module snapshots for Cray systems
-case ${host} in
-  atlantis)
-    ;;
-  blueback)
-    rm -vf ${module_snapshot}
-    ;;
-  cole)
-    rm -vf ${module_snapshot}
-    ;;
-  narwhal)
-    rm -vf ${module_snapshot}
-    ;;
-  nautilus)
-    ;;
-  tusk)
-    rm -vf ${module_snapshot}
-    ;;
-  blackpearl)
-    ;;
-  bounty)
-    ;;
-esac
 
 # Repair permissions for environments if in installer mode
 if [[ "${update_build_cache}" == "false" ]]; then

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -393,15 +393,21 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
         ;;
       blueback)
         umask 0022
+        set +e
         module purge
+        set -e
         ;;
       cole)
         umask 0022
+        set +e
         module purge
+        set -e
         ;;
       narwhal)
         umask 0022
+        set +e
         module purge
+        set -e
         ;;
       nautilus)
         umask 0022
@@ -409,7 +415,9 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
         ;;
       tusk)
         umask 0022
+        set +e
         module purge
+        set -e
         ;;
       blackpearl)
         ulimit -s unlimited


### PR DESCRIPTION
### Summary

1. In NRL batch install script, use `module purge` on Cray and remove unnecessary `module snapshot` logic.
2. Fix compiler config for Narwhal: add `target=x86_64`, adjust indentation
3. Add `debug` variant for virtual environment `neptune-env` (uses `esmf+debug`), build bot variants in `neptune-dev` template
4. In `skylab-dev` and `unified-dev`, use `esmf@8.9.0b11` with NEPTUNE

### Testing

- [x] Ran `./uti/nr/batch_install.sh` on the two NRL Cray machines `Blueback` and `Narwhal`
- [x] CI

### Applications affected

NEPTUNE

### Systems affected

NRL systems

### Dependencies

None

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1674

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
