### PR TITLE
[release/2.0] Update .gitmodules: use tags spack-stack-2.0.0 for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "spack"]
   path = spack
   url = https://github.com/jcsda/spack
-  branch = release/2.0
+  branch = spack-stack-2.0.0
 [submodule "repos/builtin"]
   path = repos/builtin
   url = https://github.com/jcsda/spack-packages
-  branch = release/2.0
+  branch = spack-stack-2.0.0


### PR DESCRIPTION
## Description

For `release/2.0`: Update `.gitmodules` to use tags `spack-stack-2.0.0` for submodules spack and spack-packages. No code changes.

### Dependencies

None

### Issues addressed

Working toward #1835 

### Applications affected

None

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.~~
- [ ] ~~These changes have been tested on the affected systems and applications.~~
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
