### PR TITLE
Add missing dependency py-cfgrib to neptune-python-env

### DIFF
--- a/spack-ext/repos/spack-stack/packages/neptune-python-env/package.py
+++ b/spack-ext/repos/spack-stack/packages/neptune-python-env/package.py
@@ -24,6 +24,7 @@ class NeptunePythonEnv(BundlePackage):
     depends_on("esmf +python", type="run")
 
     depends_on("py-arch", type="run")
+    depends_on("py-cfgrib", type="run")
     depends_on("py-h5py", type="run")
     depends_on("py-netcdf4", type="run")
     depends_on("py-pandas", type="run")


### PR DESCRIPTION
## Description

All in the title. This will need to be pulled into the `feature/update_to_spack_v1` branch once it is merged.

### Dependencies

None

### Issues addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1795

### Applications affected

NEPTUNE

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
