### PR TITLE
Bump w3emc to 2.11.0, fix bug on Blueback to use correct Fortran compiler with oneapi@2024.2

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -307,7 +307,7 @@ packages:
     require: '@10.0.10'
   # Need extradeps for grib-utils, enable by default to avoid duplicate packages
   w3emc:
-    require: '@2.12.0 precision=4,d,8 +extradeps'
+    require: '@2.12.0 precision=4,d,8'
   w3nco:
     require: '@2.4.1'
   # See macOS site config for wgrib2 version/variant overrides

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -307,7 +307,7 @@ packages:
     require: '@10.0.10'
   # Need extradeps for grib-utils, enable by default to avoid duplicate packages
   w3emc:
-    require: '@2.10.0 precision=4,d,8 +extradeps'
+    require: '@2.12.0 precision=4,d,8 +extradeps'
   w3nco:
     require: '@2.4.1'
   # See macOS site config for wgrib2 version/variant overrides

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -307,7 +307,12 @@ packages:
     require: '@10.0.10'
   # Need extradeps for grib-utils, which ties us to w3ecm@:2.11
   w3emc:
-    require: '@2.11.0 precision=4,d,8 +extradeps'
+    require:
+    - '@:2.11.0'
+    - 'precision=4,d,8 +extradeps'
+    # https://github.com/NOAA-EMC/NCEPLIBS-w3emc/issues/246
+    - one_of: ['@2.10.0']
+      when: "%clang"
   w3nco:
     require: '@2.4.1'
   # See macOS site config for wgrib2 version/variant overrides

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -305,9 +305,9 @@ packages:
   # Note - we can remove upp from stack at some point?
   upp:
     require: '@10.0.10'
-  # Need extradeps for grib-utils, enable by default to avoid duplicate packages
+  # Need extradeps for grib-utils, which ties us to w3ecm@:2.11
   w3emc:
-    require: '@2.12.0 precision=4,d,8'
+    require: '@2.11.0 precision=4,d,8 +extradeps'
   w3nco:
     require: '@2.4.1'
   # See macOS site config for wgrib2 version/variant overrides

--- a/configs/containers/specs/jedi-ci.yaml
+++ b/configs/containers/specs/jedi-ci.yaml
@@ -45,7 +45,7 @@
     py-shapely,
     py-xarray,
     udunits@2.2.28,
-    w3emc@2.10.0,
+    w3emc,
     nco,
     esmf@8.8.0,
     mapl@2.53.4,

--- a/configs/sites/tier1/blueback/compilers.yaml
+++ b/configs/sites/tier1/blueback/compilers.yaml
@@ -42,6 +42,8 @@ compilers::
       set:
         CONFIG_SITE: ''
         CRAY_CPU_TARGET: x86-genoa
+        # Force ifort not ifx
+        INTEL_COMPILER_TYPE: 'RECOMMENDED'
     extra_rpaths: []
 - compiler:
     spec: oneapi@=2025.0.4

--- a/configs/sites/tier1/narwhal/compilers.yaml
+++ b/configs/sites/tier1/narwhal/compilers.yaml
@@ -1,29 +1,5 @@
 compilers::
 - compiler:
-    spec: intel@2021.10.0
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules:
-    - PrgEnv-intel/8.4.0
-    - intel-classic/2023.2.0
-    - cray-libsci/23.05.1.4
-    - libfabric/1.12.1.2.2.1
-    environment:
-      prepend_path:
-        PATH: '/opt/cray/pe/gcc/10.3.0/snos/bin'
-        CPATH: '/opt/cray/pe/gcc/10.3.0/snos/include'
-        LD_LIBRARY_PATH: '/opt/cray/libfabric/1.12.1.2.2.1/lib64:/opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib:/opt/cray/pe/gcc/10.3.0/snos/lib:/opt/cray/pe/gcc/10.3.0/snos/lib64'
-      set:
-        CRAYPE_LINK_TYPE: 'dynamic'
-    extra_rpaths:
-    - /opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib
-- compiler:
     spec: oneapi@2024.2.0
     paths:
       cc: cc
@@ -47,6 +23,8 @@ compilers::
         CPATH: '/opt/intel/oneapi_2024.2.0.634/compiler/2024.2/opt/compiler/include/intel64'
       set:
         CRAYPE_LINK_TYPE: 'dynamic'
+        # Force ifort not ifx
+        INTEL_COMPILER_TYPE: 'RECOMMENDED'
     extra_rpaths:
     - /opt/cray/pe/libsci/23.05.1.4/INTEL/2022.2/x86_64/lib
 - compiler:


### PR DESCRIPTION
## Description

Bump w3emc to 2.11.0 because 2.10.0 is incompatible with ifx, and 2.12.0 is not backward compatible (breaks grib-utils).

On Blueback, set environment variable `INTEL_COMPILER_TYPE` in oneapi@2024.2 compiler config to use the correct Fortran compiler (ifort instead of ifx). The same setting is added for Narwhal as a precaution, but strictly speaking it is not necessary at this point (it may become necessary when Narwhal is updated to match Blueback). While at it, I also removed the deprecated Intel Classic compiler config for Narwhal (no longer used).

## Dependencies

None

## Issues addressed

Closes #1716 

### Applications affected

All using unified environment or neptune environment.

### Systems affected

Blueback

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built neptune environment on Blueback with oneapi@2024.2.1 and verified that w3emc@2.11.0 was built correctly (with ifx and with the correct flags for the `_d` library)

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
