### PR TITLE
wgrib2: support variants ipolates and netcdf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = release/1.9.0
+  url = https://github.com/rickgrubin-noaa/spack
+  branch = wgrib2-netcdf
+  #url = https://github.com/jcsda/spack
+  #branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/rickgrubin-noaa/spack
-  branch = wgrib2-netcdf
-  #url = https://github.com/jcsda/spack
-  #branch = release/1.9.0
+  url = https://github.com/jcsda/spack
+  branch = release/1.9.0
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -293,7 +293,7 @@ packages:
   # See macOS site config for wgrib2 version/variant overrides
   wgrib2:
     require:
-    - '@3.6.0'
+    - '@3.6.0 +ipolates +netcdf'
   wrf-io:
     require: '@1.2.0'
   zstd:


### PR DESCRIPTION
## Description

Add support for variants `ipolates` and `netcdf` for `release/1.9.0` (and expected tag `1.9.3`) for `wgrib2@3.6.0`

Will require reverting changes to `.gitmodules` prior to merging.

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/561

### Issues addressed

Resolves #1685 
Resolves #1711 

### Applications affected

Any application that builds with / links against `wgrib2@3.6.0` with variants `ipolates` and / or `netcdf`

### Systems affected

Any system that specs `wgrib2@3.6.0` with variants `ipolates` and / or `netcdf`

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] see attached files: spack.yaml, log.concretize, and excerpted log.install

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] All necessary updates to the spack-stack wiki will be made when this PR is merged
