### PR TITLE
Acorn: use gettext%gcc

### DIFF
--- a/configs/sites/tier1/acorn/packages_intel.yaml
+++ b/configs/sites/tier1/acorn/packages_intel.yaml
@@ -44,6 +44,8 @@
       - any_of: ["@2.25.0"]
         when: "%intel@19.1.3.304"
         message: "2.25.0 is the last version to use C++11 (as opposed to C++17)"
+    gettext:
+      require: ['%gcc', '@0.21.1']
     py-scipy:
       require:
       - any_of: ["@1.10.1"]


### PR DESCRIPTION
## Description

The head of develop ends up requiring a more recent gettext than what intel 19 can build, so this PR requires gettext%gcc on Acorn.

### Dependencies

none

### Issues addressed

none

### Applications affected

UFSWM, GW, GSI

### Systems affected

Acorn

## Testing

tested manually

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
