### PR TITLE
Final updates of develop from release 1.9.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/final_update_from_rel193
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/final_update_from_rel193
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = bugfix/wgrib2_netcdf_temp_fix_from_rel193
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = bugfix/wgrib2_netcdf_temp_fix_from_rel193
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -324,6 +324,7 @@ packages:
   wgrib2:
     require:
     - '@3.6.0'
+    - '+ipolates +netcdf'
   wrf-io:
     require: '@1.2.0'
   zstd:

--- a/configs/sites/tier1/hera/packages.yaml
+++ b/configs/sites/tier1/hera/packages.yaml
@@ -1,7 +1,8 @@
 packages:
   all:
+    # https://github.com/JCSDA/spack-stack/issues/1781
     # To support hecflow01
-    target: [haswell]
+    #target: [haswell]
     providers:
       zlib-api:: [zlib]
   zlib-api:
@@ -110,10 +111,10 @@ packages:
   mysql:
     buildable: False
     externals:
-    - spec: mysql@8.0.31
-      prefix: /scratch1/NCEPDEV/global/spack-stack/apps/mysql-8.0.31
+    - spec: mysql@8.0.36
+      prefix: /contrib/spack-stack/installs/mysql/8.0.36
       modules:
-      - mysql/8.0.31
+      - mysql/8.0.36
   ncurses:
     externals:
     - spec: ncurses@5.9.20130511+termlib abi=5
@@ -129,7 +130,7 @@ packages:
   qt:
     externals:
     - spec: qt@5.12.6
-      prefix: /scratch1/NCEPDEV/nems/role.epic/installs/qt-5.12.6/qtbase
+      prefix: /contrib/spack-stack/installs/qt-5.12.6/qtbase
   rsync:
     externals:
     - spec: rsync@3.1.2

--- a/configs/sites/tier1/hera/packages_oneapi.yaml
+++ b/configs/sites/tier1/hera/packages_oneapi.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler:: [oneapi@2024.2.1]
+    compiler:: [oneapi@2024.2.1, gcc@13.3.0]
     providers:
       mpi:: [intel-oneapi-mpi@2021.13]
       # Remove the next three lines to switch to intel-oneapi-mkl

--- a/configs/sites/tier1/hercules/compilers.yaml
+++ b/configs/sites/tier1/hercules/compilers.yaml
@@ -10,11 +10,15 @@ compilers:
     operating_system: rocky9
     target: x86_64
     modules:
+    - spack-managed-x86-64_v3
     - intel-oneapi-compilers/2024.2.1
     environment:
       set:
         # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
         I_MPI_EXTRA_FILESYSTEM: 'ON'
+        # Override system module settings for FC and F77 (they're set to ifx)
+        F77: '/apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort'
+        FC: '/apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort'
       prepend_path:
         PATH: /usr/bin
         LD_LIBRARY_PATH: /usr/lib:/usr/lib64

--- a/configs/sites/tier1/hercules/packages_oneapi.yaml
+++ b/configs/sites/tier1/hercules/packages_oneapi.yaml
@@ -15,6 +15,8 @@ packages:
     - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
       prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-3pv63eugwmse2xpeglxib4dr2oeb42g2
       modules:
+      - spack-managed-x86-64_v3
+      - intel-oneapi-compilers/2024.2.1
       - intel-oneapi-mpi/2021.13.1
 
   intel-oneapi-mkl:
@@ -23,6 +25,7 @@ packages:
     - spec: intel-oneapi-mkl@2024.2.1
       prefix: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-mkl-2024.2.1-aeiool3i5jj4newwifvkhow5almp67rt
       modules:
+      - spack-managed-x86-64_v3
       - intel-oneapi-mkl/2024.2.1
 
   intel-oneapi-runtime:
@@ -30,6 +33,7 @@ packages:
     - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
       prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-runtime-2024.2.1-hl5zgdjaldynq35dq3yotclfy2vblybx
       modules:
+      - spack-managed-x86-64_v3
       - intel-oneapi-compilers/2024.2.1
       - intel-oneapi-runtime/2024.2.1
 
@@ -49,3 +53,6 @@ packages:
   py-scipy:
     require:
     - '%gcc'
+  zlib-ng:
+    require:
+    - '~shared'

--- a/configs/sites/tier1/nas/README.md
+++ b/configs/sites/tier1/nas/README.md
@@ -1,49 +1,131 @@
 # How to build spack-stack at NAS
 
-## Generic
+In the commands below some will be run on login nodes (with internet access) and some
+on compute nodes as, at NAS, you aren't allowed more than 2 processes on a login node.
+
+## Clone spack-stack
 
 ```
-git clone --recursive https://github.com/JCSDA/spack-stack.git -b release/1.9.0 spack-stack-1.9.1
+git clone --recursive https://github.com/JCSDA/spack-stack.git -b release/1.9.0 spack-stack-1.9.3
 ```
 
-## oneapi
+## Grab interactive node
+
+Since NAS limits you to 2 processes on a login node, you'll need to grab an interactive node. For example:
+```
+qsub -I -V -X -l select=1:ncpus=128:mpiprocs=128:model=mil_ait -l walltime=12:00:00 -W group_list=s1873 -m b -N Interactive
+```
+will get you a Milan node for 12 hours
+
+## Setup spack-stack on each node
+
+We will start on a login node with internet access. This is mainly needed for the
+`spack mirror create` command which downloads all the source code for the packages.
 
 ```
-cd spack-stack-1.9.1
+cd spack-stack-1.9.3
 . setup.sh
+```
+
+## Create environments
+
+We create two different environments, one for oneAPI and one for GCC. The commands below
+are used to create the environments. You only need to do this once.
+
+### oneAPI
+
+To create the oneAPI environment, do:
+
+```
 spack stack create env --name ue-oneapi-2024.2.0 --template unified-dev --site nas --compiler oneapi
 cd envs/ue-oneapi-2024.2.0
-spack env activate .
-spack concretize 2>&1 | tee log.concretize
-spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 ```
 
-NOTE: You might need to run the `spack install` command multiple times because sometimes
-it just fails. But then you run it more and more and it will eventually succeed.
+### GCC
+
+To create the GCC environment, do:
 
 ```
-spack module tcl refresh -y
-spack stack setup-meta-modules
-spack env deactivate
-```
-
-## gcc
-
-```
-cd spack-stack-1.9.1
-. setup.sh
 spack stack create env --name ue-gcc-12.3.0 --template unified-dev --site nas --compiler gcc
 cd envs/ue-gcc-12.3.0
+```
+
+## Activate environment
+
+Now enter the spack environment you just created:
+
+```
 spack env activate .
+```
+
+NOTE: You need to make sure you do this in *any* terminal where you want to do any commmand
+below with this environment.
+
+## Concretize and create source cache
+
+```
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
+```
+
+## Create source cache (LOGIN NODE ONLY)
+
+Because this step downloads all the source code for all packages and all versions, it
+should be done on a login node with internet access.
+
+```
+spack mirror create -a -d /nobackup/gmao_SIteam/spack-stack/source-cache
+```
+
+NOTE: Make sure you are in an environment when you run that `spack mirror create` command. Otherwise,
+you will download *EVERY* package and *EVERY* version in spack!
+
+## Install packages
+
+Our install process will actually have (at least) three steps. This is because of the `crtm` package
+which requires internet access at build time.
+
+### Install crtm dependencies (COMPUTE NODE)
+
+```
+spack install -j 10 --verbose --fail-fast --show-log-on-error --no-check-signature --only dependencies crtm 2>&1 | tee log.install.crtm_dependencies
+```
+
+### Install crtm (LOGIN NODE)
+
+```
+spack install -j 2 --verbose --fail-fast --show-log-on-error --no-check-signature crtm 2>&1 | tee log.install.crtm
+```
+
+Note we are only using 2 processes here because NAS limits you to 2 processes on a login node.
+
+### Install rest of packages (COMPUTE NODE)
+
+```
+spack install -j 10 --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install.after_crtm
 ```
 
 NOTE: You might need to run the `spack install` command multiple times because sometimes
 it just fails. But then you run it more and more and it will eventually succeed.
 
+### Packages needing internet access to build
+
+If you encounter other packages that need internet access to build, you can install them with:
+
+```
+spack install -j 2 --verbose --fail-fast --show-log-on-error --no-check-signature <package> |& tee log.install.<package>
+```
+
+Then, once that package is built, you can go back to the compute node and run the `spack install` command again.
+
+## Update module files and setup meta-modules
+
 ```
 spack module tcl refresh -y
 spack stack setup-meta-modules
+```
+
+## Deactivate environment
+
+```
 spack env deactivate
 ```

--- a/configs/sites/tier1/nas/packages.yaml
+++ b/configs/sites/tier1/nas/packages.yaml
@@ -40,10 +40,18 @@ packages:
     externals:
     - spec: gawk@4.2.1
       prefix: /usr
+  gh:
+    externals:
+    - spec: gh@2.78.0
+      prefix: /nobackup/gmao_SIteam/gh/2.78.0
   git:
     externals:
     - spec: git@2.43.5~tcltk
       prefix: /usr
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.7.0
+      prefix: /nobackup/gmao_SIteam/git-lfs/3.7.0
   gmake:
     externals:
     - spec: gmake@4.2.1

--- a/configs/sites/tier1/noaa-aws/README.md
+++ b/configs/sites/tier1/noaa-aws/README.md
@@ -1,6 +1,6 @@
 # Provisiong ParallelWorks AWS clusters
 
-## Steps to perform before installing spack-stack version 1.9.2
+## Steps to perform before installing spack-stack version 1.9.3
 
 sudo su -
 chmod 777 /contrib
@@ -8,30 +8,22 @@ yum install -y qt5-qtbase-devel
 yum install -y qt5-qtsvg-devel
 
 
-## Steps to install spack-stack version 1.9.2
+## Steps to install spack-stack version 1.8.0
 
 sudo su -
 chmod 777 /contrib
 
 module purge
-module unuse /opt/cray/craype/default/modulefiles
-module unuse /opt/cray/modulefiles
-### For noaa-aws, run the line below as well:
-module unuse /opt/intel/impi/2019.5.281/intel64/modulefiles
-module load gnu
-module load intel/2024.2.1
-module load impi/2024.2.1
-module unload gnu
 
 cd /contrib/spack-stack-rocky8/
-git clone --recursive https://github.com/JCSDA/spack-stack -b release/1.9.0 spack-stack-1.9.2
-cd spack-stack-1.9.2
+git clone --recursive https://github.com/JCSDA/spack-stack -b release/1.9.0 spack-stack-1.9.3
+cd spack-stack-1.9.3
 . setup.sh
 spack stack create env --name ue-oneapi-2024.2.1 --template unified-dev --site noaa-aws --compiler oneapi
 cd envs/ue-oneapi-2024.2.1
 spack env activate .
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose 2>&1 | tee log.install
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 spack module lmod refresh -y
 spack stack setup-meta-modules
 
@@ -40,12 +32,12 @@ spack stack setup-meta-modules
 sudo su -
 chmod 777 /contrib
 
-cd /contrib/spack-stack-rocky8/spack-stack-1.9.2
+cd /contrib/spack-stack-rocky8/spack-stack-1.9.3
 . setup.sh
-spack stack create env --name gsi-oneapi-2024.2.1 --template gsi-addon-dev --site noaa-aws --upstream /contrib/spack-stack-rocky8/spack-stack-1.9.2/envs/ue-intel-2024.2.1/install --compiler intel
+spack stack create env --name gsi-oneapi-2024.2.1 --template gsi-addon-dev --site noaa-aws --upstream /contrib/spack-stack-rocky8/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install --compiler oneapi
 cd envs/gsi-oneapi-2024.2.1
 spack env activate .
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose 2>&1 | tee log.install
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 spack module lmod refresh --upstream-modules
 spack stack setup-meta-modules

--- a/configs/sites/tier1/noaa-azure/README.md
+++ b/configs/sites/tier1/noaa-azure/README.md
@@ -1,6 +1,6 @@
 # Provisiong ParallelWorks Azure clusters
 
-## Steps to perform before installing spack-stack version 1.9.2
+## Steps to perform before installing spack-stack version 1.9.3
 
 sudo su -
 chmod 777 /contrib
@@ -8,28 +8,22 @@ yum install -y qt5-qtbase-devel
 yum install -y qt5-qtsvg-devel
 
 
-## Steps to install spack-stack version 1.9.2
+## Steps to install spack-stack version 1.8.0
 
 sudo su -
 chmod 777 /contrib
 
 module purge
-module unuse /opt/cray/craype/default/modulefiles
-module unuse /opt/cray/modulefiles
-module load gnu
-module load intel/2024.2.1
-module load impi/2024.2.1
-module unload gnu
 
 cd /contrib/spack-stack-rocky8/
-git clone --recursive https://github.com/JCSDA/spack-stack -b release/1.9.0 spack-stack-1.9.2
-cd spack-stack-1.9.2
+git clone --recursive https://github.com/JCSDA/spack-stack -b release/1.9.0 spack-stack-1.9.3
+cd spack-stack-1.9.3
 . setup.sh
 spack stack create env --name ue-oneapi-2024.2.1 --template unified-dev --site noaa-azure --compiler oneapi
-cd envs/ue-intel-2024.2.1
+cd envs/ue-oneapi-2024.2.1
 spack env activate .
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose 2>&1 | tee log.install
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 spack module lmod refresh -y
 spack stack setup-meta-modules
 
@@ -38,12 +32,12 @@ spack stack setup-meta-modules
 sudo su -
 chmod 777 /contrib
 
-cd /contrib/spack-stack-rocky8/spack-stack-1.9.2
+cd /contrib/spack-stack-rocky8/spack-stack-1.9.3
 . setup.sh
-spack stack create env --name gsi-oneapi-2024.2.1 --template gsi-addon-dev --site noaa-azure --upstream /contrib/spack-stack-rocky8/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install --compiler oneapi
+spack stack create env --name gsi-oneapi-2024.2.1 --template gsi-addon-dev --site noaa-azure --upstream /contrib/spack-stack-rocky8/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install --compiler oneapi
 cd envs/gsi-oneapi-2024.2.1
 spack env activate .
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose 2>&1 | tee log.install
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 spack module lmod refresh --upstream-modules
 spack stack setup-meta-modules

--- a/configs/sites/tier1/noaa-gcloud/README.md
+++ b/configs/sites/tier1/noaa-gcloud/README.md
@@ -1,6 +1,6 @@
 # Provisiong ParallelWorks GCP clusters
 
-## Steps to perform before installing spack-stack version 1.9.2
+## Steps to perform before installing spack-stack version 1.9.3
 
 sudo su -
 chmod 777 /contrib
@@ -8,28 +8,22 @@ yum install -y qt5-qtbase-devel
 yum install -y qt5-qtsvg-devel
 
 
-## Steps to install spack-stack version 1.9.2
+## Steps to install spack-stack version 1.8.0
 
 sudo su -
 chmod 777 /contrib
 
 module purge
-module unuse /opt/cray/craype/default/modulefiles
-module unuse /opt/cray/modulefiles
-module load gnu
-module load intel/2024.2.1
-module load impi/2024.2.1
-module unload gnu
 
 cd /contrib/spack-stack-rocky8/
-git clone --recursive https://github.com/JCSDA/spack-stack -b release/1.9.0 spack-stack-1.9.2
-cd spack-stack-1.9.2
+git clone --recursive https://github.com/JCSDA/spack-stack -b release/1.9.0 spack-stack-1.9.3
+cd spack-stack-1.9.3
 . setup.sh
 spack stack create env --name ue-oneapi-2024.2.1 --template unified-dev --site noaa-gcloud --compiler oneapi
 cd envs/ue-oneapi-2024.2.1
 spack env activate .
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose 2>&1 | tee log.install
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 spack module lmod refresh -y
 spack stack setup-meta-modules
 
@@ -38,11 +32,12 @@ spack stack setup-meta-modules
 sudo su -
 chmod 777 /contrib
 
-cd /contrib/spack-stack-rocky8/spack-stack-1.9.2
+cd /contrib/spack-stack-rocky8/spack-stack-1.9.3
 . setup.sh
-spack stack create env --name gsi-oneapi-2024.2.1 --template gsi-addon-dev --site noaa-gcloud --upstream /contrib/spack-stack-rocky8/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install --compiler oneapi
+spack stack create env --name gsi-oneapi-2024.2.1 --template gsi-addon-dev --site noaa-gcloud --upstream /contrib/spack-stack-rocky8/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install --compiler oneapi
 cd envs/gsi-oneapi-2024.2.1
+spack env activate .
 spack concretize 2>&1 | tee log.concretize
-spack install --verbose 2>&1 | tee log.install
+spack install --verbose --fail-fast --show-log-on-error --no-check-signature 2>&1 | tee log.install
 spack module lmod refresh --upstream-modules
 spack stack setup-meta-modules

--- a/configs/sites/tier1/orion/compilers.yaml
+++ b/configs/sites/tier1/orion/compilers.yaml
@@ -41,11 +41,15 @@ compilers:
     operating_system: rocky9
     target: x86_64
     modules:
+    - spack-managed-x86-64_v3
     - intel-oneapi-compilers/2024.2.1
     environment:
       set:
         # https://github.com/ufs-community/ufs-weather-model/issues/2015#issuecomment-1864438186
         I_MPI_EXTRA_FILESYSTEM: 'ON'
+        # override system module settings for FC and F77 (they're set to ifx)
+        F77: '/apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort'
+        FC: '/apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-compilers-2024.2.1-podbez65l57ms4uba527kg7pomxk5y3m/compiler/2024.2/bin/ifort'
       prepend_path:
         PATH: /usr/bin
         LD_LIBRARY_PATH: /usr/lib:/usr/lib64

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -91,6 +91,10 @@ packages:
     externals:
     - spec: openssh@8.7p1
       prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@3.0.1
+      prefix: /usr
   perl:
     externals:
     - spec: perl@5.32.1~cpanm+opcode+open+shared+threads

--- a/configs/sites/tier1/orion/packages_oneapi.yaml
+++ b/configs/sites/tier1/orion/packages_oneapi.yaml
@@ -14,6 +14,8 @@ packages:
     externals:
     - spec: intel-oneapi-mpi@2021.13%oneapi@2024.2.1
       modules:
+      - spack-managed-x86-64_v3
+      - intel-oneapi-compilers/2024.2.1
       - intel-oneapi-mpi/2021.13.1
       prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-mpi-2021.13.1-3pv63eugwmse2xpeglxib4dr2oeb42g2
 
@@ -22,6 +24,7 @@ packages:
     externals:
     - spec: intel-oneapi-mkl@2024.2.1
       modules:
+      - spack-managed-x86-64_v3
       - intel-oneapi-mkl/2024.2.1
       prefix: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/intel-oneapi-mkl-2024.2.1-aeiool3i5jj4newwifvkhow5almp67rt
 
@@ -30,6 +33,7 @@ packages:
     - spec: intel-oneapi-runtime@2024.2.1%oneapi@2024.2.1
       prefix: /apps/spack-managed-x86_64_v3-v1.0/oneapi-2024.2.1/intel-oneapi-runtime-2024.2.1-hl5zgdjaldynq35dq3yotclfy2vblybx
       modules:
+      - spack-managed-x86-64_v3
       - intel-oneapi-compilers/2024.2.1
       - intel-oneapi-runtime/2024.2.1
 

--- a/configs/sites/tier1/ursa/compilers.yaml
+++ b/configs/sites/tier1/ursa/compilers.yaml
@@ -32,4 +32,3 @@ compilers:
       prepend_path:
         CPATH: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/lib/gcc/x86_64-pc-linux-gnu/12.4.0/include
     extra_rpaths: []
-

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -143,6 +143,10 @@ packages:
     externals:
     - spec: sed@4.8
       prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.34
+      prefix: /usr
   texinfo:
     externals:
     - spec: texinfo@7.1


### PR DESCRIPTION
## Description

Final round of updates from release 1.9.3 (branch `release/1.9.0`) for develop. An attempt will be made to pull these updatesinto the new `feature/update_to_spack_v1` branch for changes that are not related to site configs, and for site configs that haven't been updated yet to work with spack v1. This will be a follow-up PR titled "Update feature/update_to_spack_v1 from develop".

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack/pull/567
- [x] Waiting on https://github.com/JCSDA/spack/pull/568

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1694
Closes https://github.com/JCSDA/spack-stack/issues/1760

### Applications affected

None (all changes already deployed as part of spack-stack-1.9.3)

### Systems affected

None (all changes already deployed as part of spack-stack-1.9.3)

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~ deferred
