### PR TITLE
[skip ci] Set UDUNITS2_XML_PATH in modules

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -266,6 +266,12 @@ modules:
           set:
             'UPP_INC': '{prefix}/include'
             'UPP_LIB': '{prefix}/lib/libupp.a'
+      # NOTE: This will be fixed upstream in udunits Spack package
+      # Once this is done, remove this section
+      udunits:
+        environment:
+          set:
+            'UDUNITS2_XML_PATH': '{prefix}/share/udunits/udunits2.xml'
 
       hierarchy:
       - mpi

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -285,3 +285,9 @@ modules:
           set:
             'UPP_INC': '{prefix}/include'
             'UPP_LIB': '{prefix}/lib/libupp.a'
+      # NOTE: This will be fixed upstream in udunits Spack package
+      # Once this is done, remove this section
+      udunits:
+        environment:
+          set:
+            'UDUNITS2_XML_PATH': '{prefix}/share/udunits/udunits2.xml'


### PR DESCRIPTION
## Description

This is the "simple" solution to #1842. The ideal way will be to do so via spack-packages, but since spack-stack 2.0 is out soon, this is the "easy" way. 

We can undo this once/if https://github.com/spack/spack-packages/pull/2729 is merged and then get into 2.1


### Dependencies

None.

### Issues addressed

Addresses #1842 though a true fix is in https://github.com/spack/spack-packages/pull/2729

### Applications affected

I suppose anything using udunits will be affected. But then, without this, they shouldn't have been able to run, I'd think (unless the code hardcoded in the path to the xml file).


### Systems affected

All that use modulefiles.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
