### PR TITLE
setup.sh: match host with FQDN (+update acorn pattern)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,9 @@
 # Portable way to get current directory
 SPACK_STACK_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-hostname=$(hostname)
+hostname=$(hostname -f)
 case $hostname in
-  alogin*)
+  *acorn.wcoss2*)
     . ${SPACK_STACK_DIR}/configs/sites/tier1/acorn/setup.sh
     ;;
 esac


### PR DESCRIPTION
## Description

This PR updates setup.sh to use `hostname -f` for identifying which platform it's running on. This is needed on, e.g., acorn where compute node short names are "nidXXXXXX".

### Dependencies

none

### Issues addressed

none

### Applications affected

all

### Systems affected

Acorn

## Testing

Tested on Acorn login and compute nodes.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
