### PR TITLE
[spack v0.23 / spack-stack v1] Add esmf@8.9.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/esmf891
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "spack"]
   path = spack
-  url = https://github.com/jcsda/spack
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack
+  branch = feature/esmf891
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -136,6 +136,8 @@ modules:
           ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
           ^esmf@8.9.0~debug snapshot=none: 'esmf-8.9.0'
           ^esmf@8.9.0+debug snapshot=none: 'esmf-8.9.0-debug'
+          ^esmf@8.9.1~debug snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug snapshot=none: 'esmf-8.9.1-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -134,6 +134,8 @@ modules:
           ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
           ^esmf@8.9.0~debug snapshot=none: 'esmf-8.9.0'
           ^esmf@8.9.0+debug snapshot=none: 'esmf-8.9.0-debug'
+          ^esmf@8.9.1~debug snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug snapshot=none: 'esmf-8.9.1-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@ packages:
   esmf:
     require:
     - '~xerces ~pnetcdf +shared +external-parallelio'
-    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0 snapshot=none']
+    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.1 snapshot=none']
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env ~debug +espc ^esmf@=8.9.0 snapshot=none
-      - neptune-env +debug +espc ^esmf@=8.9.0 snapshot=none
-      - neptune-python-env ^neptune-env ~debug +espc ^esmf@=8.9.0 snapshot=none
+      - neptune-env ~debug +espc ^esmf@=8.9.1 snapshot=none
+      - neptune-env +debug +espc ^esmf@=8.9.1 snapshot=none
+      - neptune-python-env ^neptune-env ~debug +espc ^esmf@=8.9.1 snapshot=none
 
   specs:
     - matrix:

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,12 +14,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.9.0
+    - jedi-neptune-env      ^esmf@=8.9.1
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.9.0
-    - neptune-python-env    ^esmf@=8.9.0
+    - neptune-env           ^esmf@=8.9.1
+    - neptune-python-env    ^esmf@=8.9.1
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)
@@ -34,7 +34,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1
     - esmf@=8.8.0
-    - esmf@=8.9.0
+    - esmf@=8.9.1
 
   specs:
   - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -17,12 +17,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.9.0
+    - jedi-neptune-env      ^esmf@=8.9.1
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.9.0
-    - neptune-python-env    ^esmf@=8.9.0
+    - neptune-env           ^esmf@=8.9.1
+    - neptune-python-env    ^esmf@=8.9.1
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.2
     - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.2
@@ -39,7 +39,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1
     - esmf@=8.8.0
-    - esmf@=8.9.0
+    - esmf@=8.9.1
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5


### PR DESCRIPTION
## Description

Update esmf@8.9.0 to esmf@8.9.1.

A similar change already went into the feature/update_to_spack_v1 branches, but it turns out we need it in develop now.

I will resolve merge conflicts when I pull the updated spack-stack develop / spack spack-stack-dev branches into the feature/update_to_spack_v1 branche

### Dependencies

- [x] waiting on https://github.com/JCSDA/spack/pull/571

### Issues addressed

n/a (already resolved for the feature/update_to_spack_v1 branches)

### Applications affected

NEPTUNE

### Systems affected

NRL systems

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] All necessary updates to the spack-stack wiki will be made when this PR is merged
