### PR TITLE
[skip ci] Update NAS README for modulefile generation

### DIFF
--- a/configs/sites/tier1/nas/README.md
+++ b/configs/sites/tier1/nas/README.md
@@ -75,14 +75,16 @@ NAS login nodes allow only **2 processes**, so use:
 
 ```bash
 qsub -I -V -X \
-    -l select=1:ncpus=128:mpiprocs=128:model=mil_ait \
+    -l select=1:ncpus=128:mpiprocs=128:model=rom_ait \
     -l walltime=12:00:00 \
     -W group_list=s1873 \
     -m b \
     -N Interactive
 ```
 
-This gives a **Milan** compute node for up to 12 hours.
+This gives a **Rome** compute node for up to 12 hours. 
+
+For a **Milan** node, change `model=rom_ait` to `model=mil_ait` and run the `qsub` command on a Milan-capable login node (e.g., `afe02`).
 
 ---
 
@@ -227,7 +229,7 @@ spack install -j 16 --verbose --fail-fast --show-log-on-error \
 
 ---
 
-### Packages Requiring Internet
+### Packages Requiring Internet (AFE LOGIN NODE)
 
 If you encounter another package that insists on network access:
 
@@ -237,18 +239,22 @@ spack install -j 2 --verbose --fail-fast --show-log-on-error \
     |& tee log.install.<package> ; bell
 ```
 
+Again, this must be done on an **afe** login node because of the CPU architecture.
+
 Once built, return to the compute node and resume the full installation.
 
 ---
 
-## Update Module Files
+## Update Module Files (AFE LOGIN NODE)
 
-After installation completes:
+After installation completes, on an **afe** login node run:
 
 ```bash
 spack module tcl refresh -y --delete-tree ; bell
 spack stack setup-meta-modules
 ```
+
+Apparently, spack modulefile generation might use code that spack built for `x86_64_v3`.
 
 ---
 


### PR DESCRIPTION
## Description

This PR updates the NAS README as it was found you must run modulefile generation on a newer-than-PFE node.

### Dependencies

None.

### Issues addressed

None.

### Applications affected

None.

### Systems affected

None.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
