### PR TITLE
enable autocompletion for spack-stack extensions

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,8 @@ echo "Setting environment variable SPACK_STACK_DIR to ${SPACK_STACK_DIR}"
 export SPACK_DISABLE_LOCAL_CONFIG=true
 export SPACK_USER_CACHE_PATH=${SPACK_STACK_DIR}/cache/user_cache
 
+echo "Enabling shell completions for spack-stack extensions..."
+${SPACK_STACK_DIR}/spack/bin/spack commands --update-completion
 source ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh
 echo "Sourcing spack environment ${SPACK_STACK_DIR}/spack/share/spack/setup-env.sh"
 


### PR DESCRIPTION
## Description

This PR enables shell autocompletions for the spack-stack Spack extension commands. It modifies setup.sh to run `spack commands --update-completion`, which detects the argparse arguments defined in our extensions and translates them into shell completions. As far as I can tell this is the "right" way to implement this, and in particular it does not require any spack-stack-specific logic.

### Dependencies
none

### Issues addressed

none

### Applications affected

n/a

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- tested on personal computer

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
