### PR TITLE
Bug fixes for weekly builds on Atlantis and Nautilus in util/weekly_build/sites/

### DIFF
--- a/util/weekly_build/sites/atlantis.sh
+++ b/util/weekly_build/sites/atlantis.sh
@@ -17,6 +17,8 @@ umask 0022
 if [[ "${COMPILERS}" == "clang@=20.1.5" ]]; then
   module use /gpfs/neptune/spack-stack/llvm-20.1.5/modulefiles
   module use /gpfs/neptune/spack-stack/openmpi-5.0.6/llvm-20.1.5/modulefiles
+elif [[ "${COMPILERS}" == "gcc@=13.4.0" ]]; then
+  module use /gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
 fi
 
 SPACK_STACK_URL=${SPACK_STACK_URL:-https://github.nrlmry.navy.mil/JCSDA/spack-stack}

--- a/util/weekly_build/sites/nautilus.sh
+++ b/util/weekly_build/sites/nautilus.sh
@@ -14,6 +14,10 @@ set +e
 module purge
 umask 0022
 
+if [[ "${COMPILERS}" == "gcc@=13.4.0" ]]; then
+  module use /p/app/projects/NEPTUNE/spack-stack/gcc-13.4.0/modulefiles
+fi
+
 SPACK_STACK_URL=${SPACK_STACK_URL:-https://github.nrlmry.navy.mil/JCSDA/spack-stack}
 SPACK_STACK_BRANCH=${SPACK_STACK_BRANCH:-ci}
 KEEP_WEEKLY_BUILD_DIR="YES"


### PR DESCRIPTION
## Description

Bug fixes for weekly builds on Atlantis and Nautilus in util/weekly_build/sites/atlantis.sh and util/weekly_build/sites/nautilus.sh: add missing `module use` statements for `gcc@13.4.0`. Follow-up to https://github.com/JCSDA/spack-stack/pull/1707

This will be the last patch for the weekly build scripts. Next week, I will update the automated spack-stack builds to use `nrl_batch_install.sh` instead.

## Dependencies

None

## Issues addressed

Fixes failing automated CI builds in NRL GitHub Enterprise fork of spack-stack

### Applications affected

None

### Systems affected

Atlantis, Nautilus

## Testing

**No CI testing necessary**

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Manual testing on Atlantis and Nautilus

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
