### PR TITLE
fetch_cargo_deps.py: ensure CARGO_HOME is used

### DIFF
--- a/util/fetch_cargo_deps.py
+++ b/util/fetch_cargo_deps.py
@@ -25,7 +25,7 @@ from spack_repo.builtin.build_systems.cargo import CargoPackage
 from spack_repo.builtin.build_systems.python import PythonPackage
 from spack.package_base import PackageBase
 from spack.util.executable import Executable, which
-from llnl.util.filesystem import working_dir
+from spack.llnl.util.filesystem import working_dir
 from spack.store import find
 from spack.util.environment import EnvironmentModifications
 from spack.error import SpackError
@@ -117,6 +117,7 @@ export RUSTUP_HOME="{cargo_home}/rustup"
         cargo_exe = Executable(cargo_wrapper)
 
     env = EnvironmentModifications()
+    env.set("CARGO_HOME", cargo_home)
     if cargo_bin:
         env.prepend_path("PATH", cargo_bin)
     for root, dirs, files in os.walk(pkg.stage.source_path):


### PR DESCRIPTION
## Description

This PR ensures that CARGO_HOME is used (rather than the default of ~/.cargo) when fetching cargo deps, and also gets rid of the llnl.* deprecation warning for fetch_cargo_deps.py.

### Dependencies

none

### Issues addressed

none

### Applications affected

most

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
- Additional testing: _Add information on any additional tests conducted_
    - [x] Acorn (manual test)

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
