### PR TITLE
Bug fix for Atlantis site config (packages_gcc.yaml)

### DIFF
--- a/configs/sites/tier1/atlantis/packages_gcc.yaml
+++ b/configs/sites/tier1/atlantis/packages_gcc.yaml
@@ -9,7 +9,6 @@ packages:
     buildable: False
     externals:
     - spec: openmpi@4.1.8 %gcc@=13.4.0
-      # Note: slurm must be loaded before openmpi on Atlantis
+      prefix: /gpfs/neptune/spack-stack/openmpi-4.1.8/gcc-13.4.0
       modules:
-      - slurm
       - openmpi/4.1.8


### PR DESCRIPTION
## Description

Bug fix for Atlantis site config (packages_gcc.yaml). Set prefix and load only the modules that are needed for the new openmpi@4.1.8. Tested on Atlantis (built neptune-dev template).

### Dependencies

None

### Issues addressed

Related to #1709 

### Applications affected

None

### Systems affected

Atlantis

## Testing

**No CI testing needed**

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
