### PR TITLE
Update GCC stack on Atlantis: use openmpi@4.1.8 compiled with gcc@13.4.0

### DIFF
--- a/configs/sites/tier1/atlantis/packages_gcc.yaml
+++ b/configs/sites/tier1/atlantis/packages_gcc.yaml
@@ -2,14 +2,14 @@ packages:
   all:
     compiler:: [gcc@13.4.0]
     providers:
-      mpi:: [openmpi@4.1.5]
+      mpi:: [openmpi@4.1.8]
   mpi:
     buildable: False
   openmpi:
     buildable: False
     externals:
-    - spec: openmpi@4.1.5 ~cuda~cxx~cxx_exceptions~java~memchecker+pmi~static~wrapper-rpath fabrics=ucx schedulers=slurm %gcc@=13.4.0
+    - spec: openmpi@4.1.8 %gcc@=13.4.0
       # Note: slurm must be loaded before openmpi on Atlantis
       modules:
       - slurm
-      - openmpi/mlnx/gcc/64/4.1.5a1
+      - openmpi/4.1.8

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -391,6 +391,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
             ;;
           gcc@=13.4.0)
             module use /gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
+	    module use /gpfs/neptune/spack-stack/openmpi-4.1.8/gcc-13.4.0/modulefiles
             ;;
         esac
         ;;

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -391,7 +391,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
             ;;
           gcc@=13.4.0)
             module use /gpfs/neptune/spack-stack/gcc-13.4.0/modulefiles
-	    module use /gpfs/neptune/spack-stack/openmpi-4.1.8/gcc-13.4.0/modulefiles
+            module use /gpfs/neptune/spack-stack/openmpi-4.1.8/gcc-13.4.0/modulefiles
             ;;
         esac
         ;;


### PR DESCRIPTION
## Description

Update GCC stack on Atlantis: use openmpi@4.1.8 compiled with gcc@13.4.0.

### Dependencies

None

### Issues addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1709

### Applications affected

None

### Systems affected

Atlantis

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built spack-stack on Atlantis with GNU, built NEPTUNE against this stack, ran all regression tests

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
