### PR TITLE
[release/2.0] Fix MET segmentation faults in spack-packages, navy-aws site config updates round 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = release/2.0
+  #url = https://github.com/jcsda/spack-packages
+  #branch = release/2.0
+  url = https://github.com/climbfuji/spack-packages
+  branch = bugfix/rel20_met_segfault

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
   branch = v1.3.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = release/2.0
-  url = https://github.com/climbfuji/spack-packages
-  branch = bugfix/rel20_met_segfault
+  url = https://github.com/jcsda/spack-packages
+  branch = release/2.0

--- a/configs/sites/tier1/navy-aws/bootstrap.yaml
+++ b/configs/sites/tier1/navy-aws/bootstrap.yaml
@@ -1,9 +1,0 @@
-bootstrap:
-  sources:
-  - name: local-binaries
-    metadata: /project/spack-stack/spack-bootstrap-mirror/metadata/binaries
-  - name: local-sources
-    metadata: /project/spack-stack/spack-bootstrap-mirror/metadata/sources
-  trusted:
-    local-sources: true
-    local-binaries: true

--- a/configs/sites/tier1/navy-aws/config.yaml
+++ b/configs/sites/tier1/navy-aws/config.yaml
@@ -1,10 +1,10 @@
 config:
-  build_jobs: 6
+  build_jobs: 24
 
   # Overrides for spack build and staging areas to speed up builds
   # and avoid errors with hard links on the NFS filesystem /contrib
 
-  build_stage: ${HOME}/spack-stack-cache/build_stage
-  test_stage: ${HOME}/spack-stack-cache/test_stage
-  source_cache: ${HOME}/spack-stack-cache/source_cache
-  misc_cache: ${HOME}/spack-stack-cache/misc_cache
+  build_stage: /scratch/spack-stack-cache/build_stage
+  test_stage: /scratch/spack-stack-cache/test_stage
+  source_cache: /scratch/spack-stack-cache/source_cache
+  misc_cache: /scratch/spack-stack-cache/misc_cache

--- a/configs/sites/tier1/navy-aws/mirrors.yaml
+++ b/configs/sites/tier1/navy-aws/mirrors.yaml
@@ -1,18 +1,4 @@
 mirrors:
-  local-source:
-    fetch:
-      url: file:///contrib/spack-stack/source-cache
-      access_pair:
-      - null
-      - null
-      access_token: null
-      profile: null
-      endpoint_url: null
-    push:
-      url: file:///contrib/spack-stack/source-cache
-      access_pair:
-      - null
-      - null
-      access_token: null
-      profile: null
-      endpoint_url: null
+  local-source: file:///project/spack-stack/source-cache
+  local-binary: file:///project/spack-stack/build-cache
+

--- a/configs/sites/tier1/navy-aws/packages.yaml
+++ b/configs/sites/tier1/navy-aws/packages.yaml
@@ -2,14 +2,6 @@ packages:
   # Modification of common packages
 
   # All other packages listed alphabetically
-  autoconf:
-    externals:
-    - spec: autoconf@2.69
-      prefix: /usr
-  automake:
-    externals:
-    - spec: automake@1.16.2
-      prefix: /usr
   bash:
     externals:
     - spec: bash@5.1.8

--- a/configs/sites/tier1/navy-aws/packages_gcc-13.3.1.yaml
+++ b/configs/sites/tier1/navy-aws/packages_gcc-13.3.1.yaml
@@ -26,4 +26,7 @@ packages:
   openmpi:
     externals:
     - spec: openmpi@4.1.8
-      prefix: /project/spack-stack/openmpi-4.1.8/gcc-13.3.1
+      #prefix: /project/spack-stack/openmpi-4.1.8/gcc-13.3.1
+      modules:
+      - openmpi/4.1.8
+

--- a/util/ldd_check.py
+++ b/util/ldd_check.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 # Whitelist file patterns (checked with re.match()) that will be satisfied by
-# compiler & MPI modules (though arguably these should be added as extra
-# rpaths).
+# compiler, MPI, and Python modules (though arguably these should be added as
+# extra rpaths).
 whitelist = [
     "^libmkl.+",
     "^libifcore.so.*",
+    "~libpython3.*",
 ]
 
 ########

--- a/util/ldd_check.py
+++ b/util/ldd_check.py
@@ -6,7 +6,7 @@
 whitelist = [
     "^libmkl.+",
     "^libifcore.so.*",
-    "~libpython3.*",
+    "^libpython3.*",
 ]
 
 ########

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -103,6 +103,11 @@ fi
 SPACK_STACK_BATCH_HOST=$(echo ${HOSTNAME} | cut -d "." -f 1)
 SPACK_STACK_BATCH_HOST=${SPACK_STACK_BATCH_HOST//[0-9]/}
 
+# Workaround for ParallelWorks login nodes
+if [[ "${SPACK_STACK_BATCH_HOST}" == *"awsneptunecluster"* ]]; then
+  SPACK_STACK_BATCH_HOST="navy-aws"
+fi
+
 case ${SPACK_STACK_BATCH_HOST} in
   atlantis)
     SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.3.0" "gcc@=13.4.0" "clang@=21.1.0")
@@ -138,6 +143,13 @@ case ${SPACK_STACK_BATCH_HOST} in
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/bootstrap-mirror"
     SPACK_STACK_CARGO_MIRROR="/p/cwfs/projects/NEPTUNE/spack-stack/cargo-mirror"
+    ;;
+  navy-aws)
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2025.3.0" "gcc@=13.3.1")
+    SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "cylc-dev")
+    SPACK_STACK_MODULE_CHOICE="tcl"
+    SPACK_STACK_BOOTSTRAP_MIRROR="/project/spack-stack/bootstrap-mirror"
+    SPACK_STACK_CARGO_MIRROR="/project/spack-stack/cargo-mirror"
     ;;
   tusk)
     SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.0" "gcc@=12.1.0")
@@ -221,6 +233,13 @@ function fix_permissions() {
         sleep 30
       fi
       nice -n 19 lfs find ${dir} -type f -print0 | xargs --null chmod a+r
+      ;;
+    navy-aws)
+      nice -n 19 find ${dir} -type d -print0 | xargs --null chmod a+rx
+      if [[ ${executables} -eq 1 ]]; then
+        nice -n 19 find ${dir} -type f -executable -print0 | xargs --null chmod a+rx
+      fi
+      nice -n 19 find ${dir} -type f -print0 | xargs --null chmod a+r
       ;;
     tusk)
       nice -n 19 lfs find ${dir} -type d -print0 | xargs --null chmod a+rx
@@ -426,6 +445,15 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       nautilus)
         umask 0022
         module purge
+        ;;
+      navy-aws)
+        umask 0022
+        module purge
+        case ${compiler} in
+          gcc-13.3.1)
+	    module use /project/spack-stack/openmpi-4.1.8/gcc-13.3.1/modulefiles
+	    ;;
+	esac
         ;;
       tusk)
         umask 0022


### PR DESCRIPTION
## Description

1. Fix MET segmentation faults (spack-packages submodule, see https://github.com/JCSDA/spack-packages/pull/29). This requires adding `libpython3.*` to the whitelist in `util/ldd_check.py`
2. Site config updates for navy-aws tier1 site, add site config to NRL batch install script

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/29

### Issues addressed

Closes #1839 

### Applications affected

MET

### Systems affected

All, but in particular NRL sites Atlantis and Nautilus where the issue was reported

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] All necessary updates to the spack-stack wiki will be made when this PR is merged
