### PR TITLE
CRTM updates to crtm@3.1.2 and crtm@2.4.1-jedi.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/crtm_updates_20250616
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/crtm_updates_20250616
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -49,6 +49,10 @@ spack:
     # py-torch in ai-env doesn't build with Intel
     - ai-env%intel
     - ai-env%oneapi
+
+    # Skip incompatible CRTM versions with oneapi
+    - crtm@2.4.0.1%oneapi
+
   packages:
     # Avoid duplicate builds of parallelio +pnetcdf and ~pnetcdf
     parallelio:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -23,8 +23,8 @@ spack:
 
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
-    - crtm@v2.4.1-jedi
-    - crtm@3.1.1-build1
+    - crtm@v2.4.1-jedi.2
+    - crtm@3.1.2
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -11,9 +11,9 @@ spack:
     - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
-    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.2
     - gmao-swell-env
-    - gsi-env ^crtm@=3.1.1-build1
+    - gsi-env ^crtm@=3.1.2
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
@@ -24,13 +24,13 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.1-build1
-    - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.1-build1
+    - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.2
+    - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.2
 
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
-    - crtm@v2.4.1-jedi
-    - crtm@3.1.1-build1
+    - crtm@v2.4.1-jedi.2
+    - crtm@3.1.2
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -60,6 +60,8 @@ spack:
     # Skip neptune-python-env with Intel Classic due to problems
     # with new versions of py-numpy, py-scipy, ...
     - neptune-python-env%intel
+    # Skip incompatible CRTM versions with oneapi
+    - crtm@2.4.0.1%oneapi
   packages:
     # Avoid duplicate builds of parallelio +pnetcdf and ~pnetcdf
     parallelio:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -12,8 +12,8 @@ spack:
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
     - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.2
-    - gmao-swell-env
-    - gsi-env ^crtm@=3.1.2
+    - gmao-swell-env                     ^crtm@=v2.4.1-jedi.2
+    - gsi-env                            ^crtm@=3.1.2
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env

--- a/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/gmao-swell-env/package.py
@@ -21,7 +21,7 @@ class GmaoSwellEnv(BundlePackage):
     depends_on("jedi-base-env", type="run")
 
     # Add CRTM 2.4.0
-    depends_on("crtm@v2.4-jedi.2", type="run")
+    depends_on("crtm", type="run")
 
     # Additional dependencies for JEDI used by swell
     depends_on("fms", type="run")


### PR DESCRIPTION
### Summary

Update CRTM versions to 3.1.2 and 2.4.1-jedi.2 in `skylab-dev` and `unified-dev` templates. This is required because earlier versions of CRTM (v2 and v3) segfault with Intel oneAPI compilers in an OpenMP parallel region. See https://github.com/JCSDA/crtm/releases/tag/v2.4.1-jedi.2, https://github.com/JCSDA/CRTMv3/releases/tag/v3.1.2, and https://github.com/JCSDA/CRTMv3/issues/231).

### Testing

Describe the testing done for this PR.

### Applications affected

Applications using `unified-dev` or `skylab-dev` templates.

### Systems affected

None

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack/pull/553

### Issue(s) addressed

Closes https://github.com/JCSDA/CRTMv3/issues/231

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
