### PR TITLE
Update Derecho site config

### DIFF
--- a/configs/sites/tier1/derecho/compilers.yaml
+++ b/configs/sites/tier1/derecho/compilers.yaml
@@ -2,21 +2,21 @@ compilers::
 - compiler:
     spec: oneapi@2024.2.1
     paths:
-      cc: /glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1/compiler/2024.2/bin/icx
-      cxx: /glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1/compiler/2024.2/bin/icpx
-      f77: /glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1/compiler/2024.2/bin/ifort
-      fc: /glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1/compiler/2024.2/bin/ifort
+      cc: /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-compilers/2024.2.1/gcc/12.4.0/iq3b/compiler/2024.2/bin/icx
+      cxx: /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-compilers/2024.2.1/gcc/12.4.0/iq3b/compiler/2024.2/bin/icpx
+      f77: /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-compilers/2024.2.1/gcc/12.4.0/iq3b/compiler/2024.2/bin/ifort
+      fc: /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-compilers/2024.2.1/gcc/12.4.0/iq3b/compiler/2024.2/bin/ifort
     flags: {}
     operating_system: sles15
     target: x86_64
     modules:
-    - ncarenv/23.09
-    - intel-oneapi/2024.2.1
+    - ncarenv/24.12
+    - intel/2024.2.1
     environment:
       prepend_path:
-        PATH: '/opt/cray/pe/gcc/12.2.0/snos/bin'
-        CPATH: '/opt/cray/pe/gcc/12.2.0/snos/include'
-        LD_LIBRARY_PATH: '/opt/cray/pe/gcc/12.2.0/snos/lib:/opt/cray/pe/gcc/12.2.0/snos/lib64'
+        PATH: '/glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/bin'
+        CPATH: '/glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/include'
+        LD_LIBRARY_PATH: '/glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/lib:/glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/lib64'
       set:
         # https://github.com/JCSDA/spack-stack/issues/957
         FI_CXI_RX_MATCH_MODE: 'hybrid'
@@ -24,22 +24,22 @@ compilers::
         I_MPI_EXTRA_FILESYSTEM: 'ON'
     extra_rpaths: []
 - compiler:
-    spec: gcc@12.2.0
+    spec: gcc@12.4.0
     paths:
-      cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
-      cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
-      f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-      fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran
+      cc: /glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/bin/gcc
+      cxx: /glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/bin/g++
+      f77: /glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/bin/gfortran
+      fc: /glade/u/apps/casper/24.12/spack/opt/spack/gcc/12.4.0/5b5c/bin/gfortran
     flags: {}
     operating_system: sles15
     target: x86_64
     modules:
-    - ncarenv/23.09
-    - gcc/12.2.0
+    - ncarenv/24.12
+    - gcc/12.4.0
     environment:
       prepend_path:
         # For compiling scotch (which requires Intel MPI) with gcc in the oneapi@2024.2.1 unified environment
-        LD_LIBRARY_PATH: '/glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1/compiler/2024.2/lib'
+        LD_LIBRARY_PATH: '/glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-compilers/2024.2.1/gcc/12.4.0/iq3b/compiler/2024.2/lib'
       set:
         # https://github.com/JCSDA/spack-stack/issues/957
         FI_CXI_RX_MATCH_MODE: 'hybrid'

--- a/configs/sites/tier1/derecho/packages.yaml
+++ b/configs/sites/tier1/derecho/packages.yaml
@@ -34,10 +34,6 @@ packages:
     externals:
     - spec: coreutils@8.32
       prefix: /usr
-  curl:
-    externals:
-    - spec: curl@8.1.2+gssapi+ldap+nghttp2
-      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/curl/8.1.2/gcc/7.5.0/uq6y
   cvs:
     externals:
     - spec: cvs@1.12.13
@@ -56,14 +52,12 @@ packages:
       prefix: /usr
   git:
     externals:
-    - spec: git@2.41.0+tcltk
-      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/git/2.41.0/gcc/7.5.0/jgni
-    - spec: git@2.35.3+tcltk
-      prefix: /usr
+    - spec: git@2.47.0
+      prefix: /glade/u/apps/casper/24.12/spack/opt/spack/git/2.47.0/gcc/12.4.0/cn62
   git-lfs:
     externals:
-    - spec: git-lfs@3.3.0
-      prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/git-lfs/3.3.0/gcc/7.5.0/u3kh
+    - spec: git-lfs@3.5.1
+      prefix: /glade/u/apps/casper/24.12/spack/opt/spack/git-lfs/3.5.1/gcc/12.4.0/aivb
   gmake:
     externals:
     - spec: gmake@4.2.1
@@ -107,6 +101,9 @@ packages:
     buildable: False
     externals:
     - spec: qt@5.14.2
+      # Newer versions don't work, some headers are missing
+      #prefix: /glade/u/apps/casper/24.12/spack/opt/spack/qt/5.14.2/gcc/12.4.0/6suc
+      #prefix: /glade/u/apps/casper/24.12/spack/opt/spack/qt/5.14.2/gcc/12.4.0/axtw
       prefix: /glade/u/apps/derecho/23.09/spack/opt/spack/qt/5.14.2/gcc/7.5.0/eqcj
   sed:
     externals:

--- a/configs/sites/tier1/derecho/packages_gcc.yaml
+++ b/configs/sites/tier1/derecho/packages_gcc.yaml
@@ -1,15 +1,16 @@
 packages:
   all:
-    compiler:: [gcc@12.2.0]
+    compiler:: [gcc@12.4.0]
     providers:
-      mpi:: [cray-mpich@8.1.27]
+      mpi:: [cray-mpich@8.1.29]
   mpi:
     buildable: False
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.27%gcc@12.2.0 +wrappers
+    - spec: cray-mpich@8.1.29 +wrappers %gcc@12.4.0
+      prefix: /opt/cray/pe/mpich/8.1.29/ofi/gnu/12.3
       modules:
-      - craype/2.7.20
-      - cray-mpich/8.1.27
+      - ncarenv/24.12
+      - craype/2.7.31
+      - cray-mpich/8.1.29
       - libfabric/1.15.2.0
-      - cray-pals/1.2.11

--- a/configs/sites/tier1/derecho/packages_gcc.yaml
+++ b/configs/sites/tier1/derecho/packages_gcc.yaml
@@ -14,3 +14,5 @@ packages:
       - craype/2.7.31
       - cray-mpich/8.1.29
       - libfabric/1.15.2.0
+      - cray-pals/1.2.11
+

--- a/configs/sites/tier1/derecho/packages_oneapi.yaml
+++ b/configs/sites/tier1/derecho/packages_oneapi.yaml
@@ -1,25 +1,21 @@
 packages:
   all:
-    compiler:: [oneapi@2024.2.1, gcc@12.2.0]
+    compiler:: [oneapi@2024.2.1, gcc@12.4.0]
     providers:
       mpi:: [cray-mpich@8.1.29]
   mpi:
     buildable: False
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.29%oneapi@2024.2.1 +wrappers
+    - spec: cray-mpich@8.1.29 +wrappers %oneapi@2024.2.1
+      prefix: /opt/cray/pe/mpich/8.1.29/ofi/intel/2022.1
       modules:
-      - craype/2.7.20
+      - ncarenv/24.12
+      - craype/2.7.31
       - cray-mpich/8.1.29
       - libfabric/1.15.2.0
-      - cray-pals/1.2.11
   intel-oneapi-runtime:
     buildable: False
     externals:
     - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
-      prefix: /glade/u/apps/common/23.08/spack/opt/spack/intel-oneapi-compilers/2024.2.1
-  intel-oneapi-mkl:
-    # No intel-oneapi-mkl installed on Derecho, install via spack.
-    # Prefer the version that Intel releases with the above compiler
-    prefer:
-    - '@2024.2'
+      prefix: /glade/u/apps/casper/24.12/spack/opt/spack/intel-oneapi-compilers/2024.2.1/gcc/12.4.0/iq3b/compiler/2024.2

--- a/configs/sites/tier1/derecho/packages_oneapi.yaml
+++ b/configs/sites/tier1/derecho/packages_oneapi.yaml
@@ -14,6 +14,7 @@ packages:
       - craype/2.7.31
       - cray-mpich/8.1.29
       - libfabric/1.15.2.0
+      - cray-pals/1.2.11
   intel-oneapi-runtime:
     buildable: False
     externals:

--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -191,12 +191,7 @@ The following is required for building new spack environments with any supported
 
 .. code-block:: console
 
-   module purge
-   # ignore that the sticky module ncarenv/... is not unloaded
-   export LMOD_TMOD_FIND_FIRST=yes
-   module load ncarenv/23.09
-   module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
-
+   module --force purge
 
 .. _Preconfigured_Sites_Acorn:
 


### PR DESCRIPTION
## Description

Update `configs/sites/tier1/derecho/*` and `doc/source/PreConfiguredSites.rst` to use the current default NCAR environment and compilers on Derecho.

## Dependencies

None

## Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1728

### Applications affected

None

### Systems affected

Derecho

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built unified environment with both compilers. Ran mpas-jedi variational tests for #1588 

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
