### PR TITLE
NCO/WCOSS2-related updates from release/1.9.0 to develop

### DIFF
--- a/configs/sites/tier1/wcoss2/compilers.yaml
+++ b/configs/sites/tier1/wcoss2/compilers.yaml
@@ -43,3 +43,49 @@ compilers:
         CONFIG_SITE: ''
       unset: [PYTHONPATH]
     extra_rpaths: []
+- compiler:
+    spec: oneapi@2024.2.1
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags:
+      cflags: '--gcc-toolchain=/opt/cray/pe/gcc/12.1.0/snos/'
+      fflags: '-gcc-name=/opt/cray/pe/gcc/12.1.0/snos/bin/gcc -gxx-name=/opt/cray/pe/gcc/12.1.0/snos/bin/g++'
+      cxxflags: '--gcc-toolchain=/opt/cray/pe/gcc/12.1.0/snos/'
+    operating_system: sles15
+    modules:
+    - PrgEnv-intel/8.3.3
+    - craype/2.7.17
+    - intel-oneapi/2024.2
+    - libfabric
+    environment:
+      prepend_path:
+        PATH: /opt/cray/pe/gcc/12.1.0/snos/bin
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc/12.1.0/snos/lib64
+        LIBRARY_PATH: /opt/cray/pe/gcc/12.1.0/snos/lib64
+        CPATH: /opt/cray/pe/gcc/12.1.0/snos/include
+      set:
+        # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so
+        # Automake-based builds are installed in lib64
+        # which confuses some packages.
+        CONFIG_SITE: ''
+    extra_rpaths: []
+- compiler:
+    spec: gcc@12.1.0
+    paths:
+      cc: /opt/cray/pe/gcc/12.1.0/snos/bin/gcc
+      cxx: /opt/cray/pe/gcc/12.1.0/snos/bin/g++
+      f77: /opt/cray/pe/gcc/12.1.0/snos/bin/gfortran
+      fc: /opt/cray/pe/gcc/12.1.0/snos/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    modules: []
+    environment:
+      set:
+        # OpenSUSE on WCOSS2 machines sets CONFIG_SITE so
+        # Automake-based builds are installed in lib64
+        # which confuses some packages.
+        CONFIG_SITE: ''
+    extra_rpaths: []

--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -71,6 +71,8 @@
     gsibec:
       require::
       - '@1.2.1 ~mkl'
+    icu4c:
+      require: ['%gcc']
     libffi:
       require:
       - any_of: ['@3.3']
@@ -92,10 +94,6 @@
       require:
       - any_of: ['@0.29.36']
         when: '%intel'
-    py-numpy:
-      require::
-      - '^[virtuals=lapack,blas] openblas'
-      - '@1.26'
     py-pandas:
       'require:': ~excel #   minimize dependencies
     py-scipy:
@@ -116,4 +114,4 @@
     crtm:                                                     
       require: ['@2.4.0.1 +fix']
     scotch:
-      require: ['@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']
+      require:: ['@7.0.7 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']

--- a/configs/sites/tier1/wcoss2/packages.yaml
+++ b/configs/sites/tier1/wcoss2/packages.yaml
@@ -1,14 +1,6 @@
   packages:
     #
-    ### Set compiler.
-    #
-    all:
-      prefer: ['%intel@19.1.3.304']
-      compiler:: [intel@19.1.3.304]
-      providers:
-        mpi: [cray-mpich]
-    #
-    ### Strictly set virtual package providers.
+    ### Strictly set virtual package providers (+disable mkl).
     #
     mpi:
       buildable: False
@@ -21,16 +13,8 @@
       require: openblas
     jpeg:
       require: libjpeg-turbo
-    #
-    ### External packages.
-    #
-    cray-mpich:
-      externals:
-      - spec: cray-mpich@8.1.9~wrappers
-        modules:
-        - libfabric
-        - craype-network-ofi
-        - cray-mpich/8.1.9
+    intel-oneapi-mkl:
+      buildable: false
     #
     ### Individual package settings.
     # Use `require::` to override require's from {common,site}/packages.yaml,
@@ -44,7 +28,6 @@
     cdo:
       require:
       - 'grib2=none'   # avoids eccodes/grib-api dependency
-      - '%intel'
       - any_of: ["@2.2.2"]
         when: "%intel@2022.0.2.262"
         message: "2.3.0 is the last version to use C++17"
@@ -72,13 +55,13 @@
       - snapshot=none   # make sure spack-stack doesn't accidentally give us a beta snapshot
       - '~python'
     flex:
-      require: '@2.6.4'
-    gcc-runtime:
-      require: '%gcc'
+      require: ['@2.6.4']
     gdal:
       variants: ~curl
     gettext:
-      version: ['0.19.7']
+      require:
+      - any_of: ['@0.19.7']
+        when: '%intel@19.1.3.304'
     git-lfs:
       require: '%gcc'
     glib:
@@ -88,27 +71,31 @@
     gsibec:
       require::
       - '@1.2.1 ~mkl'
-    harfbuzz:
-      require: '%gcc'
     libffi:
-      require: '@3.3'
+      require:
+      - any_of: ['@3.3']
+        when: '%intel'
     libunistring:
-      require: '@:1.0'
+      require:
+      - any_of: ['@:1.0']
+        when: '%intel'
     mapl:
       require:
       - ~pflogger ~fargparse ~extdata2g #   minimize dependencies
     netcdf-c:
       'require:': +mpi ~parallel-netcdf ~dap ~blosc ~szip build_system=autotools # disabling dap prevents network access; disabling blosc and szip reduces dependencies
     patchelf:
-      version: ['0.13.1']
+      require:
+      - any_of: ['@0.13.1']
+        when: '%intel'
     py-cython::
-      require: '@0.29.36'
+      require:
+      - any_of: ['@0.29.36']
+        when: '%intel'
     py-numpy:
       require::
       - '^[virtuals=lapack,blas] openblas'
-      - '@:1.25'
-      - any_of: ['@:1.24']
-        when: '%intel@:19'
+      - '@1.26'
     py-pandas:
       'require:': ~excel #   minimize dependencies
     py-scipy:
@@ -116,9 +103,17 @@
       - any_of: ["@1.10.1"]
         when: '%intel@:19'
     py-setuptools:
-      require: '@63.4.3' #   avoid duplicate build deps
+      require: ['@63.4.3'] #   avoid duplicate build deps
     rhash:
-      version: ['1.3.5']
+      require:
+      - any_of: ['@1.3.5']
+        when: '%intel'
     subversion:
       require:
       - ~serf +pic #   avoid serf dependency
+    zlib-ng:
+      require: ['+compat ~new_strategies']
+    crtm:                                                     
+      require: ['@2.4.0.1 +fix']
+    scotch:
+      require: ['@7.0.4 +mpi+metis~shared~threads~mpi_thread+noarch+esmumps build_system=cmake']

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -1,0 +1,27 @@
+packages:
+    #
+    ### Set compiler. 
+    # 
+    all: 
+      compiler:: [intel@19.1.3.304]
+    #
+    ### External packages.
+    # 
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@8.1.9~wrappers
+        modules:
+        - libfabric
+        - craype-network-ofi
+        - cray-mpich/8.1.9
+    #
+    ### Set GCC version.
+    #
+    gcc-runtime:
+      require: ['%gcc@10.2.0']
+    #
+    ### Package settings.
+    #
+    harfbuzz:
+      require:
+      - '%gcc'

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -1,9 +1,11 @@
 packages:
     #
-    ### Set compiler. 
+    ### Set compilers & MPI provider for metamodule generation. 
     # 
     all: 
       compiler:: [intel@19.1.3.304]
+      providers:
+        mpi:: [cray-mpich]
     #
     ### External packages.
     # 
@@ -25,6 +27,14 @@ packages:
     harfbuzz:
       require: ['%gcc']
     ecflow:
-      require:: ['@5.11.4', '+ui', '^boost %gcc', '%intel']
-    py-numpy:
-      require: ['%gcc']
+      require::
+      - '@5.11.4'
+      - '+ui'
+      - 'cflags="-no-ipo" cxxflags="-no-ipo"'
+      - '^boost %gcc'
+      - '%intel'
+    py-numpy::
+      require::
+      - '^[virtuals=lapack,blas] openblas'
+      - '@1.26'
+      - '%gcc'

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -23,5 +23,6 @@ packages:
     ### Package settings.
     #
     harfbuzz:
-      require:
-      - '%gcc'
+      require: ['%gcc']
+    ecflow:
+      require:: ['@5.11.4', '+ui', '^boost %gcc', '%intel']

--- a/configs/sites/tier1/wcoss2/packages_intel.yaml
+++ b/configs/sites/tier1/wcoss2/packages_intel.yaml
@@ -26,3 +26,5 @@ packages:
       require: ['%gcc']
     ecflow:
       require:: ['@5.11.4', '+ui', '^boost %gcc', '%intel']
+    py-numpy:
+      require: ['%gcc']

--- a/configs/sites/tier1/wcoss2/packages_oneapi.yaml
+++ b/configs/sites/tier1/wcoss2/packages_oneapi.yaml
@@ -1,0 +1,45 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.1]
+  gcc-runtime:
+    require: '%gcc@12.1.0'
+  cray-mpich:
+    externals:
+    - spec: cray-mpich@8.1.29~wrappers
+      modules:
+      - libfabric
+      - craype-network-ofi
+      - cray-mpich/8.1.29
+      - cray-pals
+  bison:
+    require: ['%gcc']
+  cairo:
+    require: ['+fc']
+  ectrans:
+    require::
+    - '@1.2.0 ~mkl +fftw'
+  elfutils:
+    require: ['@0.191']
+  gsibec:
+    require::
+    - '@1.2.1 ~mkl'
+  subversion:
+    require: ['%gcc']
+  cmake:
+    require: ['%gcc']
+  proj:
+    require: ['@9.4.1']
+  libtiff:
+    require: ['build_system=cmake']
+  icu4c:
+    require: ['%gcc']
+  ninja:
+    require: ['~re2c %gcc']
+  pixman:
+    require: ['build_system=meson']
+  apr:
+    require: ['@:1.6', '%gcc']
+  glib:
+    require: ['%gcc']
+  zlib-ng:
+    require: ['cflags="-static-intel"', 'cxxflags="-static-intel"']

--- a/configs/sites/tier1/wcoss2/packages_oneapi.yaml
+++ b/configs/sites/tier1/wcoss2/packages_oneapi.yaml
@@ -1,6 +1,11 @@
 packages:
+  #
+  ### Set compilers & MPI provider for metamodule generation.
+  #
   all:
     compiler:: [oneapi@2024.2.1]
+    providers:
+      mpi:: [cray-mpich]
   gcc-runtime:
     require: '%gcc@12.1.0'
   cray-mpich:
@@ -31,8 +36,6 @@ packages:
     require: ['@9.4.1']
   libtiff:
     require: ['build_system=cmake']
-  icu4c:
-    require: ['%gcc']
   ninja:
     require: ['~re2c %gcc']
   pixman:
@@ -43,3 +46,7 @@ packages:
     require: ['%gcc']
   zlib-ng:
     require: ['cflags="-static-intel"', 'cxxflags="-static-intel"']
+  py-numpy::
+    require::
+    - '^[virtuals=lapack,blas] openblas'
+    - '@1.26'

--- a/configs/templates/nco/spack.yaml
+++ b/configs/templates/nco/spack.yaml
@@ -19,7 +19,7 @@ spack:
   - cdo
   - cfitsio
   - cmake
-  - crtm
+  - crtm@=2.4.0.1
   - curl
   - ecflow ^boost%gcc
   - eckit

--- a/configs/templates/nco/spack.yaml
+++ b/configs/templates/nco/spack.yaml
@@ -14,14 +14,14 @@ spack:
   specs:
   - awscli
   - bacio
-  - boost %intel
+  - boost
   - bufr
   - cdo
   - cfitsio
   - cmake
   - crtm@=2.4.0.1
   - curl
-  - ecflow ^boost%gcc
+  - ecflow
   - eckit
   - ecmwf-atlas
   - eigen

--- a/configs/templates/nco/spack.yaml
+++ b/configs/templates/nco/spack.yaml
@@ -25,7 +25,7 @@ spack:
   - eckit
   - ecmwf-atlas
   - eigen
-  - esmf
+  - esmf@8.8.0
   - fckit
   - fms
   - g2
@@ -53,7 +53,7 @@ spack:
   - libxml2
   - libxrender
   - madis
-  - mapl
+  - mapl@2.53.4 ^esmf@8.8.0
   - mbedtls
   - met
   - metis

--- a/util/fetch_go_deps.py
+++ b/util/fetch_go_deps.py
@@ -5,22 +5,45 @@
 # 'spack-python' or have 'spack-python' in your $PATH. Ensure $GOMODCACHE has
 # the same value when 'spack install' is run.
 #
-# For each spec that is a GoPackage, it will attempt to use that spec's 'go'
-# dependency to execute '', but will fall back to searching $PATH if that
-# dependency has not already been installed.
+# For each spec that depends on 'go' and/or is specified by the user, it will
+# attempt to use that spec's 'go' dependency to execute 'go mod download', but
+# will fall back to searching for 'go' in $PATH if that dependency has not
+# already been installed.
 #
 # Alex Richert, Apr 2025
 #
 
 import os
+import argparse
 
 from spack.environment import active_environment
-from spack.build_systems.go import GoPackage
-from spack.package_base import PackageBase
+from spack.error import SpackError
+from spack.installer import PackageInstaller
+from spack.spec import Spec
 from spack.util.executable import Executable, which
 from llnl.util.filesystem import working_dir
-from spack.store import find
-from spack.error import SpackError
+
+parser = argparse.ArgumentParser(
+    description="Fetch Go dependencies for packages in a Spack environment"
+)
+parser.add_argument(
+    "--spec", "-s",
+    nargs="+",
+    default=[],
+    help="Additional specs for which to fetch go dependencies",
+)
+parser.add_argument(
+    "--install-go",
+    action="store_true",
+    help="Install go dependency if not already installed",
+)
+parser.add_argument(
+    "--only-listed", "-o",
+    action="store_true",
+    help="Only fetch user-provided specs (no auto-detection of go dependents)",
+)
+
+args = parser.parse_args()
 
 # Load the current environment
 env = active_environment()
@@ -31,26 +54,63 @@ gomodcache = os.getenv("GOMODCACHE")
 if not gomodcache:
     raise SpackError("GOMODCACHE must be set")
 
-# Find each spec that is a GoPackage
-#  and fetch its dependencies to $GOMODCACHE
+user_specs = []
+for spec_str in args.spec:
+    try:
+        user_specs.append(Spec(spec_str))
+    except Exception as e:
+        print(f"Warning: Invalid spec '{spec_str}': {e}")
+
+# Find each spec that depends on 'go' or is in the user-specified package list
 for spec in env.all_specs():
     if not spec.concrete:
         continue
-    pkg_cls = spec.package.__class__
-    if issubclass(pkg_cls, GoPackage):
-        print(f"Found spec with GoPackage: {spec.name}@{spec.version}/{spec.dag_hash()}")
+     
+    # Check if the package depends on go or is user specified
+    is_user_specified = False
+    for user_spec in user_specs:
+        if spec.satisfies(user_spec):
+            is_user_specified = True
+            break
+    if is_user_specified:
+        fetch_it = True
+    elif not args.only_listed:
+        fetch_it = any(dep.name == 'go' for dep in spec.dependencies())
     else:
-        continue
-    pkg = spec.package
-    pkg.do_stage()
+        fetch_it = False
+    
+    if fetch_it:
+        print(f"Processing: {spec.name}@{spec.version}/{spec.dag_hash()}")
+     
+        # Check if package actually has a go dependency
+        if 'go' not in spec:
+            print(f"  Warning: {spec.name} does not have a 'go' dependency, skipping")
+            continue
+         
+        pkg = spec.package
+        pkg.do_stage()
+     
+        # Install go dependency if requested and not already installed
+        go_dep = spec["go"]
+        dep_go_path = os.path.join(go_dep.prefix.bin, "go")
+     
+        if not which(dep_go_path) and args.install_go:
+            print(f"  Installing go dependency: {go_dep}")
+            installer = PackageInstaller([go_dep.package])
+            installer.install()
+     
+        # Now try to use the go dependency's go executable
+        if which(dep_go_path):
+            go_exe = Executable(dep_go_path)
+        elif which("go"):
+            go_exe = Executable("go")
+        else:
+            raise SpackError("Could not find 'go' executable")
 
-    dep_go_path = os.path.join(spec["go"].prefix.bin, "go")
-    if which(dep_go_path):
-        go_exe = Executable(dep_go_path)
-    elif which("go"):
-        go_exe = Executable("go")
-    else:
-        raise SpackError("Could not find 'go' executable")
-
-    with working_dir(pkg.stage.source_path):
-        go_exe("mod", "download")
+        # Execute go mod download
+        with working_dir(pkg.stage.source_path):
+            if os.path.isfile("go.mod"):
+                go_exe("mod", "download")
+                print(f"  Successfully fetched dependencies for {spec.name}")
+            else:
+                print(f"  No go.mod for {spec.name}")


### PR DESCRIPTION
### Summary

This PR brings NCO/WCOSS2-related updates from release/1.9.0 branch to develop. This includes an update to the fetch_go_deps.py script that makes it a little nicer.

### Testing

Diffed wcoss2 site dir and nco template dir against release/1.9.0 after cherry-pick's.

### Applications affected

Update to go dep fetcher; otherwise just WCOSS2/NCO.

### Systems affected

Acorn/WCOSS2

### Dependencies

none

### Issue(s) addressed

Closes https://github.com/JCSDA/spack-stack/issues/1669

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
