### PR TITLE
Hot fix for feature/update_to_spack_v1: update invalid syntax in mpi.lua

### DIFF
--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/templates/mpi.lua
@@ -27,7 +27,7 @@ setenv("MPICXX", "@MPICXX@")
 setenv("MPIF77", "@MPIF77@")
 setenv("MPIF90", "@MPIF90@")
 
-# underlying compilers for mpi distributions
+-- underlying compilers for mpi distributions
 setenv("I_MPI_CC",  "@CC@")
 setenv("I_MPI_CXX", "@CXX@")
 setenv("I_MPI_F77", "@F77@")


### PR DESCRIPTION
## Description

In the title. In the last PR, I copied over the comment from the tcl/tk modulefile to the lua/lmod file. This bug will cause failures when trying to load the stack-MPI module.

### Dependencies

None

### Issues addressed

This bug will cause failures when trying to load the stack-MPI module.

### Applications affected

All

### Systems affected

All

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications. (NRL Atlantis)
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
