### PR TITLE
Bug fix for building scotch in oneAPI environments on Derecho (for release/1.9.0)

### DIFF
--- a/configs/sites/tier1/derecho/compilers.yaml
+++ b/configs/sites/tier1/derecho/compilers.yaml
@@ -37,6 +37,9 @@ compilers::
     - ncarenv/23.09
     - gcc/12.2.0
     environment:
+      prepend_path:
+        # For compiling scotch (which requires Intel MPI) with gcc in the oneapi@2024.2.1 unified environment
+        LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1/compiler/2024.2/lib'
       set:
         # https://github.com/JCSDA/spack-stack/issues/957
         FI_CXI_RX_MATCH_MODE: 'hybrid'

--- a/configs/sites/tier1/derecho/packages.yaml
+++ b/configs/sites/tier1/derecho/packages.yaml
@@ -1,8 +1,17 @@
 packages:
+# Modification of common packages
   all:
     target: [core2]
-
-### Modification of common packages
+    # Use system zlib instead of spack-built zlib-ng
+    providers:
+      zlib-api:: [zlib]
+  zlib-api:
+    buildable: False
+  zlib:
+    buildable: False
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr
   # Tell esmf that this is not a 'normal' Cray ...
   esmf:
     require:


### PR DESCRIPTION

### Summary

**For release/1.9.0**

Update Derecho site config to fix build error of scotch with GNU when preferred compiler is oneAPI. Adding the Intel compiler library directory to LD_LIBRARY_PATH is necessary, because the Intel MPI wrapper on Derecho, which is required for a software stack with preferred compiler oneAPI, doesn't add this directory. It's also safe in general, because the GNU compilers will not link to any of the libraries in that directory.

Note that this PR must be merged back to develop.

### Testing

Built unified environment with GNU and oneAPI on Derecho

### Applications affected

Applications using unified environment

### Systems affected

Derecho

### Dependencies

None

### Issue(s) addressed

Working towards https://github.com/ufs-community/ufs-weather-model/pull/2650

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
