### PR TITLE
Update esmf@8.9.0b11 to esmf@8.9.0b12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = esmf890b12
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = esmf890b12
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -140,6 +140,8 @@ modules:
           ^esmf@8.9.0b09+debug snapshot=b09: 'esmf-8.9.0b09-debug'
           ^esmf@8.9.0b11~debug snapshot=b11: 'esmf-8.9.0b11'
           ^esmf@8.9.0b11+debug snapshot=b11: 'esmf-8.9.0b11-debug'
+          ^esmf@8.9.0b12~debug snapshot=b12: 'esmf-8.9.0b12'
+          ^esmf@8.9.0b12+debug snapshot=b12: 'esmf-8.9.0b12-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -138,6 +138,8 @@ modules:
           ^esmf@8.9.0b09+debug snapshot=b09: 'esmf-8.9.0b09-debug'
           ^esmf@8.9.0b11~debug snapshot=b11: 'esmf-8.9.0b11'
           ^esmf@8.9.0b11+debug snapshot=b11: 'esmf-8.9.0b11-debug'
+          ^esmf@8.9.0b12~debug snapshot=b12: 'esmf-8.9.0b12'
+          ^esmf@8.9.0b12+debug snapshot=b12: 'esmf-8.9.0b12-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@ packages:
   esmf:
     require:
     - '~xerces ~pnetcdf +shared +external-parallelio'
-    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0b11 snapshot=b11']
+    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0b12 snapshot=b12']
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env ~debug +espc ^esmf@=8.9.0b11 snapshot=b11
-      - neptune-env +debug +espc ^esmf@=8.9.0b11 snapshot=b11
-      - neptune-python-env +xnrl ^neptune-env ~debug +espc ^esmf@=8.9.0b11 snapshot=b11
+      - neptune-env ~debug +espc ^esmf@=8.9.0b12 snapshot=b12
+      - neptune-env +debug +espc ^esmf@=8.9.0b12 snapshot=b12
+      - neptune-python-env +xnrl ^neptune-env ~debug +espc ^esmf@=8.9.0b12 snapshot=b12
 
   specs:
     - matrix:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,12 +14,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.9.0b11
+    - jedi-neptune-env      ^esmf@=8.9.0b12
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.9.0b11
-    - neptune-python-env    ^esmf@=8.9.0b11
+    - neptune-env           ^esmf@=8.9.0b12
+    - neptune-python-env    ^esmf@=8.9.0b12
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)
@@ -34,7 +34,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none
-    - esmf@=8.9.0b11 snapshot=b11
+    - esmf@=8.9.0b12 snapshot=b12
 
   specs:
   - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -17,12 +17,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.9.0b11
+    - jedi-neptune-env      ^esmf@=8.9.0b12
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.9.0b11
-    - neptune-python-env    ^esmf@=8.9.0b11
+    - neptune-env           ^esmf@=8.9.0b12
+    - neptune-python-env    ^esmf@=8.9.0b12
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.2
     - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.2
@@ -39,7 +39,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1 snapshot=none
     - esmf@=8.8.0 snapshot=none
-    - esmf@=8.9.0b11 snapshot=b11
+    - esmf@=8.9.0b12 snapshot=b12
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5


### PR DESCRIPTION
### Summary

1. Update submodule pointer for spack for the changes in https://github.com/JCSDA/spack/pull/556 (note: this also includes a recent PR to the spack submodule that added `iotaa` and `uwtools`, but neither of these two packages is used yet in any of our environments --> zero impact)
2. Update `configs/**`: replace `esmf@8.9.0b11` with `esmf@8.9.0b12`

### Testing

- [x] See https://github.com/JCSDA/spack/pull/556
- [x] CI

### Applications affected

NEPTUNE, NEPTUNE-JEDI

### Systems affected

None

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack/pull/556

### Issue(s) addressed

None created

### Checklist
- [x] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
