### PR TITLE
Update cylc-dev template to use py-cylc-flow@8.4.2, py-cylc-rose@1.5.1, py-cylc-uiserver@1.6.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/cylc842plusdeps
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/cylc842plusdeps
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/templates/cylc-dev/spack.yaml
+++ b/configs/templates/cylc-dev/spack.yaml
@@ -23,9 +23,9 @@ spack:
   definitions:
   - compilers: ['%gcc']
   - packages:
-    - py-cylc-flow@8.3.6
-    - py-cylc-rose@1.4.2
-    - py-cylc-uiserver@1.5.1
+    - py-cylc-flow@8.4.2
+    - py-cylc-rose@1.5.1
+    - py-cylc-uiserver@1.6.1
 
   specs:
   - matrix:


### PR DESCRIPTION
### Summary

Update `cylc-dev` template to use new versions of `cylc` components: `py-cylc-flow@8.4.2`, `py-cylc-rose@1.5.1`, `py-cylc-uiserver@1.6.1`.

### Testing

- [x] CI (Ubuntu GNU builds Cylc environment in CI)
- [x] Built `cylc-dev` environment on my dev machine with `gcc@13.3.0`, ran `cylc gui`:
    ![image](https://github.com/user-attachments/assets/31d52996-5a32-4fe3-a846-9228706bb8f5)
- [x] Tested on DOD HPC with NEPTUNE

### Applications affected

NEPTUNE

### Systems affected

None

### Dependencies

- [ ] Waiting on https://github.com/JCSDA/spack/pull/552

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1677

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
