### PR TITLE
Avoid using rust-boostrap, switch to zlib instead of zlib-ng as provider for zlib-api

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -7,7 +7,7 @@ packages:
       jpeg: [libjpeg-turbo]
       pkgconfig: [pkg-config]
       yacc: [bison]
-      zlib-api: [zlib-ng]
+      zlib-api: [zlib]
   #
   awscli-v2:
     require: '~examples'
@@ -231,11 +231,6 @@ packages:
     require: '@3.11.11 ~crypt'
   py-cartopy:
     require: '+plotting'
-  # Avoid full rust dependency: version 43+ requires py-maturin
-  # DH* 20250214 No longer needed?
-  # https://github.com/JCSDA/spack-stack/pull/1519
-  py-cryptography:
-    require: '@:42 +rust_bootstrap'
   # Pin py-cython to avoid duplicate packages
   py-cython:
     require: '@3'
@@ -254,8 +249,6 @@ packages:
   # https://github.com/JCSDA/spack-stack/issues/1276
   py-matplotlib:
     require: '@3.7.4'
-  py-maturin:
-    require: '+rust_bootstrap'
   # https://github.com/Unidata/netcdf4-python/issues/1389
   # https://github.com/Unidata/netcdf4-python/issues/1389#issuecomment-2599760051
   py-netcdf4:
@@ -264,16 +257,12 @@ packages:
   py-numpy:
     require:
     - '@1.26'
-  py-rpds-py:
-    require: '+rust_bootstrap'
   # To avoid duplicate packages
   py-ruamel-yaml:
     require: '@0.17.16'
   # Pin the py-setuptools version to avoid duplicate Python packages
   py-setuptools:
     require: '@69'
-  py-setuptools-rust:
-    require: '+rust_bootstrap'
   # When making changes here, also check the packages.yaml for atlantis, nautilus, blackpearl
   py-torch:
     require:


### PR DESCRIPTION
## Description

In `configs/common/packages.yaml`: avoid using `rust-boostrap`, switch to `zlib` instead of `zlib-ng` as provider for `zlib-api`

Reasons:
1. `rust-bootstrap` was used as a workaround while we had issues downloading and building dependencies with the real `rust` packages. Now, we have tools to create `cargo` mirrors that can be used by spack to install on air-gapped systems. Further, there is much criticism of the `rust-bootstrap` package itself, because it is maintained manually and not necessarily kept in sync with `rust`. Lastly, removing the `rust-bootstrap` variants here and the corresponding modifications we made in the spack package recipes allows us to minimize differences in the spack packages between `spack-stack-dev` and upstream.
2. `zlib-ng` sounded promising at first, but the reality is a little different. For many reasons, one of them being Intel library linking issues, we had to resort to using the native `zlib` package instead, overwrite the `zlib-api` provider in the site configs, and mark the external `zlib` packages as `buildable: false`. We did this for several RDHPCS and all NRL systems. It seems safer to make the default `zlib` and leave it to the site maintainers whether `zlib` should be an external package, built by spack, or whether the `zlib-api` definition should be overwritten on a per-site basis config with another provider, if so desired.

For now, the site configs can remain as they are. We need to update them anyway when we move to spack v1.0.0 in the next few weeks, at which point we can remove the redundant `zlib-api` redefinitions in the site configs.

## Dependencies

None

## Issues addressed

See detailed description above

### Applications affected

All (but in practice most of the critical systems already use `zlib` instead of `zlib-ng`).

### Systems affected

All

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] `zlib` change tested every day for the sites that already use it

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
