### PR TITLE
[feature/update_to_spack_v1] Add suffix `-openmp` to package modules with package variant `+openmp`; add variants `ncview` and `openmp` to `neptune-env`

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -112,7 +112,7 @@ jobs:
 
             # Concretize and check for duplicates
             spack concretize --force --fresh 2>&1 | tee log.concretize.${ENVNAME}
-            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms
+            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms -i ip
 
             # Add and update source cache
             spack mirror add local-source file://${SOURCE_CACHE_PATH}/
@@ -190,7 +190,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.${ENVNAME}
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms -i ip
 
           # Add binary cache back in
           spack mirror add local-binary file://${BUILD_CACHE_PATH}/

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -128,7 +128,7 @@ jobs:
 
             # Concretize and check for duplicates
             spack concretize --force --fresh 2>&1 | tee log.concretize.${ENVNAME}
-            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms
+            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms -i ip
 
             # Add and update source cache
             spack mirror add local-source file://${SOURCE_CACHE_PATH}/
@@ -209,7 +209,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.${ENVNAME}
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms -i ip
 
           # Add binary cache back in
           spack mirror add local-binary file://${BUILD_CACHE_PATH}/

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -128,7 +128,7 @@ jobs:
 
             # Concretize and check for duplicates
             spack concretize --force --fresh 2>&1 | tee log.concretize.${ENVNAME}
-            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms
+            ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms -i ip
 
             # Add and update source cache
             spack mirror add local-source file://${SOURCE_CACHE_PATH}/
@@ -209,7 +209,7 @@ jobs:
 
           # Concretize and check for duplicates
           spack concretize --force 2>&1 | tee log.concretize.${ENVNAME}
-          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms
+          ${SPACK_STACK_DIR}/util/show_duplicate_packages.py -i fms -i crtm -i crtm-fix -i esmf -i mapl -i py-cython -i neptune-env -i fms -i ip
 
           # Add binary cache back in
           spack mirror add local-binary file://${BUILD_CACHE_PATH}/

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -136,6 +136,8 @@ modules:
           ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
           ^esmf@8.9.0~debug snapshot=none: 'esmf-8.9.0'
           ^esmf@8.9.0+debug snapshot=none: 'esmf-8.9.0-debug'
+          ^esmf@8.9.1~debug snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug snapshot=none: 'esmf-8.9.1-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -112,6 +112,7 @@ modules:
         suffixes:
           +debug: 'debug'
           build_type=Debug:  'debug'
+          +openmp: 'openmp'
       ecmwf-atlas:
         environment:
           set:
@@ -130,22 +131,18 @@ modules:
             'MADIS_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.4.2~debug snapshot=none: 'esmf-8.4.2'
-          ^esmf@8.4.2+debug snapshot=none: 'esmf-8.4.2-debug'
-          ^esmf@8.5.0~debug snapshot=none: 'esmf-8.5.0'
-          ^esmf@8.5.0+debug snapshot=none: 'esmf-8.5.0-debug'
-          ^esmf@8.6.0~debug snapshot=none: 'esmf-8.6.0'
-          ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
-          ^esmf@8.6.1~debug snapshot=none: 'esmf-8.6.1'
-          ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
-          ^esmf@8.7.0~debug snapshot=none: 'esmf-8.7.0'
-          ^esmf@8.7.0+debug snapshot=none: 'esmf-8.7.0-debug'
-          ^esmf@8.8.0~debug snapshot=none: 'esmf-8.8.0'
-          ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
-          ^esmf@8.9.0~debug snapshot=none: 'esmf-8.9.0'
-          ^esmf@8.9.0+debug snapshot=none: 'esmf-8.9.0-debug'
-          ^esmf@8.9.1~debug snapshot=none: 'esmf-8.9.1'
-          ^esmf@8.9.1+debug snapshot=none: 'esmf-8.9.1-debug'
+          ^esmf@8.6.1~debug ~openmp snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug ~openmp snapshot=none: 'esmf-8.6.1-debug'
+          ^esmf@8.6.1~debug +openmp snapshot=none: 'esmf-8.6.1-openmp'
+          ^esmf@8.6.1+debug +openmp snapshot=none: 'esmf-8.6.1-debug-openmp'
+          ^esmf@8.8.0~debug ~openmp snapshot=none: 'esmf-8.8.0'
+          ^esmf@8.8.0+debug ~openmp snapshot=none: 'esmf-8.8.0-debug'
+          ^esmf@8.8.0~debug +openmp snapshot=none: 'esmf-8.8.0-openmp'
+          ^esmf@8.8.0+debug +openmp snapshot=none: 'esmf-8.8.0-debug-openmp'
+          ^esmf@8.9.1~debug ~openmp snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug ~openmp snapshot=none: 'esmf-8.9.1-debug'
+          ^esmf@8.9.1~debug +openmp snapshot=none: 'esmf-8.9.1-openmp'
+          ^esmf@8.9.1+debug +openmp snapshot=none: 'esmf-8.9.1-debug-openmp'
       fms:
         suffixes:
           constants=GFS: 'gfs-constants'

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -112,7 +112,6 @@ modules:
         suffixes:
           +debug: 'debug'
           build_type=Debug:  'debug'
-          +openmp: 'openmp'
       ecmwf-atlas:
         environment:
           set:
@@ -121,6 +120,14 @@ modules:
         environment:
           set:
             'ESMFMKFILE': '{prefix}/lib/esmf.mk'
+        suffixes:
+          ~openmp: 'noopenmp'
+      ip:
+        suffixes:
+          ~openmp: 'noopenmp'
+      neptune-env:
+        suffixes:
+          ~openmp: 'noopenmp'
       libpng:
         environment:
           set:
@@ -131,18 +138,18 @@ modules:
             'MADIS_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.6.1~debug ~openmp snapshot=none: 'esmf-8.6.1'
-          ^esmf@8.6.1+debug ~openmp snapshot=none: 'esmf-8.6.1-debug'
-          ^esmf@8.6.1~debug +openmp snapshot=none: 'esmf-8.6.1-openmp'
-          ^esmf@8.6.1+debug +openmp snapshot=none: 'esmf-8.6.1-debug-openmp'
-          ^esmf@8.8.0~debug ~openmp snapshot=none: 'esmf-8.8.0'
-          ^esmf@8.8.0+debug ~openmp snapshot=none: 'esmf-8.8.0-debug'
-          ^esmf@8.8.0~debug +openmp snapshot=none: 'esmf-8.8.0-openmp'
-          ^esmf@8.8.0+debug +openmp snapshot=none: 'esmf-8.8.0-debug-openmp'
-          ^esmf@8.9.1~debug ~openmp snapshot=none: 'esmf-8.9.1'
-          ^esmf@8.9.1+debug ~openmp snapshot=none: 'esmf-8.9.1-debug'
-          ^esmf@8.9.1~debug +openmp snapshot=none: 'esmf-8.9.1-openmp'
-          ^esmf@8.9.1+debug +openmp snapshot=none: 'esmf-8.9.1-debug-openmp'
+          ^esmf@8.6.1~debug ~openmp snapshot=none: 'esmf-8.6.1-noopenmp'
+          ^esmf@8.6.1+debug ~openmp snapshot=none: 'esmf-8.6.1-debug-noopenmp'
+          ^esmf@8.6.1~debug +openmp snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug +openmp snapshot=none: 'esmf-8.6.1-debug'
+          ^esmf@8.8.0~debug ~openmp snapshot=none: 'esmf-8.8.0-noopenmp'
+          ^esmf@8.8.0+debug ~openmp snapshot=none: 'esmf-8.8.0-debug-noopenmp'
+          ^esmf@8.8.0~debug +openmp snapshot=none: 'esmf-8.8.0'
+          ^esmf@8.8.0+debug +openmp snapshot=none: 'esmf-8.8.0-debug'
+          ^esmf@8.9.1~debug ~openmp snapshot=none: 'esmf-8.9.1-noopenmp'
+          ^esmf@8.9.1+debug ~openmp snapshot=none: 'esmf-8.9.1-debug-noopenmp'
+          ^esmf@8.9.1~debug +openmp snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug +openmp snapshot=none: 'esmf-8.9.1-debug'
       fms:
         suffixes:
           constants=GFS: 'gfs-constants'

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -134,6 +134,8 @@ modules:
           ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
           ^esmf@8.9.0~debug snapshot=none: 'esmf-8.9.0'
           ^esmf@8.9.0+debug snapshot=none: 'esmf-8.9.0-debug'
+          ^esmf@8.9.1~debug snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug snapshot=none: 'esmf-8.9.1-debug'
       openmpi:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -131,6 +131,7 @@ modules:
         suffixes:
           +debug: 'debug'
           build_type=Debug:  'debug'
+          +openmp: 'openmp'
       ecmwf-atlas:
         environment:
           set:
@@ -149,22 +150,18 @@ modules:
             'MADIS_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.4.2~debug snapshot=none: 'esmf-8.4.2'
-          ^esmf@8.4.2+debug snapshot=none: 'esmf-8.4.2-debug'
-          ^esmf@8.5.0~debug snapshot=none: 'esmf-8.5.0'
-          ^esmf@8.5.0+debug snapshot=none: 'esmf-8.5.0-debug'
-          ^esmf@8.6.0~debug snapshot=none: 'esmf-8.6.0'
-          ^esmf@8.6.0+debug snapshot=none: 'esmf-8.6.0-debug'
-          ^esmf@8.6.1~debug snapshot=none: 'esmf-8.6.1'
-          ^esmf@8.6.1+debug snapshot=none: 'esmf-8.6.1-debug'
-          ^esmf@8.7.0~debug snapshot=none: 'esmf-8.7.0'
-          ^esmf@8.7.0+debug snapshot=none: 'esmf-8.7.0-debug'
-          ^esmf@8.8.0~debug snapshot=none: 'esmf-8.8.0'
-          ^esmf@8.8.0+debug snapshot=none: 'esmf-8.8.0-debug'
-          ^esmf@8.9.0~debug snapshot=none: 'esmf-8.9.0'
-          ^esmf@8.9.0+debug snapshot=none: 'esmf-8.9.0-debug'
-          ^esmf@8.9.1~debug snapshot=none: 'esmf-8.9.1'
-          ^esmf@8.9.1+debug snapshot=none: 'esmf-8.9.1-debug'
+          ^esmf@8.6.1~debug ~openmp snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug ~openmp snapshot=none: 'esmf-8.6.1-debug'
+          ^esmf@8.6.1~debug +openmp snapshot=none: 'esmf-8.6.1-openmp'
+          ^esmf@8.6.1+debug +openmp snapshot=none: 'esmf-8.6.1-debug-openmp'
+          ^esmf@8.8.0~debug ~openmp snapshot=none: 'esmf-8.8.0'
+          ^esmf@8.8.0+debug ~openmp snapshot=none: 'esmf-8.8.0-debug'
+          ^esmf@8.8.0~debug +openmp snapshot=none: 'esmf-8.8.0-openmp'
+          ^esmf@8.8.0+debug +openmp snapshot=none: 'esmf-8.8.0-debug-openmp'
+          ^esmf@8.9.1~debug ~openmp snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug ~openmp snapshot=none: 'esmf-8.9.1-debug'
+          ^esmf@8.9.1~debug +openmp snapshot=none: 'esmf-8.9.1-openmp'
+          ^esmf@8.9.1+debug +openmp snapshot=none: 'esmf-8.9.1-debug-openmp'
       fms:
         suffixes:
           constants=GFS: 'gfs-constants'

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -131,7 +131,6 @@ modules:
         suffixes:
           +debug: 'debug'
           build_type=Debug:  'debug'
-          +openmp: 'openmp'
       ecmwf-atlas:
         environment:
           set:
@@ -140,6 +139,14 @@ modules:
         environment:
           set:
             'ESMFMKFILE': '{prefix}/lib/esmf.mk'
+        suffixes:
+          ~openmp: 'noopenmp'
+      ip:
+        suffixes:
+          ~openmp: 'noopenmp'
+      neptune-env:
+        suffixes:
+          ~openmp: 'noopenmp'
       libpng:
         environment:
           set:
@@ -150,18 +157,18 @@ modules:
             'MADIS_ROOT': '{prefix}'
       mapl:
         suffixes:
-          ^esmf@8.6.1~debug ~openmp snapshot=none: 'esmf-8.6.1'
-          ^esmf@8.6.1+debug ~openmp snapshot=none: 'esmf-8.6.1-debug'
-          ^esmf@8.6.1~debug +openmp snapshot=none: 'esmf-8.6.1-openmp'
-          ^esmf@8.6.1+debug +openmp snapshot=none: 'esmf-8.6.1-debug-openmp'
-          ^esmf@8.8.0~debug ~openmp snapshot=none: 'esmf-8.8.0'
-          ^esmf@8.8.0+debug ~openmp snapshot=none: 'esmf-8.8.0-debug'
-          ^esmf@8.8.0~debug +openmp snapshot=none: 'esmf-8.8.0-openmp'
-          ^esmf@8.8.0+debug +openmp snapshot=none: 'esmf-8.8.0-debug-openmp'
-          ^esmf@8.9.1~debug ~openmp snapshot=none: 'esmf-8.9.1'
-          ^esmf@8.9.1+debug ~openmp snapshot=none: 'esmf-8.9.1-debug'
-          ^esmf@8.9.1~debug +openmp snapshot=none: 'esmf-8.9.1-openmp'
-          ^esmf@8.9.1+debug +openmp snapshot=none: 'esmf-8.9.1-debug-openmp'
+          ^esmf@8.6.1~debug ~openmp snapshot=none: 'esmf-8.6.1-noopenmp'
+          ^esmf@8.6.1+debug ~openmp snapshot=none: 'esmf-8.6.1-debug-noopenmp'
+          ^esmf@8.6.1~debug +openmp snapshot=none: 'esmf-8.6.1'
+          ^esmf@8.6.1+debug +openmp snapshot=none: 'esmf-8.6.1-debug'
+          ^esmf@8.8.0~debug ~openmp snapshot=none: 'esmf-8.8.0-noopenmp'
+          ^esmf@8.8.0+debug ~openmp snapshot=none: 'esmf-8.8.0-debug-noopenmp'
+          ^esmf@8.8.0~debug +openmp snapshot=none: 'esmf-8.8.0'
+          ^esmf@8.8.0+debug +openmp snapshot=none: 'esmf-8.8.0-debug'
+          ^esmf@8.9.1~debug ~openmp snapshot=none: 'esmf-8.9.1-noopenmp'
+          ^esmf@8.9.1+debug ~openmp snapshot=none: 'esmf-8.9.1-debug-noopenmp'
+          ^esmf@8.9.1~debug +openmp snapshot=none: 'esmf-8.9.1'
+          ^esmf@8.9.1+debug +openmp snapshot=none: 'esmf-8.9.1-debug'
       fms:
         suffixes:
           constants=GFS: 'gfs-constants'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -70,7 +70,7 @@ packages:
   esmf:
     require:
     - '~xerces ~pnetcdf +shared +external-parallelio'
-    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.0 snapshot=none']
+    - any_of: ['@=8.6.1 snapshot=none', '@=8.8.0 snapshot=none', '@=8.9.1 snapshot=none']
     - any_of: ['fflags="-fp-model precise" cxxflags="-fp-model precise"']
       when: "%intel"
       message: "Extra ESMF compile options for Intel"

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,10 +8,12 @@ spack:
   include: []
 
   specs:
-  - neptune-env ~debug +espc ^esmf@=8.9.1
-  - neptune-env +debug +espc ^esmf@=8.9.1
-  - neptune-python-env    ^neptune-env ~debug +espc ^esmf@=8.9.1
-  - jedi-neptune-env +adp ^neptune-env ~debug +espc ^esmf@=8.9.1
+  - neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-env +debug +openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-env ~debug ~openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-env +debug ~openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-python-env    ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  - jedi-neptune-env +adp ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
   - crtm@3.1.2
   - crtm@v2.4.1-jedi.2
 

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   - compilers: ['%aocc', '%apple-clang', '%gcc', '%intel', '%oneapi']
   - packages:
-      - neptune-env ~debug +espc ^esmf@=8.9.0 snapshot=none
-      - neptune-env +debug +espc ^esmf@=8.9.0 snapshot=none
-      - neptune-python-env ^neptune-env ~debug +espc ^esmf@=8.9.0 snapshot=none
+      - neptune-env ~debug +espc ^esmf@=8.9.1 snapshot=none
+      - neptune-env +debug +espc ^esmf@=8.9.1 snapshot=none
+      - neptune-python-env ^neptune-env ~debug +espc ^esmf@=8.9.1 snapshot=none
 
   specs:
     - matrix:

--- a/configs/templates/neptune-ops/spack.yaml
+++ b/configs/templates/neptune-ops/spack.yaml
@@ -8,7 +8,7 @@ spack:
   include: []
 
   specs:
-  - neptune-env ~debug +espc ^esmf@=8.9.1
+  - neptune-env ~debug +openmp +espc ~ncview ^esmf@=8.9.1
 
   packages:
     # Turn off python variant for esmf

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,12 +14,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.9.0
+    - jedi-neptune-env      ^esmf@=8.9.1
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.9.0
-    - neptune-python-env    ^esmf@=8.9.0
+    - neptune-env           ^esmf@=8.9.1
+    - neptune-python-env    ^esmf@=8.9.1
     - soca-env
 
     # Various crtm tags (list all to avoid duplicate packages)
@@ -34,7 +34,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1
     - esmf@=8.8.0
-    - esmf@=8.9.0
+    - esmf@=8.9.1
 
   specs:
   - matrix:

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -17,12 +17,12 @@ spack:
     - jedi-fv3-env
     - jedi-geos-env         ^esmf@=8.6.1
     - jedi-mpas-env
-    - jedi-neptune-env      ^esmf@=8.9.0
+    - jedi-neptune-env      ^esmf@=8.9.1
     - jedi-tools-env
     - jedi-ufs-env          ^esmf@=8.8.0
     - jedi-um-env
-    - neptune-env           ^esmf@=8.9.0
-    - neptune-python-env    ^esmf@=8.9.0
+    - neptune-env           ^esmf@=8.9.1
+    - neptune-python-env    ^esmf@=8.9.1
     - soca-env
     - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.2
     - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.2
@@ -39,7 +39,7 @@ spack:
     # Various esmf tags (list all to avoid duplicate packages)
     - esmf@=8.6.1
     - esmf@=8.8.0
-    - esmf@=8.9.0
+    - esmf@=8.9.1
 
     # MADIS for WCOSS2 decoders.
     - madis@4.5

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_env/package.py
@@ -21,7 +21,9 @@ class NeptuneEnv(BundlePackage):
     version("1.5.0")
 
     variant("espc", default=False, description="Build ESPC dependencies")
+    variant("ncview", default=False, description="Build ncview")
     variant("debug", default=False, description="Build debug version of selected dependencies")
+    variant("openmp", default=True, description="Build OpenMP-enabled versions of dependencies")
 
     depends_on("base-env", type="run")
 
@@ -33,15 +35,21 @@ class NeptuneEnv(BundlePackage):
     depends_on("libyaml", type="run")
     depends_on("p4est", type="run")
     depends_on("w3emc", type="run")
-    depends_on("ip", type="run")
-    depends_on("esmf ~debug", type="run", when="~debug")
-    depends_on("esmf +debug", type="run", when="+debug")
+    depends_on("ip ~openmp", type="run", when="~openmp")
+    depends_on("ip +openmp", type="run", when="+openmp")
+    depends_on("esmf ~debug ~openmp", type="run", when="~debug ~openmp")
+    depends_on("esmf ~debug +openmp", type="run", when="~debug +openmp")
+    depends_on("esmf +debug ~openmp", type="run", when="+debug ~openmp")
+    depends_on("esmf +debug +openmp", type="run", when="+debug +openmp")
     depends_on("nco", type="run")
     depends_on("mct", type="run")
 
     with when("+espc"):
         depends_on("fftw", type="run")
         depends_on("netlib-lapack", type="run")
+
+    with when("+ncview"):
+        depends_on("ncview", type="run")
 
     # Basic Python dependencies that are always needed
     depends_on("py-f90nml", type="run")

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -529,7 +529,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     fi
 
     # Check for duplicate packages
-    ./util/show_duplicate_packages.py -i crtm -i crtm-fix -i esmf -i mapl -i neptune-env -i py-cython
+    ./util/show_duplicate_packages.py -i crtm -i crtm-fix -i esmf -i mapl -i neptune-env -i py-cython -i ip
 
     # Update local source cache if requested
     if [[ "${update_source_cache}" == "true"* ]]; then


### PR DESCRIPTION
## Description

1. Add suffix `-noopenmp` to package modules for `esmf`, `ip`, `neptune-env` when variant `~openmp` is used. This includes the special ESMF suffices for MAPL.
2. Remove unused ESMF suffices for MAPL modules.
3. Add variants `ncview` and `openmp` to the `neptune-env` virtual package; update the `neptune-dev` and `neptune-ops` templates accordingly.
4. Update submodule pointer for `repos/builtin` (https://github.com/JCSDA/spack-packages/pull/24 and https://github.com/JCSDA/spack-packages/pull/25),
5. Update submodule pointer for `spack` (https://github.com/JCSDA/spack/pull/569),

Resulting `module li` after loading the NEPTUNE environment for no-openmp release build
```
Currently Loaded Modules:
  1) gcc/13.2.1           13) git/2.43.0            25) sqlite/3.46.0            37) wget/1.24.5          49) nco/5.3.3
  2) stack-gcc/13.2.1     14) hdf5/1.14.5           26) util-linux-uuid/2.41     38) base-env/1.0.0       50) netlib-lapack/3.12.1
  3) glibc/2.34           15) snappy/1.2.1          27) python/3.11.11           39) libyaml/0.2.5        51) p4est/2.8.7
  4) numactl/2.0.18       16) zstd/1.5.7            28) python-venv/1.0          40) py-pyyaml/6.0.2      52) py-f90nml/1.4.3
  5) zlib/1.3.1           17) c-blosc/1.21.6        29) py-pip/25.1.1            41) esmf/8.9.1-noopenmp  53) py-six/1.17.0
  6) pmix/5.0.5           18) netcdf-c/4.9.2        30) py-iniconfig/1.1.1       42) fftw/3.3.10          54) py-python-dateutil/2.8.2
  7) openmpi/5.0.8        19) nccmp/1.9.0.1         31) py-packaging/25.0        43) openblas/0.3.29      55) bacio/2.6.0
  8) stack-openmpi/5.0.8  20) netcdf-fortran/4.6.1  32) py-pluggy/1.5.0          44) ip/5.4.0-noopenmp    56) w3emc/2.11.0
  9) cloc/2.00            21) parallelio/2.6.2      33) py-pytest/8.2.1          45) mct/2.11.0           57) neptune-env/1.5.0-noopenmp
 10) nghttp2/1.65.0       22) pigz/2.8              34) py-setuptools/69.2.0     46) antlr/2.7.7
 11) curl/8.11.1          23) tar/1.35              35) py-setuptools-scm/8.2.1  47) gsl/2.8
 12) cmake/3.31.8         24) gettext/0.23.1        36) py-wheel/0.45.1          48) udunits/2.2.28
```

### Dependencies

None (all submodule PRs listed above already merged)

### Issues addressed

Closes #1770 
Closes #1803

### Applications affected

NEPTUNE

### Systems affected

None directly

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] All necessary updates to the spack-stack wiki will be made when this PR is merged
