### PR TITLE
Add neptune-env to list of allowed duplicate packages (debug and non-debug builds)

### DIFF
--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -521,7 +521,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     fi
 
     # Check for duplicate packages
-    ./util/show_duplicate_packages.py -i crtm -i crtm-fix -i esmf -i mapl
+    ./util/show_duplicate_packages.py -i crtm -i crtm-fix -i esmf -i mapl -i neptune-env
 
     # Update local source cache if requested
     if [[ "${update_source_cache}" == "true"* ]]; then

--- a/util/weekly_build/03_SetupEnv.sh
+++ b/util/weekly_build/03_SetupEnv.sh
@@ -23,7 +23,7 @@ for compiler in $COMPILERS; do
     spack config add "config:install_tree:padded_length:${PADDED_LENGTH:-200}"
     # Check for duplicates and fail before doing the "real" concretization:
     spack_wrapper log.concretize concretize --fresh
-    ${SPACK_STACK_DIR:?}/util/show_duplicate_packages.py -i crtm-fix -i crtm -i esmf -i mapl
+    ${SPACK_STACK_DIR:?}/util/show_duplicate_packages.py -i crtm-fix -i crtm -i esmf -i mapl -i neptune-env
 #   The following is not working at the moment, for seemingly a couple reasons. Therefore packages with test-only deps cannot be tested.
 #    spack concretize --force --fresh --test all | tee log.concretize_test
   done


### PR DESCRIPTION
### Summary

Add `neptune-env` to list of allowed duplicate packages in `util/nrl/batch_install.sh` and `util/weekly_build/03_SetupEnv.sh` to enable debug and release builds of it. This is necessary because of https://github.com/JCSDA/spack-stack/pull/1673. A similar change was made for the GitHub actions testing on the Ubuntu CI runner as part of #1673.

### Testing

- [x] Manual testing on NRL systems using `util/nrl/batch_install.sh`

### Applications affected

NEPTUNE

### Systems affected

NRL machines

### Dependencies

None

### Issue(s) addressed

None, this is a follow-up/bugfix for a PR merged two days ago

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
