### PR TITLE
New package adp-preprocessors (Navy only), use w3emc@2.10.0 with LLVM, bug fix for Intel oneAPI MPI in setup-meta-modules

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -74,6 +74,11 @@ jobs:
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler gcc
             spack env activate ${ENVDIR}
 
+            # Turn off variant "adp" for neptune-dev (NRL internal only)
+            if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
+              sed -i 's/+adp/~adp/g' ${ENVDIR}/spack.yaml
+            fi
+
             unset SPACK_DISABLE_LOCAL_CONFIG
             export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -74,6 +74,11 @@ jobs:
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler oneapi
             spack env activate ${ENVDIR}
 
+            # Turn off variant "adp" for neptune-dev (NRL internal only)
+            if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
+              sed -i 's/+adp/~adp/g' ${ENVDIR}/spack.yaml
+            fi
+
             unset SPACK_DISABLE_LOCAL_CONFIG
             export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -74,6 +74,11 @@ jobs:
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler oneapi
             spack env activate ${ENVDIR}
 
+            # Turn off variant "adp" for neptune-dev (NRL internal only)
+            if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
+              sed -i 's/+adp/~adp/g' ${ENVDIR}/spack.yaml
+            fi
+
             unset SPACK_DISABLE_LOCAL_CONFIG
             export SPACK_SYSTEM_CONFIG_PATH="${ENVDIR}/site"
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,5 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/mct_fpic_new_syntax_for_spack_stack_dev
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,7 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/mct_fpic_new_syntax_for_spack_stack_dev

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -420,9 +420,12 @@ packages:
       require:
       - '@2.7.2'
     # Need extradeps for grib-utils, enable by default to avoid duplicate packages
+    # w3emc@2.11.0 doesn't build with LLVM 21
     w3emc:
       require:
-      - '@2.11.0'
+      - one_of: ['@=2.11.0', '@=2.10.0']
+      - one_of: ['@=2.10.0']
+        when: '%clang'
       - precision=4,d,8 +extradeps
     w3nco:
       require:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -10,8 +10,8 @@ spack:
   specs:
   - neptune-env ~debug +espc ^esmf@=8.9.0
   - neptune-env +debug +espc ^esmf@=8.9.0
-  - neptune-python-env ^neptune-env ~debug +espc ^esmf@=8.9.0
-  - jedi-neptune-env   ^neptune-env ~debug +espc ^esmf@=8.9.0
+  - neptune-python-env    ^neptune-env ~debug +espc ^esmf@=8.9.0
+  - jedi-neptune-env +adp ^neptune-env ~debug +espc ^esmf@=8.9.0
   - crtm@3.1.2
   - crtm@v2.4.1-jedi.2
 

--- a/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
@@ -21,7 +21,7 @@ class AdpPreprocessors(MakefilePackage):
 
     #license("UNKNOWN", checked_by="github_user1")
 
-    # FIXME: Add proper versions and checksums here.
+    # Update commit once 1.2.0 is released
     version("1.2.0", commit="87e93306de9df9ff4d02bce84249976cfa2f4c97")
     version("1.1.0", commit="b2d9d4ffb472eff9ab973ef2a12f574d92c9754b")
 

--- a/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 
 class AdpPreprocessors(MakefilePackage):
-    """FIXME: Put a proper description of your package here."""
+    """Unified, model-agnostic software system that processes atmospheric observations for the Navy's numerical weather prediction data assimilation systems"""
 
     homepage = "https://github.nrlmry.navy.mil/ADP/adp-preprocessors/wiki"
     #git = "https://github.nrlmry.navy.mil/ADP/adp-preprocessors.git"

--- a/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
@@ -19,9 +19,6 @@ class AdpPreprocessors(MakefilePackage):
 
     maintainers("climbfuji")
 
-    # FIXME: Add the SPDX identifier of the project's license below.
-    # See https://spdx.org/licenses/ for a list. Upon manually verifying
-    # the license, set checked_by to your Github username.
     #license("UNKNOWN", checked_by="github_user1")
 
     # FIXME: Add proper versions and checksums here.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
@@ -1,0 +1,84 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import subprocess
+
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class AdpPreprocessors(MakefilePackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://github.nrlmry.navy.mil/ADP/adp-preprocessors/wiki"
+    #git = "https://github.nrlmry.navy.mil/ADP/adp-preprocessors.git"
+    git = "https://github.nrlmry.navy.mil/climbfuji/adp-preprocessors.git"
+
+    maintainers("climbfuji")
+
+    # FIXME: Add the SPDX identifier of the project's license below.
+    # See https://spdx.org/licenses/ for a list. Upon manually verifying
+    # the license, set checked_by to your Github username.
+    #license("UNKNOWN", checked_by="github_user1")
+
+    # FIXME: Add proper versions and checksums here.
+    version("1.2.0", commit="87e93306de9df9ff4d02bce84249976cfa2f4c97")
+    version("1.1.0", commit="b2d9d4ffb472eff9ab973ef2a12f574d92c9754b")
+
+    # MakefilePackage dependencies
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+    depends_on("gmake", type="build")
+
+    depends_on("mpi")
+    depends_on("fftw-api")
+    depends_on("lapack")
+    # Unclear what to do for GNU. Would be better to fix the build system
+    # and let spack provide whatever lapack/fftw provider the user wants
+    # instead of hardcoding it to MKL for Intel?
+    depends_on("mkl", when="^intel-oneapi-compilers")
+    depends_on("mkl", when="^intel-oneapi-compilers-classic")
+    depends_on("hdf5@1.14: +fortran")
+    depends_on("netcdf-fortran@4.4.4:")
+    depends_on("esmf@8.5.0:")
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        env.set("BUILD_WITH_HDF5", "ON")
+        env.set("HDF5PATH", self.spec["hdf5"].prefix)
+        env.set("HDF5LIB", f"-L{self.spec['hdf5'].prefix.lib}")
+        env.set("HDF5MOD", f"-I{join_path(self.spec['hdf5'].prefix, 'mod/static')}")
+
+    def build(self, spec, prefix):
+        with working_dir("src"):
+            if self.compiler.name == "gcc":
+                make("-f", "makefile", "spack_gcc")
+            elif self.compiler.name == "intel-oneapi-compilers":
+                make("-f", "makefile", "spack_oneapi")
+            else:
+                raise InstallError(f"Compiler {self.compiler.name} not configured")
+
+    def install(self, spec, prefix):
+        for subdir in ['bin', 'lib', 'mod']:
+            copy_tree(join_path(self.stage.source_path, subdir), join_path(prefix, subdir))
+
+    def check(self):
+        # Serial tests
+        for test in ["test_paths", "test_serial"]:
+            test_program = which(join_path(self.stage.source_path, "src/io_tools/test/.objdir", test))
+            test_program()
+        # Parallel tests
+        for test in ["test_parallel"]:
+            mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+            test_program = join_path(self.stage.source_path, "src/io_tools/test/.objdir", test)
+            if mpirun:
+                mpirun("-np", "4", test_program)
+            else:
+                tty.info(f"Bypassing test {test} because mpirun not found")
+        # Smoke test: call main executable without arguments, according to the package,
+        # this prints an error message but still exits with status code zero
+        tty.info("Smoke test for do_satwind_processing.exe, expect 'failed--istats = 3'")
+        res = subprocess.run(join_path(self.stage.source_path, "bin", "do_satwind_processing.exe"))
+        assert res.returncode == 0

--- a/repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py
@@ -18,7 +18,12 @@ class JediNeptuneEnv(BundlePackage):
 
     version("1.0.0")
 
+    variant("adp", default=False, description="Build ADP preprocessors")
+
     depends_on("jedi-base-env", type="run")
     depends_on("neptune-env", type="run")
+
+    with when("+adp"):
+        depends_on("adp-preprocessors", type="run")
 
     # There is no need for install() since there is no code.

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -575,21 +575,33 @@ def setup_meta_modules():
             #    substitutes["MPIF77"] = substitutes["MPIF77"].replace("mpiifx", "mpiifort")
             #    substitutes["MPIF90"] = substitutes["MPIF90"].replace("mpiifx", "mpiifort")
             if mpi_provider.name == "intel-oneapi-mpi" and compiler.name == "intel-oneapi-compilers":
-                substitutes["MPICC"]  = os.path.join(mpi_provider.prefix.bin, "mpiicx")
-                substitutes["MPICXX"] = os.path.join(mpi_provider.prefix.bin, "mpiicpx")
+                if os.path.exists(os.path.join(mpi_provider.prefix.bin, "mpiicx")):
+                    mpi_provider_prefix = mpi_provider.prefix.bin
+                elif os.path.exists(os.path.join(mpi_provider.prefix, "mpi", str(mpi_provider.version), "bin", "mpiicx")):
+                    mpi_provider_prefix = os.path.join(mpi_provider.prefix, "mpi", str(mpi_provider.version), "bin")
+                else:
+                    raise Exception("Unable to locate 'mpiicx'")
+                substitutes["MPICC"]  = os.path.join(mpi_provider_prefix, "mpiicx")
+                substitutes["MPICXX"] = os.path.join(mpi_provider_prefix, "mpiicpx")
                 if "ifx" in COMPILER_SUBSTITUTES_SAVE["FC"] and not "ifort" in COMPILER_SUBSTITUTES_SAVE["FC"]:
-                    substitutes["MPIF77"] = os.path.join(mpi_provider.prefix.bin, "mpiifx")
-                    substitutes["MPIF90"] = os.path.join(mpi_provider.prefix.bin, "mpiifx")
+                    substitutes["MPIF77"] = os.path.join(mpi_provider_prefix, "mpiifx")
+                    substitutes["MPIF90"] = os.path.join(mpi_provider_prefix, "mpiifx")
                 elif not "ifx" in COMPILER_SUBSTITUTES_SAVE["FC"] and "ifort" in COMPILER_SUBSTITUTES_SAVE["FC"]:
-                    substitutes["MPIF77"] = os.path.join(mpi_provider.prefix.bin, "mpiifort")
-                    substitutes["MPIF90"] = os.path.join(mpi_provider.prefix.bin, "mpiifort")
+                    substitutes["MPIF77"] = os.path.join(mpi_provider_prefix, "mpiifort")
+                    substitutes["MPIF90"] = os.path.join(mpi_provider_prefix, "mpiifort")
                 else:
                     raise Exception(f"For {mpi_provider.name}, cannot determine MPI wrapper from FC={COMPILER_SUBSTITUTES_SAVE['FC']}")
             elif mpi_provider.name == "intel-oneapi-mpi" and compiler.name == "intel-oneapi-compilers-classic":
-                substitutes["MPICC"]  = os.path.join(mpi_provider.prefix.bin, "mpiicc")
-                substitutes["MPICXX"] = os.path.join(mpi_provider.prefix.bin, "mpiicpc")
-                substitutes["MPIF77"] = os.path.join(mpi_provider.prefix.bin, "mpiifort")
-                substitutes["MPIF90"] = os.path.join(mpi_provider.prefix.bin, "mpiifort")
+                if os.path.exists(os.path.join(mpi_provider.prefix.bin, "mpiicc")):
+                    mpi_provider_prefix = mpi_provider.prefix.bin
+                elif os.path.exists(os.path.join(mpi_provider.prefix, "mpi", str(mpi_provider.version), "bin", "mpiicc")):
+                    mpi_provider_prefix = os.path.join(mpi_provider.prefix, "mpi", str(mpi_provider.version), "bin")
+                else:
+                    raise Exception("Unable to locate 'mpiicc'")
+                substitutes["MPICC"]  = os.path.join(mpi_provider_prefix, "mpiicc")
+                substitutes["MPICXX"] = os.path.join(mpi_provider_prefix, "mpiicpc")
+                substitutes["MPIF77"] = os.path.join(mpi_provider_prefix, "mpiifort")
+                substitutes["MPIF90"] = os.path.join(mpi_provider_prefix, "mpiifort")
             else:
                 substitutes["MPICC"]  = os.path.join(mpi_provider.prefix.bin, "mpicc")
                 substitutes["MPICXX"] = os.path.join(mpi_provider.prefix.bin, "mpic++")


### PR DESCRIPTION
## Description

1. New package `adp-preprocessors`, enabled as a variant for `jedi-neptune-env` and off by default so that the unified environment builds out of the box on other systems.
2. Use `w3emc` version 2.10.0 instead of the newer 2.11.0 with LLVM native, because 2.11.0 doesn't build. We only need 2.11.0 with Intel LLVM for now, because the older versions don't support the Intel LLVM compilers. In a future update, when `grib-utils` are updated to no longer require the deprecated `extradeps` variant from `w3emc`, we can hopefully update to 2.12.0 or a newer version that builds with all compilers.
3. Update submodule pointer for spack-packages for the recently merged PR https://github.com/JCSDA/spack-packages/pull/17 (use spack v1 syntax in MCT package to set -fPIC).
4. Bug fix in `spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py`: set correct path to Intel oneAPI MPI compiler wrappers (this can be wrong, depending on how the external Intel oneAPI MPI was installed and is used (prefix vs modules).

### Dependencies

- [x] https://github.com/JCSDA/spack-packages/pull/17

### Issues addressed

NRL-internal GitHub issue only, none created here

### Applications affected

None directly

### Systems affected

Atlantis (because it uses LLVM 21.1.0), Nautilus (`setup-meta-modules` bug fix)

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation on readthedocs are included in this PR~~
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
