### PR TITLE
Add NAS as tier1 site

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -172,7 +172,7 @@ packages:
     require: '@2.53 ~shared ~f2py'
     variants: '+pflogger'
   # Note: Please check the sites/tier1/nas/packages_gcc.yaml if
-  #       this is changed, as it has a custom variant compbination
+  #       this is changed, as it has a custom variant combination
   met:
     require:
     - '@12.0.1'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -171,6 +171,8 @@ packages:
   mapl:
     require: '@2.53 ~shared ~f2py'
     variants: '+pflogger'
+  # Note: Please check the sites/tier1/nas/packages_gcc.yaml if
+  #       this is changed, as it has a custom variant compbination
   met:
     require:
     - '@12.0.1'

--- a/configs/sites/tier1/nas/README.md
+++ b/configs/sites/tier1/nas/README.md
@@ -1,0 +1,49 @@
+# How to build spack-stack at NAS
+
+## Generic
+
+```
+git clone --recursive https://github.com/JCSDA/spack-stack.git -b release/1.9.0 spack-stack-1.9.1
+```
+
+## oneapi
+
+```
+cd spack-stack-1.9.1
+. setup.sh
+spack stack create env --name ue-oneapi-2024.2.0 --template unified-dev --site nas --compiler oneapi
+cd envs/ue-oneapi-2024.2.0
+spack env activate .
+spack concretize 2>&1 | tee log.concretize
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
+```
+
+NOTE: You might need to run the `spack install` command multiple times because sometimes
+it just fails. But then you run it more and more and it will eventually succeed.
+
+```
+spack module tcl refresh -y
+spack stack setup-meta-modules
+spack env deactivate
+```
+
+## gcc
+
+```
+cd spack-stack-1.9.1
+. setup.sh
+spack stack create env --name ue-gcc-12.3.0 --template unified-dev --site nas --compiler gcc
+cd envs/ue-gcc-12.3.0
+spack env activate .
+spack concretize 2>&1 | tee log.concretize
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
+```
+
+NOTE: You might need to run the `spack install` command multiple times because sometimes
+it just fails. But then you run it more and more and it will eventually succeed.
+
+```
+spack module tcl refresh -y
+spack stack setup-meta-modules
+spack env deactivate
+```

--- a/configs/sites/tier1/nas/compilers.yaml
+++ b/configs/sites/tier1/nas/compilers.yaml
@@ -55,18 +55,3 @@ compilers:
         OMPI_MCA_coll_tuned_use_dynamic_rules: 1
         OMPI_MCA_sharedfp: '^lockedfile,individual'
     extra_rpaths: []
-## Needed for Intel backend
-#- compiler:
-    #spec: gcc@=12.3.0
-    #paths:
-      #cc: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gcc
-      #cxx: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/g++
-      #f77: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gfortran
-      #fc: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gfortran
-    #flags: {}
-    #operating_system: rhel8
-    #target: x86_64
-    #modules:
-    #- comp-gcc/12.3.0-TOSS4
-    #environment: {}
-    #extra_rpaths: []

--- a/configs/sites/tier1/nas/compilers.yaml
+++ b/configs/sites/tier1/nas/compilers.yaml
@@ -1,0 +1,72 @@
+compilers:
+- compiler:
+    spec: oneapi@=2024.2.0
+    paths:
+      cc: /nobackup/gmao_SIteam/intel/oneapi/compiler/2024.2/bin/icx
+      cxx: /nobackup/gmao_SIteam/intel/oneapi/compiler/2024.2/bin/icpx
+      f77: /nobackup/gmao_SIteam/intel/oneapi/compiler/2024.2/bin/ifort
+      fc: /nobackup/gmao_SIteam/intel/oneapi/compiler/2024.2/bin/ifort
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - comp-intel/2024.2.0-ifort
+    environment:
+      prepend_path:
+        PATH: '/nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin'
+        CPATH: '/nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/include'
+        LD_LIBRARY_PATH: '/nobackup/gmao_SIteam/intel/oneapi/compiler/2024.2/lib/:/nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/lib64'
+      set:
+        MPI_COLL_REPRODUCIBLE: 'yes'
+        MPI_MEMMAP_OFF: 'yes'
+        MPI_XPMEM_ENABLED: 'yes'
+        MPI_LAUNCH_TIMEOUT: '40'
+        MPI_COMM_MAX: '1024'
+        MPI_GROUP_MAX: '1024'
+        MPI_BUFS_PER_PROC: '256'
+      unset:
+        - MPI_NUM_MEMORY_REGIONS
+        - SUPPRESS_XPMEM_TRIM_THRESH
+        - PMI_RANK
+    extra_rpaths: []
+- compiler:
+    spec: gcc@=12.3.0
+    paths:
+      cc: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gcc
+      cxx: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/g++
+      f77: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gfortran
+      fc: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules:
+    - comp-gcc/12.3.0-TOSS4
+    environment:
+      set:
+        OMPI_MCA_mpi_preconnect_all: 1
+        OMPI_MCA_coll_tuned_bcast_algorithm: 7
+        OMPI_MCA_coll_tuned_scatter_algorithm: 2
+        OMPI_MCA_coll_tuned_reduce_scatter_algorithm: 3
+        OMPI_MCA_coll_tuned_allreduce_algorithm: 3
+        OMPI_MCA_coll_tuned_allgather_algorithm: 4
+        OMPI_MCA_coll_tuned_allgatherv_algorithm: 3
+        OMPI_MCA_coll_tuned_gather_algorithm: 1
+        OMPI_MCA_coll_tuned_barrier_algorithm: 0
+        OMPI_MCA_coll_tuned_use_dynamic_rules: 1
+        OMPI_MCA_sharedfp: '^lockedfile,individual'
+    extra_rpaths: []
+## Needed for Intel backend
+#- compiler:
+    #spec: gcc@=12.3.0
+    #paths:
+      #cc: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gcc
+      #cxx: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/g++
+      #f77: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gfortran
+      #fc: /nobackup/gmao_SIteam/gcc/gcc-12.3.0-TOSS4/bin/gfortran
+    #flags: {}
+    #operating_system: rhel8
+    #target: x86_64
+    #modules:
+    #- comp-gcc/12.3.0-TOSS4
+    #environment: {}
+    #extra_rpaths: []

--- a/configs/sites/tier1/nas/config.yaml
+++ b/configs/sites/tier1/nas/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 6

--- a/configs/sites/tier1/nas/mirrors.yaml
+++ b/configs/sites/tier1/nas/mirrors.yaml
@@ -1,0 +1,18 @@
+mirrors:
+  local-source:
+    fetch:
+      url: file:///nobackup/gmao_SIteam/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null
+    push:
+      url: file:///nobackup/gmao_SIteam/spack-stack/source-cache
+      access_pair:
+      - null
+      - null
+      access_token: null
+      profile: null
+      endpoint_url: null

--- a/configs/sites/tier1/nas/modules.yaml
+++ b/configs/sites/tier1/nas/modules.yaml
@@ -1,0 +1,8 @@
+modules:
+  default:
+    enable::
+    - tcl
+    tcl:
+      include:
+      # List of packages for which we need modules that are blacklisted by default
+      - python

--- a/configs/sites/tier1/nas/packages.yaml
+++ b/configs/sites/tier1/nas/packages.yaml
@@ -8,87 +8,87 @@ packages:
   met:
     variants: +python +grib2 +graphics +lidar2nc +modis
 ### All other external packages listed alphabetically
-  wget:
+  automake:
     externals:
-    - spec: wget@1.19.5
-      prefix: /usr
-  perl:
-    externals:
-    - spec: perl@5.26.3~cpanm+opcode+open+shared+threads
-      prefix: /usr
-  sed:
-    externals:
-    - spec: sed@4.5
-      prefix: /usr
-  grep:
-    externals:
-    - spec: grep@3.1
-      prefix: /usr
-  bison:
-    externals:
-    - spec: bison@3.0.4
+    - spec: automake@1.16.1
       prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.30.125~gold~headers
       prefix: /usr
-  zlib:
+  bison:
     externals:
-    - spec: zlib@1.2.11
-      prefix: /usr
-  groff:
-    externals:
-    - spec: groff@1.22.3
-      prefix: /usr
-  flex:
-    externals:
-    - spec: flex@2.6.1+lex
-      prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.6
-      prefix: /usr
-  subversion:
-    externals:
-    - spec: subversion@1.14.1
-      prefix: /usr
-  pkgconf:
-    externals:
-    - spec: pkgconf@1.4.2
-      prefix: /usr
-  diffutils:
-    externals:
-    - spec: diffutils@3.6
-      prefix: /usr
-  m4:
-    externals:
-    - spec: m4@1.4.18
-      prefix: /usr
-  tar:
-    externals:
-    - spec: tar@1.30
-      prefix: /usr
-  findutils:
-    externals:
-    - spec: findutils@4.6.0
-      prefix: /usr
-  git:
-    externals:
-    - spec: git@2.43.5~tcltk
-      prefix: /usr
-  automake:
-    externals:
-    - spec: automake@1.16.1
+    - spec: bison@3.0.4
       prefix: /usr
   coreutils:
     externals:
     - spec: coreutils@8.30
       prefix: /usr
-  gmake:
+  diffutils:
     externals:
-    - spec: gmake@4.2.1
+    - spec: diffutils@3.6
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.6.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1+lex
       prefix: /usr
   gawk:
     externals:
     - spec: gawk@4.2.1
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.43.5~tcltk
+      prefix: /usr
+  gmake:
+    externals:
+    - spec: gmake@4.2.1
+      prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.3
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.26.3~cpanm+opcode+open+shared+threads
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.4.2
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.5
+      prefix: /usr
+  subversion:
+    externals:
+    - spec: subversion@1.14.1
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.30
+      prefix: /usr
+  wget:
+    externals:
+    - spec: wget@1.19.5
+      prefix: /usr
+  zlib:
+    externals:
+    - spec: zlib@1.2.11
       prefix: /usr

--- a/configs/sites/tier1/nas/packages.yaml
+++ b/configs/sites/tier1/nas/packages.yaml
@@ -1,0 +1,94 @@
+packages:
+  all:
+    target: [x86_64_v3]
+### Modification of common packages
+  # Problems building shared hdf-eos2 with Intel, not needed
+  hdf-eos2:
+    variants: ~shared
+  met:
+    variants: +python +grib2 +graphics +lidar2nc +modis
+### All other external packages listed alphabetically
+  wget:
+    externals:
+    - spec: wget@1.19.5
+      prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.26.3~cpanm+opcode+open+shared+threads
+      prefix: /usr
+  sed:
+    externals:
+    - spec: sed@4.5
+      prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.1
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4
+      prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.30.125~gold~headers
+      prefix: /usr
+  zlib:
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.22.3
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.1+lex
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /usr
+  subversion:
+    externals:
+    - spec: subversion@1.14.1
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.4.2
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.30
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.6.0
+      prefix: /usr
+  git:
+    externals:
+    - spec: git@2.43.5~tcltk
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.16.1
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@8.30
+      prefix: /usr
+  gmake:
+    externals:
+    - spec: gmake@4.2.1
+      prefix: /usr
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr

--- a/configs/sites/tier1/nas/packages_gcc.yaml
+++ b/configs/sites/tier1/nas/packages_gcc.yaml
@@ -31,7 +31,8 @@ packages:
           CPATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/include
           FPATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/include
           MANPATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/share/man
-  # MAT: I cannot figure out how to get hdf-eos2 to build with GCC 14 on NAS
+  # MAT: I cannot figure out how to get hdf-eos2 to build with GCC on NAS
+  #      When I try, it dies with an error trying to *patch* the code!
   #      This turns off the variants of met that need it
   met:
     variants::

--- a/configs/sites/tier1/nas/packages_gcc.yaml
+++ b/configs/sites/tier1/nas/packages_gcc.yaml
@@ -1,0 +1,38 @@
+packages:
+  all:
+    compiler:: [gcc@12.3.0]
+    providers:
+      mpi:: [openmpi@4.1.8]
+  mpi:
+    buildable: False
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.8%gcc@=12.3.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath+lustre
+        fabrics=ucx schedulers=tm
+      prefix: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0
+      environment:
+        set:
+          OPAL_PREFIX: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0
+          UCX_MAX_EAGER_LANES: 1
+          UCX_MAX_RNDV_LANES: 1
+          OMPI_MCA_pml: ucx
+          OMPI_MCA_btl: ^openib
+          OMPI_MCA_oob_tcp_listen_mode: listen_thread
+          OMPI_MCA_oob_tcp_if_include: ib0,ib1
+          OMPI_MCA_btl_tcp_if_include: ib0,ib1
+          OMPI_MCA_opal_warn_on_missing_libcuda: 0
+          UCX_IB_SUBNET_PREFIX: fec0:0000:0000:0008
+          OMPI_MCA_shmem_mmap_enable_nfs_warning: 0
+          OPENMPI: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0
+        prepend_path:
+          PATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/bin
+          LIBRARY_PATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/lib
+          LD_LIBRARY_PATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/lib
+          CPATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/include
+          FPATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/include
+          MANPATH: /nobackup/gmao_SIteam/MPI/openmpi/4.1.8/gcc-12.3.0/share/man
+  # MAT: I cannot figure out how to get hdf-eos2 to build with GCC 14 on NAS
+  #      This turns off the variants of met that need it
+  met:
+    variants::
+      - '+python +grib2 +graphics'

--- a/configs/sites/tier1/nas/packages_oneapi.yaml
+++ b/configs/sites/tier1/nas/packages_oneapi.yaml
@@ -13,8 +13,3 @@ packages:
     externals:
     - spec: intel-oneapi-mkl@2024.2.0%oneapi@2024.2.0
       prefix: /nobackup/gmao_SIteam/intel/oneapi
-  wget:
-    buildable: False
-    externals:
-    - spec: wget@1.19.5
-      prefix: /usr

--- a/configs/sites/tier1/nas/packages_oneapi.yaml
+++ b/configs/sites/tier1/nas/packages_oneapi.yaml
@@ -1,0 +1,20 @@
+packages:
+  all:
+    compiler:: [oneapi@2024.2.0,gcc@12.3.0]
+    providers:
+      mpi:: [mpt@2.30]
+  mpi:
+    buildable: False
+  mpt:
+    externals:
+    - spec: mpt@2.30%oneapi@=2024.2.0
+      prefix: /nasa/hpe/mpt/2.30_rhel810
+  intel-oneapi-mkl:
+    externals:
+    - spec: intel-oneapi-mkl@2024.2.0%oneapi@2024.2.0
+      prefix: /nobackup/gmao_SIteam/intel/oneapi
+  wget:
+    buildable: False
+    externals:
+    - spec: wget@1.19.5
+      prefix: /usr

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -50,7 +50,9 @@ Pre-configured sites (tier 1)
 | MSU                 +-----------------------+--------------------+--------------------------------------------------------+-----------------+
 |                     | Orion                 | oneAPI             | ``/apps/contrib/spack-stack/``                         | EPIC / JCSDA    |
 +---------------------+-----------------------+--------------------+--------------------------------------------------------+-----------------+
-| NASA                | Discover SCU17        | GCC, Intel         | ``/gpfsm/dswdev/jcsda/spack-stack/scu17/``             | JCSDA           |
+|                     | Discover SCU17        | GCC, Intel         | ``/gpfsm/dswdev/jcsda/spack-stack/scu17/``             | JCSDA           |
+| NASA                +-----------------------+--------------------+--------------------------------------------------------+-----------------+
+|                     | NAS                   | GCC, Intel         | ``/nobackup/gmao_SIteam/spack-stack/``                 | GMAO            |
 +---------------------+-----------------------+--------------------+--------------------------------------------------------+-----------------+
 | NCAR-Wyoming        + Derecho               | GCC, Intel         | ``/glade/work/epicufsrt/contrib/spack-stack/derecho/`` | EPIC / JCSDA    |
 +---------------------+-----------------------+--------------------+--------------------------------------------------------+-----------------+
@@ -132,6 +134,19 @@ The following is required for building new spack environments with any supported
    module purge
    module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
    module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
+
+.. _Preconfigured_Sites_NAS:
+
+------------------------------
+NASA NAS
+------------------------------
+
+The following is required for building new spack environments with any supported compiler on this platform.
+
+.. code-block:: console
+
+   module purge
+   module use /nobackup/gmao_SIteam/modulefiles
 
 .. _Preconfigured_Sites_Narwhal:
 


### PR DESCRIPTION
## Description

This PR adds NAS as a new site for spack-stack. These files were used to build spack-stack 1.9.0 with the help of @RatkoVasic-NOAA. I'm not saying they are perfect as I'm still new to this, but at least it is a good first step.

The two stacks I was able to build are `oneapi@2024.2.0` with MPT and `gcc@12.3.0` with Open MPI.

Note: For `gcc@12.3.0` I just could not build `hdf-eos2` so I had to alter the `met` variants to skip that. The issue was weird, like it couldn't `patch` a file.

## Dependencies

None

## Issues addressed

Closes #1656 

### Applications affected

None, though `met` with `gcc@12.3.0` is built in a non-spack-stack standard variant combo

### Systems affected

Adds NAS. Shouldn't affect anything else.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
