### PR TITLE
Update met and metplus versions

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -168,7 +168,8 @@ packages:
     - '+python'
     - '+grib2'
   metplus:
-    require: '@6.0.0'
+    require:
+    - '@6.0.0'
   metis:
     require: '+int64 +real64'
   mpich:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -163,9 +163,12 @@ packages:
     require: '@2.53 ~shared ~f2py'
     variants: '+pflogger'
   met:
-    require: '@11.1.1 +python +grib2'
+    require:
+    - '@12.0.1'
+    - '+python'
+    - '+grib2'
   metplus:
-    require: '@5.1.0'
+    require: '@6.0.0'
   metis:
     require: '+int64 +real64'
   mpich:


### PR DESCRIPTION
## Description

Updated met from 11.1.0 to 12.0.1 and metplus from 5.1.0 to 6.0.0

### Dependencies

### Issues addressed

closes #1739 

### Applications affected

SRW is already using new versions.

### Systems affected

All.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
