### PR TITLE
repos/builtin/ submodule update (py-mpi4py)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,5 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  url = https://github.com/AlexanderRichert-NOAA/spack-packages
+  branch = pympi4py_cxxdep


### PR DESCRIPTION
## Description

This PR brings in the py-mpi4py update (CXX dependency). No configuration changes needed, just doing this for CI testing.

### Dependencies

https://github.com/JCSDA/spack-packages/pull/15

### Issues addressed

none

### Applications affected

GW, probably others

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested on Acorn

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
