### PR TITLE
release/2.0: Update batch_install.sh - workaround for ParallelWorks

### DIFF
--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -491,6 +491,9 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     fi
     spack env activate -p ${env_dir}
 
+    # Workaround for ParallelWorks (no NRL Enterprise GitHub access yet)
+    sed -i 's/+adp/~adp/g' ${env_dir}/spack.yaml
+
     # Update bootstrap mirror if requested
     if [[ "${update_bootstrap_mirror}" == "true"*  ]]; then
       tmp_bootstrap_mirror_path=${PWD}/tmp-bootstrap-mirror-${env_name}


### PR DESCRIPTION
## Description

release/2.0: Update batch_install.sh - workaround for ParallelWorks: no NRL GitHub access (yet), turn off `adp` variant.

### Dependencies

None

### Issues addressed

_Add any issues here that this PR closes or is related to. Use "Resolves" or "Closes" to automatically close issues when the PR is merged. Using "Working towards" or "Related to" for other cases._

### Applications affected

None

### Systems affected

ParallelWorks

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested on ParallelWorks

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [ ] All necessary updates to the spack-stack wiki will be made when this PR is merged
