### PR TITLE
Update Ursa site config for building spack-stack develop 2025/10/02 unified environments 

### DIFF
--- a/configs/sites/tier1/ursa/compilers.yaml
+++ b/configs/sites/tier1/ursa/compilers.yaml
@@ -13,9 +13,7 @@ compilers:
     - intel-oneapi-compilers/2024.2.1
     environment:
       prepend_path:
-        PATH: '/usr/bin'
-        LD_LIBRARY_PATH: '/usr/lib:/usr/lib64'
-        CPATH: '/usr/include/c++/11/x86_64-redhat-linux'
+        CPATH: /usr/include/c++/11/x86_64-redhat-linux
     extra_rpaths: []
 
 - compiler:
@@ -30,5 +28,8 @@ compilers:
     target: x86_64
     modules:
     - gcc/12.4.0
-    environment: {}
+    environment:
+      prepend_path:
+        CPATH: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/lib/gcc/x86_64-pc-linux-gnu/12.4.0/include
     extra_rpaths: []
+

--- a/configs/sites/tier1/ursa/packages_oneapi.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi.yaml
@@ -32,14 +32,15 @@ packages:
       modules:
       - intel-oneapi-mkl/2024.2.1
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-mkl-2024.2.1-srqwrbzwo2k7hxuuhlrxttburs5jvlat
-  intel-oneapi-runtime:
-    externals:
-    - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
-      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2024.2.1-oqhstbmawnrsdw472p4pjsopj547o6xs/compiler/2024.2
-      modules:
-      - compiler-rt/2024.2.1
-  gcc-runtime:
-    externals:
-    - spec: gcc-runtime@12.4.0%gcc@12.4.0
-      prefix: /usr
+# Commented out for spack v0.23 to avoid duplicate packages
+#  intel-oneapi-runtime:
+#    externals:
+#    - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
+#      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2024.2.1-oqhstbmawnrsdw472p4pjsopj547o6xs/compiler/2024.2
+#      modules:
+#      - compiler-rt/2024.2.1
+#  gcc-runtime:
+#    externals:
+#    - spec: gcc-runtime@12.4.0%gcc@12.4.0
+#      prefix: /usr
 


### PR DESCRIPTION
## Description

Update configs/sites/tier1/ursa/compilers.yaml and configs/sites/tier1/ursa/packages_oneapi.yaml for building unified environment on Ursa for spack-stack develop as of 2025/10/02.

Tested on Ursa, environments built cleanly for both compilers.

Note that the Ursa site config will be updated shortly again on the feature/update_to_spack_v1 branch, this will likely include reverting back to external compiler runtime libraries.

### Dependencies

None

### Issues addressed

None. Related to automation work (see https://github.com/JCSDA/spack-stack/pull/1788).

### Applications affected

None

### Systems affected

Ursa

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass **in progress, but not necessary (only site config changes)**
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested on Ursa, unified environments built cleanly for both compilers.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
