### PR TITLE
[release/1.9.0] Bugfix for met on Hera

### DIFF
--- a/configs/sites/tier1/hera/packages.yaml
+++ b/configs/sites/tier1/hera/packages.yaml
@@ -1,7 +1,8 @@
 packages:
   all:
+    # https://github.com/JCSDA/spack-stack/issues/1781
     # To support hecflow01
-    target: [haswell]
+    #target: [haswell]
     providers:
       zlib-api:: [zlib]
   zlib-api:

--- a/configs/sites/tier1/hera/packages_oneapi.yaml
+++ b/configs/sites/tier1/hera/packages_oneapi.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [oneapi@2024.2.1]
+    compiler:: [oneapi@2024.2.1, gcc@13.3.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.13]
       # Remove the next three lines to switch to intel-oneapi-mkl


### PR DESCRIPTION
## Description

For `release/1.9.0`: Update Hera site config: remove haswell target in `packages.yaml` and add missing gcc compiler to compiler list in `packages_oneapi.yaml`.

See https://github.com/JCSDA/spack-stack/issues/1781#issuecomment-3361539201 and https://github.com/JCSDA/spack-stack/issues/1781#issuecomment-3361590900 for the possible implications of dropping the target.

See https://github.com/JCSDA/spack-stack/issues/1781#issuecomment-3365910951 for testing in the global workflow context.

### Dependencies

None

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1781

### Applications affected

MET

### Systems affected

Hera

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications (https://github.com/JCSDA/spack-stack/issues/1781#issuecomment-3362518187)
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged: https://github.com/JCSDA/spack-stack/wiki/spack%E2%80%90stack%E2%80%901.9.3-release-documentation#noaa-rdhpcs-hera
