### PR TITLE
Add paths-ignore for GitHub actions, ignore cargo mirror update errors in NRL batch install scripts

### DIFF
--- a/.github/workflows/TMP_OFF/ubuntu-ci-containers-x86_64.yaml
+++ b/.github/workflows/TMP_OFF/ubuntu-ci-containers-x86_64.yaml
@@ -1,14 +1,15 @@
 name: ubuntu-ci-container-x86_64-build
 on:
   # Uncomment this to test for PRs (but do not submit)
-  # pull_request:
-  #  paths-ignore:
-  #    - 'configs/sites/**'
-  #    - 'doc/**'
-  #    - '**.md'
-  #    - '.github/ISSUE_TEMPLATE/*'
-  #    - '.gitignore'
-  
+  pull_request:
+    paths-ignore:
+      - 'configs/sites/**'
+      - '!configs/sites/tier2/*.default/*'
+      - '**.md'
+      - '.github/CODEOWNERS'
+      - '.github/pull_request_template.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
@@ -55,12 +56,9 @@ jobs:
           DOW=$(date +%u)
           # Monday is 1 ... Sunday is 7
           if [[ $DOW == 1 || $DOW == 4 ]]; then
-            export CONTAINER=${{ inputs.container || 'docker-ubuntu-clang-mpich' }}
-            export SPECS=${{ inputs.specs || 'jedi-ci' }}
-          elif [[ $DOW == 2 ]]; then
             export CONTAINER=${{ inputs.container || 'docker-ubuntu-gcc-openmpi' }}
             export SPECS=${{ inputs.specs || 'jedi-ci' }}
-          elif [[ $DOW == 5 ]]; then
+          elif [[ $DOW == 2 || $DOW == 5 ]]; then
             export CONTAINER=${{ inputs.container || 'docker-ubuntu-gcc11-openmpi' }}
             export SPECS=${{ inputs.specs || 'jedi-ci' }}
           elif [[ $DOW == 3 || $DOW == 6 ]]; then

--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -1,6 +1,14 @@
 name: ubuntu-ci-c6a-x86_64-gnu-build
 on:
   pull_request:
+    paths-ignore:
+      - 'configs/sites/**'
+      - '!configs/sites/tier2/*.default/*'
+      - '**.md'
+      - '.github/CODEOWNERS'
+      - '.github/pull_request_template.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -1,6 +1,14 @@
 name: ubuntu-ci-c6a-x86_64-oneapi-ifx-build
 on:
   pull_request:
+    paths-ignore:
+      - 'configs/sites/**'
+      - '!configs/sites/tier2/*.default/*'
+      - '**.md'
+      - '.github/CODEOWNERS'
+      - '.github/pull_request_template.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -1,6 +1,14 @@
 name: ubuntu-ci-c6a-x86_64-oneapi-build
 on:
   pull_request:
+    paths-ignore:
+      - 'configs/sites/**'
+      - '!configs/sites/tier2/*.default/*'
+      - '**.md'
+      - '.github/CODEOWNERS'
+      - '.github/pull_request_template.md'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -569,10 +569,13 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       spack mirror create -a -d ${source_mirror_path}
     fi
 
-    # Update local cargo mirror if requested
+    # Update local cargo mirror if requested; this can be
+    # unreliable, therefore ignore errors and proceed ...
     if [[ "${update_cargo_mirror}" == "true"* ]]; then
+      set +e
       echo "Updating local cargo mirror ..."
       ./util/fetch_cargo_deps.py
+      set -e
     fi
 
     # Install the environment with the correct flags


### PR DESCRIPTION
## Description

1. Update and add `paths-ignore` for all GitHub actions workflows.
2. `util/nrl/batch_install.sh`: ignore errors when updating cargo mirrors, since this is can be unreliable.

### Dependencies

None

### Issues addressed

None

### Applications affected

None

### Systems affected

NRL systems, GitHub actions

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the spack-stack wiki will be made when this PR is merged~~
