### PR TITLE
release/1.9.0: Add crtm-fix@3.1.1.3 as additional crtm-fix package to unified environment

### DIFF
--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -11,7 +11,7 @@ spack:
     - ewok-env +ecflow ~cylc
     - ai-env
     - geos-gcm-env          ^esmf@=8.6.1
-    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1
+    - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.1-build1 ^crtm-fix@=3.1.1.3
     - gmao-swell-env
     - gsi-env ^crtm@=3.1.1-build1
     - jedi-fv3-env
@@ -24,13 +24,14 @@ spack:
     - neptune-env           ^esmf@=8.8.0
     - neptune-python-env    ^esmf@=8.8.0
     - soca-env
-    - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.1-build1
-    - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.1-build1
+    - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.1-build1 ^crtm-fix@=3.1.1.3
+    - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.1-build1 ^crtm-fix@=3.1.1.3
 
     # Various crtm tags (list all to avoid duplicate packages)
     - crtm@2.4.0.1
     - crtm@v2.4.1-jedi
-    - crtm@3.1.1-build1
+    - crtm@3.1.1-build1 ^crtm-fix@=3.1.1.3
+    - crtm-fix@3.1.1.3
 
     # Mapl with various esmf tags
     - mapl@2.53.0 ^esmf@8.6.1


### PR DESCRIPTION
## Description

See title. The common scenario for applying this update on the supported systems, which already have installations of spack-stack-1.9.3 from tag 1.9.3 (hash https://github.com/JCSDA/spack-stack/commit/58660d3d0b269e7ffd0441293d0d0cdcdd42394f; will be retagged once everything is finalized) is as follows:
```
# 1. In the spack-stack-1.9.3 directory, run the usual preamble for your system and source setup.sh

# 2. Get latest tag of the spack submodule
cd spack
git remote update
git fetch --tags --force
git checkout spack-stack-1.9.3
git log
cd ..

# 3. Update spack-stack; two options
#   a) PR https://github.com/JCSDA/spack-stack/pull/1778 isn't merged yet

git remote -v show
git remote add dom https://github.com/climbfuji/spack-stack
git remote update
git checkout dom/feature/rel190_crtmfix_addon

#    b) PR https://github.com/JCSDA/spack-stack/pull/1778 was merged and you are on the release/1.9.0 branch locally

git remote update
git pull origin release/1.9.0

# 4. For each unified environment starting with ue- in envs/, do the following (example ue-gcc-11.2.1 on Nautilus):

spack stack create env --name=ue-gcc-11.2.1-crtm-fix-3.1.1.3 --site=nautilus --compiler=gcc --template=unified-dev --upstream=$PWD/envs/ue-gcc-11.2.1/install 2>&1 | tee log.create.ue-gcc-11.2.1-crtm-fix-3.1.1.3.001
spack env activate -p envs/ue-gcc-11.2.1-crtm-fix-3.1.1.3
spack concretize --force --fresh 2>&1 | tee log.concretize.ue-gcc-11.2.1-crtm-fix-3.1.1.3.001

# Verify that there is only one version of crtm@3.1.1-build1 and that there is no crtm-fix@3.1.1.2 in the list of duplicates
./util/show_duplicate_packages.py -d log.concretize.ue-gcc-11.2.1-crtm-fix-3.1.1.3.001

spack install --verbose --no-cache 2>&1 | tee log.install.ue-gcc-11.2.1-crtm-fix-3.1.1.3.001

spack module tcl refresh -y --upstream-modules # replace tcl with lmod as required

spack stack setup-meta-modules
```

Then, update the release notes for 1.9.3 (see separate list for addon environment installations): https://github.com/JCSDA/spack-stack/issues/1760

Note that updated the spack-stack wiki release documentation accordingly: https://github.com/JCSDA/spack-stack/wiki/spack%E2%80%90stack%E2%80%901.9.3-release-documentation

### Dependencies

None

### Issues addressed

Closes https://github.com/JCSDA/spack/issues/565

### Applications affected

UFS Global Workflow

### Systems affected

All tier-1 platforms

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass **in progress**
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Installed the addon environment on Nautilus with GNU following the above instructions

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki were made
