### PR TITLE
Misc version updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,5 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/AlexanderRichert-NOAA/spack-packages
-  branch = misc_nceplibs_oct25
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,5 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  url = https://github.com/AlexanderRichert-NOAA/spack-packages
+  branch = misc_nceplibs_oct25

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -122,7 +122,7 @@ packages:
       - '@2.1.0'
     g2tmpl:
       require:
-      - '@1.13.0'
+      - '@1.17.0'
     # This version builds with Intel oneAPI compilers, newer/older versions don't
     gdal:
       require:
@@ -278,7 +278,7 @@ packages:
       - +pic
     prod-util:
       require:
-      - '@2.1.1'
+      - '@2.1.2'
     proj:
       require:
       - ~tiff
@@ -386,8 +386,8 @@ packages:
       - '@5'
     scotch:
       require:
-      - '@7.0.4'
-      - +mpi+metis~shared~threads~mpi_thread+noarch+esmumps
+      - '@7.0.10'
+      - +mpi+metis~shared~threads~mpi_thread+noarch+esmumps+fortran determinism=FIXED_SEED
     sfcio:
       require:
       - '@1.4.2'


### PR DESCRIPTION
## Description

This PR updates to the latest versions of scotch, g2tmpl, and prod-util. It will update the spack-packages submodule pointer.

### Dependencies

 - [x] waiting on https://github.com/JCSDA/spack-packages/pull/14

### Issues addressed

Fixes https://github.com/JCSDA/spack-stack/issues/1695
Fixes https://github.com/JCSDA/spack-stack/issues/1785
Fixes https://github.com/JCSDA/spack-stack/issues/1783

### Applications affected

UFSWM, GW, etc.

### Systems affected

all

## Testing


   - [x] GitHub actions CI tests pass

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
