### PR TITLE
For clang and apple-clang, turn off OpenMP variant for package ip

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -148,7 +148,8 @@ packages:
   hdf-eos2:
     require: '@2.20v1.00'
   ip:
-    require: '@5.4.0 precision=4,d,8'
+    require:
+    - '@5.4.0 precision=4,d,8'
   ip2:
     require: '@1.1.2'
   jasper:

--- a/configs/common/packages_apple-clang.yaml
+++ b/configs/common/packages_apple-clang.yaml
@@ -10,6 +10,9 @@ packages:
   gsibec:
     require:
     - '~mkl'
+  ip:
+    require:
+    - '~openmp'
   py-numpy:
     require:
     - '^openblas'

--- a/configs/common/packages_clang.yaml
+++ b/configs/common/packages_clang.yaml
@@ -10,6 +10,9 @@ packages:
   gsibec:
     require:
     - '~mkl'
+  ip:
+    require:
+    - '~openmp'
   py-numpy:
     require:
     - '^openblas'


### PR DESCRIPTION
## Description

For clang and apple-clang, turn off OpenMP variant for package ip.

All in the title. OpenMP support for LLVM clang is experimental, and on macOS we often had issues with OpenMP-enabled packages.

### Dependencies

None

### Issues addressed

Building `spack-stack@develop` failed on NRL's Atlantis with `clang@20.1.5`, after adding the `~openmp` variant for `ip`, it worked.

### Applications affected

None

### Systems affected

All using LLVM clang and Apple clang

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] See "Issues addressed above"

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
