### PR TITLE
Update Atlantis and Nautilus: add gcc@13.4.0 stack

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -274,7 +274,7 @@ packages:
     require: '@69'
   py-setuptools-rust:
     require: '+rust_bootstrap'
-  # When making changes here, also check the tier2/blackpearl/packages.yaml
+  # When making changes here, also check the packages.yaml for atlantis, nautilus, blackpearl
   py-torch:
     require:
     - '+custom-protobuf ~mkldnn'

--- a/configs/sites/tier1/atlantis/compilers.yaml
+++ b/configs/sites/tier1/atlantis/compilers.yaml
@@ -31,7 +31,8 @@ compilers:
     modules:
     - gcc/11.2.0
     environment: {}
-    extra_rpaths: []
+    # For compiling parallel-netcdf; Bright must have removed some symbolic links require for OpenMPI 4.1.5a1 ...
+    extra_rpaths: [/gpfs/neptune/spack-stack/openmpi-4.1.5-fix-lib]
 - compiler:
     spec: gcc@13.4.0
     paths:
@@ -47,7 +48,8 @@ compilers:
     environment:
       prepend_path:
         MODULEPATH: /gpfs/neptune/spack-stack/openmpi-5.0.6/gcc-13.4.0/modulefiles:/gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
-    extra_rpaths: []
+    # For compiling parallel-netcdf; Bright must have removed some symbolic links require for OpenMPI 4.1.5a1 ...
+    extra_rpaths: [/gpfs/neptune/spack-stack/openmpi-4.1.5-fix-lib]
 - compiler:
     spec: oneapi@2024.2.1
     paths:

--- a/configs/sites/tier1/atlantis/compilers.yaml
+++ b/configs/sites/tier1/atlantis/compilers.yaml
@@ -31,7 +31,7 @@ compilers:
     modules:
     - gcc/11.2.0
     environment: {}
-    # For compiling parallel-netcdf; Bright must have removed some symbolic links require for OpenMPI 4.1.5a1 ...
+    # For compiling parallel-netcdf; Bright must have removed some symbolic links required for OpenMPI 4.1.5a1 ...
     extra_rpaths: [/gpfs/neptune/spack-stack/openmpi-4.1.5-fix-lib]
 - compiler:
     spec: gcc@13.4.0
@@ -48,7 +48,7 @@ compilers:
     environment:
       prepend_path:
         MODULEPATH: /gpfs/neptune/spack-stack/openmpi-5.0.6/gcc-13.4.0/modulefiles:/gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
-    # For compiling parallel-netcdf; Bright must have removed some symbolic links require for OpenMPI 4.1.5a1 ...
+    # For compiling parallel-netcdf; Bright must have removed some symbolic links required for OpenMPI 4.1.5a1 ...
     extra_rpaths: [/gpfs/neptune/spack-stack/openmpi-4.1.5-fix-lib]
 - compiler:
     spec: oneapi@2024.2.1

--- a/configs/sites/tier1/atlantis/compilers.yaml
+++ b/configs/sites/tier1/atlantis/compilers.yaml
@@ -33,6 +33,22 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: gcc@13.4.0
+    paths:
+      cc: /gpfs/neptune/spack-stack/gcc-13.4.0/bin/gcc
+      cxx: /gpfs/neptune/spack-stack/gcc-13.4.0/bin/g++
+      f77: /gpfs/neptune/spack-stack/gcc-13.4.0/bin/gfortran
+      fc: /gpfs/neptune/spack-stack/gcc-13.4.0/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - gcc/13.4.0
+    environment:
+      prepend_path:
+        MODULEPATH: /gpfs/neptune/spack-stack/openmpi-5.0.6/gcc-13.4.0/modulefiles:/gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
+    extra_rpaths: []
+- compiler:
     spec: oneapi@2024.2.1
     paths:
       cc: /cm/shared/apps/intel/oneapi-2024.2.1/compiler/2024.2/bin/icx

--- a/configs/sites/tier1/atlantis/packages.yaml
+++ b/configs/sites/tier1/atlantis/packages.yaml
@@ -11,6 +11,10 @@ packages:
     externals:
     - spec: zlib@1.2.11
       prefix: /usr
+  # Pin py-torch to 2.5.1 to avoid build errors with 2.6.0
+  py-torch:
+    require:
+        - '@2.5.1'
 
 # All other packages listed alphabetically
   autoconf:

--- a/configs/sites/tier1/atlantis/packages_gcc.yaml
+++ b/configs/sites/tier1/atlantis/packages_gcc.yaml
@@ -1,15 +1,15 @@
 packages:
   all:
-    compiler:: [gcc@11.2.0]
+    compiler:: [gcc@13.4.0]
     providers:
-      mpi:: [openmpi@4.1.5]
+      mpi:: [openmpi@5.0.6]
   mpi:
     buildable: False
   openmpi:
     buildable: False
     externals:
-    - spec: openmpi@4.1.5%gcc@=11.2.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
-      # Note: slurm must be loaded before openmpi on Atlantis
+    - spec: openmpi@5.0.6 %gcc@13.4.0
       modules:
       - slurm
-      - openmpi/mlnx/gcc/64/4.1.5a1
+      - openmpi/5.0.6
+

--- a/configs/sites/tier1/atlantis/packages_gcc.yaml
+++ b/configs/sites/tier1/atlantis/packages_gcc.yaml
@@ -8,7 +8,7 @@ packages:
   openmpi:
     buildable: False
     externals:
-    - spec: openmpi@4.1.5%gcc@=13.4.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+    - spec: openmpi@4.1.5 ~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm %gcc@=13.4.0
       # Note: slurm must be loaded before openmpi on Atlantis
       modules:
       - slurm

--- a/configs/sites/tier1/atlantis/packages_gcc.yaml
+++ b/configs/sites/tier1/atlantis/packages_gcc.yaml
@@ -2,14 +2,14 @@ packages:
   all:
     compiler:: [gcc@13.4.0]
     providers:
-      mpi:: [openmpi@5.0.6]
+      mpi:: [openmpi@4.1.5]
   mpi:
     buildable: False
   openmpi:
     buildable: False
     externals:
-    - spec: openmpi@5.0.6 %gcc@13.4.0
+    - spec: openmpi@4.1.5%gcc@=13.4.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm
+      # Note: slurm must be loaded before openmpi on Atlantis
       modules:
       - slurm
-      - openmpi/5.0.6
-
+      - openmpi/mlnx/gcc/64/4.1.5a1

--- a/configs/sites/tier1/nautilus/compilers.yaml
+++ b/configs/sites/tier1/nautilus/compilers.yaml
@@ -16,25 +16,6 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: intel@2021.5.0
-    paths:
-      cc: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/icc
-      cxx: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/icpc
-      f77: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
-      fc: /p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: rhel8
-    target: x86_64
-    modules:
-    - slurm
-    - intel/compiler/2022.0.2
-    environment:
-      prepend_path:
-        PATH: '/opt/rh/gcc-toolset-11/root/usr/bin'
-        CPATH: '/opt/rh/gcc-toolset-11/root/usr/include'
-        LD_LIBRARY_PATH: '/opt/scyld/slurm/lib64:/opt/scyld/slurm/lib64/slurm:/p/app/compilers/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/rh/gcc-toolset-11/root/usr/lib64:/opt/rh/gcc-toolset-11/root/usr/lib'
-    extra_rpaths: []
-- compiler:
     spec: oneapi@2024.2.1
     paths:
       cc: /p/app/projects/NEPTUNE/spack-stack/oneapi-2024.2.1/compiler/2024.2/bin/icx
@@ -98,4 +79,21 @@ compilers::
     - slurm
     - scl/gcc-toolset-11
     environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@13.4.0
+    paths:
+      cc: /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/bin/gcc
+      cxx: /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/bin/g++
+      f77: /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/bin/gfortran
+      fc: /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - slurm
+    - gcc/13.4.0
+    environment:
+      prepend_path:
+        MODULEPATH: '/p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/modulefiles'
     extra_rpaths: []

--- a/configs/sites/tier1/nautilus/packages.yaml
+++ b/configs/sites/tier1/nautilus/packages.yaml
@@ -12,6 +12,11 @@ packages:
     - spec: zlib@1.2.11
       prefix: /usr
 
+  # Pin py-torch to 2.5.1 to avoid build errors with 2.6.0
+  py-torch:
+    require:
+        - '@2.5.1'
+
 # All other packages listed alphabetically
   autoconf:
     externals:

--- a/configs/sites/tier1/nautilus/packages_gcc.yaml
+++ b/configs/sites/tier1/nautilus/packages_gcc.yaml
@@ -1,13 +1,13 @@
 packages:
   all:
-    compiler:: [gcc@11.2.1]
+    compiler:: [gcc@13.4.0]
     providers:
       mpi:: [openmpi@5.0.1]
   mpi:
     buildable: False
   openmpi:
     externals:
-    - spec: openmpi@5.0.1~cuda~java~memchecker~static~wrapper-rpath fabrics=ucx schedulers=slurm %gcc@11.2.1
+    - spec: openmpi@5.0.1~cuda~java~memchecker~static~wrapper-rpath fabrics=ucx schedulers=slurm %gcc@13.4.0
       prefix: /p/app/penguin/openmpi/5.0.1/gcc-8.5.0
       modules:
       - penguin/openmpi/5.0.1/gcc-8.5.0

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -153,12 +153,18 @@ The following is required for building new spack environments with any supported
 NAVY HPCMP Nautilus
 ------------------------------
 
-The following is required for building new spack environments with any supported compiler on this platform.
+The following is required for building new spack environments with any supported compiler on this platform. For ``gcc@13.4.0``, see the additional instructions below.
 
 .. code-block:: console
 
    umask 0022
    module purge
+
+For ``gcc@13.4.0``, further run:
+
+.. code-block:: console
+
+   module use /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/modulefiles
 
 
 .. _Preconfigured_Sites_Blueback:

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -105,7 +105,7 @@ SPACK_STACK_BATCH_HOST=${SPACK_STACK_BATCH_HOST//[0-9]/}
 
 case ${SPACK_STACK_BATCH_HOST} in
   atlantis)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.0.3" "gcc@=11.2.0" "clang@=20.1.5")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.0.3" "gcc@=13.4.0" "clang@=20.1.5")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="lmod"
     SPACK_STACK_BOOTSTRAP_MIRROR="/neptune_diagnostics/spack-stack/bootstrap-mirror"
@@ -388,6 +388,10 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
           clang@=20.1.5)
             module use /gpfs/neptune/spack-stack/llvm-20.1.5/modulefiles
             module use /gpfs/neptune/spack-stack/openmpi-5.0.6/llvm-20.1.5/modulefiles
+            ;;
+          gcc@=13.4.0)
+            module use /gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
+            module use /gpfs/neptune/spack-stack/openmpi-5.0.6/gcc-13.4.0/modulefiles
             ;;
         esac
         ;;

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -133,7 +133,7 @@ case ${SPACK_STACK_BATCH_HOST} in
     SPACK_STACK_CARGO_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/cargo-mirror"
     ;;
   nautilus)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.1.1" "gcc@=11.2.1")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.1.1" "gcc@=13.4.0")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/bootstrap-mirror"
@@ -412,6 +412,11 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       nautilus)
         umask 0022
         module purge
+        case ${compiler} in
+          gcc@=13.4.0)
+            module use /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/modulefiles
+            ;;
+        esac
         ;;
       tusk)
         umask 0022

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -391,7 +391,6 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
             ;;
           gcc@=13.4.0)
             module use /gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
-            module use /gpfs/neptune/spack-stack/openmpi-5.0.6/gcc-13.4.0/modulefiles
             ;;
         esac
         ;;


### PR DESCRIPTION
## Description

This PR updates the `gcc@11` stacks on Atlantis and Nautilus to `gcc@13.4.0`. No changes are made for the `gcc` backend for Intel oneAPI. For both systems, the existing OpenMPI installations are used (provided by the system administrators).

## Dependencies

None

## Issues addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1709

### Applications affected

None

### Systems affected

Atlantis, Nautilus

## Testing

**No CI testing necessary**

Tested with neptune-atmos on NRL systems.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
