### PR TITLE
Fix incorrect openmpi version for modulefile

### DIFF
--- a/configs/sites/tier1/hercules/packages_gcc-12.2.0.yaml
+++ b/configs/sites/tier1/hercules/packages_gcc-12.2.0.yaml
@@ -9,7 +9,7 @@ packages:
     - spec: openmpi@4.1.4
       prefix: /apps/spack-managed/gcc-11.3.1/openmpi-4.1.4-zabolhazla2ahsroedlyt2pu4mkp7o3q
       modules:
-      - openmpi/4.1.6
+      - openmpi/4.1.4
   gcc-runtime:
     buildable: False
     externals:


### PR DESCRIPTION
## Description

Modulefile version was incorrect for the `openmpi` spec; pathing was correct.

Noticed / fixed in-situ when building the appropriate env; the env builds / loads as expected.

### Dependencies

None

### Issues addressed

Working towards #1835 

### Applications affected

None

### Systems affected

Hercules

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation on readthedocs are included in this PR
    - For site config updates, check in particular `doc/source/PreConfiguredSites.rst` and `doc/source/MaintainersSection.rst`
- [x] All necessary updates to the spack-stack wiki will be made when this PR is merged
