### PR TITLE
Correct documentation for Hercules and Orion

### DIFF
--- a/doc/source/PreConfiguredSites.rst
+++ b/doc/source/PreConfiguredSites.rst
@@ -108,6 +108,7 @@ The following is required for building new spack environments with any supported
    
    # Edit /path/to/env/install/modulefiles/Core/stack-oneapi/<version>.lua
    # Change:
+   # -- prerequisite modules
    # load("spack-managed-x86-64_v3")
    # load("intel-oneapi-compilers/2024.2.1")
    # prereq("spack-managed-x86-64_v3")
@@ -116,10 +117,10 @@ to
 
 .. code-block:: console
 
-   # -- load("spack-managed-x86-64_v3")
+   # -- prerequisite modules
    # prepend_path("MODULEPATH", "/apps/spack-managed-x86_64_v3-v1.0/modulefiles/Core:/apps/other/modulefiles:/apps/containers/modulefiles:/apps/licensed/modulefiles")
    # load("intel-oneapi-compilers/2024.2.1")
-   # -- prereq("spack-managed-x86-64_v3"
+   # prereq("intel-oneapi-compilers/2024.2.1")
 
 and
 
@@ -140,11 +141,7 @@ to
 .. code-block:: console
 
    # -- prerequisite modules
-   # -- load("spack-managed-x86-64_v3")
-   # load("intel-oneapi-compilers/2024.2.1")
    # load("intel-oneapi-mpi/2021.13.1")
-   # -- prereq("spack-managed-x86-64_v3")
-   # prereq("intel-oneapi-compilers/2024.2.1")
    # prereq("intel-oneapi-mpi/2021.13.1")
 
 .. _Preconfigured_Sites_Hercules:
@@ -168,6 +165,7 @@ The following is required for building new spack environments with any supported
 
    # Edit /path/to/env/install/modulefiles/Core/stack-oneapi/<version>.lua
    # Change:
+   # -- prerequisite modules
    # load("spack-managed-x86-64_v3")
    # load("intel-oneapi-compilers/2024.2.1")
    # prereq("spack-managed-x86-64_v3")
@@ -176,10 +174,10 @@ to
 
 .. code-block:: console
 
-   # -- load("spack-managed-x86-64_v3")
+   # -- prerequisite modules
    # prepend_path("MODULEPATH", "/apps/spack-managed-x86_64_v3-v1.0/modulefiles/Core:/apps/other/modulefiles:/apps/containers/modulefiles:/apps/licensed/modulefiles")
    # load("intel-oneapi-compilers/2024.2.1")
-   # -- prereq("spack-managed-x86-64_v3"
+   # prereq("intel-oneapi-compilers/2024.2.1")
 
 and
 
@@ -200,11 +198,7 @@ to
 .. code-block:: console
 
    # -- prerequisite modules
-   # -- load("spack-managed-x86-64_v3")
-   # load("intel-oneapi-compilers/2024.2.1")
    # load("intel-oneapi-mpi/2021.13.1")
-   # -- prereq("spack-managed-x86-64_v3")
-   # prereq("intel-oneapi-compilers/2024.2.1")
    # prereq("intel-oneapi-mpi/2021.13.1")
 
 .. _Preconfigured_Sites_Discover_SCU16:


### PR DESCRIPTION
Correct documentation for Hercules and Orion changes in post-install edits of modulefiles.

## Description

Loading spack-managed-x86-64_v3 module on Hercules and Orion messes up MODULEPATH, hence need for manual edits of modulefiles after spack-stack installation.

### Dependencies

### Issues addressed

No issue opened

### Applications affected

### Systems affected

Hercules and Orion documentation.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
