### PR TITLE
Spack-ify JEDI packages for FALCON (neptune-jedi)

### DIFF
--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env +espc ^esmf@=8.9.0b09 snapshot=b09
-      # Comment out for Cole and Tusk or any other air-gapped system:
+      - neptune-env +espc                           ^esmf@=8.9.0b09 snapshot=b09
       - neptune-python-env +xnrl ^neptune-env +espc ^esmf@=8.9.0b09 snapshot=b09
+      - falcon-env               ^neptune-env +espc ^esmf@=8.9.0b09 snapshot=b09
 
   specs:
     - matrix:

--- a/spack-ext/repos/spack-stack/packages/falcon-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/falcon-env/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack.package import *
+
+
+class FalconEnv(BundlePackage):
+    """Development environment for NEPTUNE-JEDI (FALCON)"""
+
+    # Fake URL
+    homepage = "https://github.nrlmry.navy.mil/falcon/neptune-bundle"
+    git = "https://github.nrlmry.navy.mil/falcon/neptune-bundle.git"
+
+    maintainers("climbfuji", "sking112")
+
+    version("1.0.0")
+
+    variant("jedi", default=False, description="Build JEDI components")
+
+    depends_on("neptune-env", type="run")
+    depends_on("neptune-python-env", type="run")
+
+    depends_on("bison", type="run")
+    depends_on("blas", type="run")
+    depends_on("boost", type="run")
+    depends_on("bufr", type="run")
+    depends_on("bufr-query", type="run")
+    depends_on("ecbuild", type="run")
+    depends_on("eccodes", type="run")
+    depends_on("eckit", type="run")
+    depends_on("ecmwf-atlas", type="run")
+    depends_on("eigen", type="run")
+    depends_on("fckit", type="run")
+    depends_on("fftw-api", type="run")
+    depends_on("flex", type="run")
+    depends_on("git-lfs", type="run")
+    #depends_on("gsibec", type="run")
+    depends_on("gsl-lite", type="run")
+    #depends_on("hdf", when="+hdf4", type="run")
+    depends_on("jedi-cmake", type="run")
+    depends_on("netcdf-cxx", type="run")
+    depends_on("nccmp", type="run")
+    depends_on("ncview", type="run")
+    depends_on("nlohmann-json", type="run")
+    depends_on("nlohmann-json-schema-validator", type="run")
+    depends_on("odc", type="run")
+    #depends_on("sp", type="run", when="^ip@:4")
+    depends_on("udunits", type="run")
+
+    with when("+jedi"):
+        depends_on("oops", type="run")
+        depends_on("crtm", type="run")
+        depends_on("ioda", type="run")
+        depends_on("ropp-ufo", type="run")
+        depends_on("ufo", type="run")
+
+    # There is no need for install() since there is no code.

--- a/spack-ext/repos/spack-stack/packages/ioda/package.py
+++ b/spack-ext/repos/spack-stack/packages/ioda/package.py
@@ -1,0 +1,68 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Ioda(CMakePackage):
+    """Interface for Observation Data Access"""
+
+    homepage = "https://github.com/JCSDA/ioda"
+    git = "https://github.com/JCSDA/ioda.git"
+
+    maintainers = ["climbfuji"]
+
+    version("develop", branch="develop", no_cache=True)
+    version("2.9.0.20241216", commit="7f0c6c058b189baa6a043c917920cc78a98a094b")
+
+    variant("doc", default=False, description="Build IODA documentation")
+    # Let's always assume IODA_BUILD_LANGUAGE_FORTRAN=on.
+    # variant('fortran', default=True, description='Build the ioda Fortran interface')
+    variant("odc", default=True, description="Build ODC bindings")
+    # ioda has no explicit OpenMP calls, but header files from Eigen and oops do use openmp.
+    variant("openmp", default=True, description="Build with OpenMP support")
+    # Let's always BUILD_PYTHON_BINDINGS.
+    # variant('python', default=True, description='Build the ioda Python interface')
+
+    depends_on("boost@1.64.0:")
+    depends_on("bufr")
+    depends_on("bufr@12.0.1:", when="@2.9:")
+    # This is optional, and it needs netcdf-cxx - which versions?
+    depends_on("bufr-query", when="@2.9:")
+    depends_on("cmake", type=("build"))
+    depends_on("cmake@3.14:", type=("build"), when="@2.9:")
+    depends_on("ecbuild", type=("build"))
+    depends_on("ecbuild@3.3.2:", type=("build"), when="@2.9:")
+    depends_on("eckit")
+    depends_on("eckit@1.23.0:", when="@2.9:")
+    depends_on("eigen")
+    depends_on("fckit")
+    depends_on("fckit@0.10.1:", when="@2.9:")
+    depends_on("gsl-lite")
+    depends_on("hdf5@1.12.0: +mpi")
+    depends_on("hdf5@1.14.0: +mpi", when="@2.9:")
+    depends_on("jedi-cmake", type=("build"))
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "link", "run"))
+    depends_on("mpi")
+    depends_on("nccmp")
+    # netcdf-cxx needed for bufr-query, but which version?
+    depends_on("netcdf-cxx", when="@2.9:")
+    depends_on("odc", when="+odc")
+    depends_on("odc@1.4.6:", when="@2.9: +odc")
+    depends_on("oops+openmp", when="+openmp")
+    depends_on("oops~openmp", when="~openmp")
+    depends_on("oops@1.10", when="@2.9:")
+    depends_on("python")
+    depends_on("python@3.9:3.11", when="@2.9:")
+    depends_on("py-pybind11")
+    depends_on("py-pycodestyle")
+    depends_on("udunits")
+    depends_on("udunits@2.2.0:", when="@2.9:")
+
+    def cmake_args(self):
+        res = [
+            self.define_from_variant("ENABLE_IODA_DOC", "doc"),
+        ]
+        return res

--- a/spack-ext/repos/spack-stack/packages/oops/package.py
+++ b/spack-ext/repos/spack-stack/packages/oops/package.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Oops(CMakePackage):
+    """Object Oriented Prediction System"""
+
+    homepage = "https://github.com/JCSDA/oops"
+    git = "https://github.com/JCSDA/oops.git"
+
+    maintainers = ["climbfuji"]
+
+    version("develop", branch="develop", no_cache=True)
+    version("1.10.0.20241216", commit="58b068767ec4af2cbecfe86499b87a0d4723778f")
+
+    variant("l95", default=True, description="Build LORENZ95 toy model")
+    variant("mkl", default=False, description="Use MKL for LAPACK implementation (if available)")
+    variant("openmp", default=True, description="Build oops with OpenMP support")
+    variant("qg", default=True, description="Build QG toy model")
+    variant('gptl', default=False, description='Use GPTL profiling library (if available)')
+
+    depends_on("boost@1.64:")
+    depends_on("cmake", type=("build"))
+    depends_on("cmake@3.12:", type=("build"), when="@1.10:")
+    depends_on("ecbuild", type=("build"))
+    depends_on("ecbuild@3.3.2:", type=("build"), when="@1.10:")
+    depends_on("eckit")
+    depends_on("eckit@1.24.4:", when="@1.10:")
+    depends_on("ecmwf-atlas")
+    depends_on("ecmwf-atlas@0.35.0:", when="@1.10:")
+    depends_on("eigen")
+    depends_on("fckit")
+    depends_on("fckit@0.11.0:", when="@1.10:")
+    depends_on('gptl', when='+gptl')
+    depends_on("jedi-cmake", type=("build"))
+    depends_on("lapack", when="~mkl")
+    depends_on("mkl", when="+mkl")
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "link", "run"))
+    depends_on("mpi")
+    depends_on("netcdf-c+mpi")
+    depends_on("netcdf-fortran")
+    depends_on("nlohmann-json")
+    depends_on("nlohmann-json-schema-validator")
+
+    def cmake_args(self):
+        res = [
+            self.define_from_variant("ENABLE_LORENZ95_MODEL", "l95"),
+            self.define_from_variant("ENABLE_QG_MODEL", "qg"),
+            self.define_from_variant("ENABLE_MKL", "mkl"),
+            self.define_from_variant("OPENMP", "openmp"),
+            self.define_from_variant("ENABLE_GPTL", "gptl"),
+        ]
+        return res

--- a/spack-ext/repos/spack-stack/packages/ropp-ufo/package.py
+++ b/spack-ext/repos/spack-stack/packages/ropp-ufo/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RoppUfo(CMakePackage):
+    """Unified Forward Operator Interface for Radio Occultation Pre-processing package (ROPP)"""
+
+    # DH* TODO CHANGE BACK TO JCSDA-INTERNALq
+    homepage = "https://github.nrlmry.navy.mil/jcsda/ropp-ufo"
+    git = "https://github.nrlmry.navy.mil/jcsda/ropp-ufo.git"
+
+    maintainers = ["climbfuji"]
+
+    version("develop", branch="develop", no_cache=True)
+    # this is the ropp-submodule branch ... update once merged
+    version("11.0.20250612", commit="6a0bea80795a1bb50e5466a8f02ab6823b39d23b", submodules=True)
+
+    depends_on("cmake", type=("build"))
+    depends_on("cmake@3.12:", type=("build"), when="@11:")
+    depends_on("ecbuild", type=("build"))
+    depends_on("ecbuild@3.3.2:", type=("build"), when="@11:")
+    depends_on("jedi-cmake", type=("build"))
+    depends_on("netcdf-c")
+    depends_on("netcdf-fortran")

--- a/spack-ext/repos/spack-stack/packages/ufo/package.py
+++ b/spack-ext/repos/spack-stack/packages/ufo/package.py
@@ -1,0 +1,86 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Ufo(CMakePackage):
+    """Unified Forward Operator"""
+
+    homepage = "https://github.com/JCSDA/ufo"
+    git = "https://github.com/JCSDA/ufo.git"
+
+    maintainers = ["climbfuji"]
+
+    version("develop", branch="develop", no_cache=True)
+    version("1.10.0.20241217", commit="49ddba60c484bc5b8bac81b660e3b1b0905cd314")
+
+    variant("crtm-v2", default=True, description="Build CRTM v2 operator")
+    variant("crtm-v3", default=False, description="Build CRTM v3 operator")
+    # JCSDA-internal repository needed.
+    variant("geos-aero", default=False, description="Build GEOS-AERO AOD operator")
+    variant("gsw", default=True, description="Build marine observation operators")
+    # JCSDA-internal repository is public, but there is no "release" of the code yet.
+    variant(
+        "oasim", default=False, description="Build with Ocean Atmosphere Spectral Irradiance Model"
+    )
+    # NRL-internal repository needed.
+    variant("ropp", default=False, description="Build ROPP operator")
+    # JCSDA-internal repository needed.
+    variant("rttov", default=False, description="Build RTTOV operator")
+
+    conflicts("+crtm-v2 +crtm-v3", msg="UFO: choose either CRTM v2 or v3, not both.")
+
+    conflicts("+geos-aero", msg="UFO: GEOS-AERO to be implemented.")
+    conflicts("+oasim", msg="UFO: OASIM to be implemented.")
+    conflicts("+rttov", msg="UFO: RTTOV to be implemented.")
+
+    depends_on("boost")
+    depends_on("cmake", type=("build"))
+    depends_on("cmake@3.12:", type=("build"), when="@1.10:")
+    depends_on("ecbuild", type=("build"))
+    depends_on("ecbuild@3.3.2:", type=("build"), when="@1.10:")
+    depends_on("eckit")
+    depends_on("eckit@1.24.4:", when="@1.10:")
+    depends_on("eigen")
+    depends_on("fckit")
+    depends_on("fckit@0.11.0:", when="@1.10:")
+    depends_on("gsl-lite")
+    depends_on("ioda")
+    # DH* TODO
+    depends_on("ioda@2.9", when="@1.10:")
+    depends_on("jedi-cmake", type=("build"))
+    depends_on("mpi")
+    depends_on("netcdf-c+mpi")
+    depends_on("netcdf-fortran")
+    depends_on("oops")
+    depends_on("oops@1.10", when="@1.10")
+
+    depends_on("crtm@v2", when="+crtm-v2")
+    # DH* TODO UPDATE
+    depends_on("crtm@=v2.4.1-jedi", when="@1.10 +crtm-v2")
+    #depends_on("crtm@=v2.4.1-jedi.2", when="@1.10 +crtm-v2")
+    # *DH
+
+    depends_on("crtm@3", when="+crtm-v3")
+    # DH* TODO UPDATE
+    depends_on("crtm@=3.1.1.2", when="@1.10 +crtm-v3")
+    #depends_on("crtm@=3.1.2", when="@1.10 +crtm-v3")
+    # *DH
+
+    # depends_on('geos-aero', when='+geos-aero')
+    # depends_on('geos-aero@0.0.0', when='@1.7.0 +geos-aero')
+
+    # depends_on('oasim', when='+oasim')
+    # depends_on('oasim@0.0.0', when='@1.7.0 +oasim')
+
+    depends_on("gsw", when="+gsw")
+    depends_on("gsw@3.0.7", when="@1.7: +gsw")
+
+    depends_on('ropp-ufo', when='+ropp')
+    depends_on('ropp-ufo@11.0', when='@1.10 +ropp')
+
+    # depends_on('rttov', when='+rttov')
+    # depends_on('rttov@12.1.0', when='@1.7.0 +rttov')


### PR DESCRIPTION
# WIP IGNORE

### Summary

Describe the changes made in this PR and why they are needed.
**Much credit and thanks to @rhoneyager-tomorrow for the original PR to JCSDA/spack (now stale) https://github.com/JCSDA/spack/pull/395.**

This PR updates the JEDI packages from PR https://github.com/JCSDA/spack/pull/395 that are relevant for NEPTUNE-JEDI (aka FALCON project) and adds them to our custom repo under `spack-ext`. Building these components in spack-stack and providing them as modules allows us to reduce the NEPTUNE-JEDI build to a small number of repositories that are controlled and developed by NRL only, and - very important - allows us to implement a pure CMake build at the top level (`neptune-bundle`/`neptune-ecosystem`) without having to deal with `ecbuild`.

### Testing

- [x] Step 1. Build these components with spack-stack as part of the `neptune-dev` template using `gcc@13` on @climbfuji's development system
- [ ] Step 2.
- [ ] ...
- [ ] Step N.

### Applications affected

NEPTUNE-JEDI

### Systems affected

None directly

### Dependencies

None

### Issue(s) addressed

Link the issues addressed or resolved by this PR (use `Fixes #???` for fully resolved issues)
**MISSING**

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
