### PR TITLE
Update w3emc to 2.13.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/w3emc_2130

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/w3emc_2130
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -434,14 +434,10 @@ packages:
     uwtools:
       require:
       - '@2.7.2'
-    # Need extradeps for grib-utils, enable by default to avoid duplicate packages
-    # w3emc@2.11.0 doesn't build with LLVM 21
     w3emc:
       require:
-      - one_of: ['@=2.11.0', '@=2.10.0']
-      - one_of: ['@=2.10.0']
-        when: '%clang'
-      - precision=4,d,8 +extradeps
+      - '@2.13.0'
+      - precision=4,d,8 +build_deprecated
     w3nco:
       require:
       - '@2.4.1'


### PR DESCRIPTION
## Description

Update w3emc to 2.13.0 to support the native LLVM compilers (clang, clang++, flang-new).

### Dependencies

- [x]  Waiting on https://github.com/JCSDA/spack-packages/pull/33

### Issues addressed

Closes #1870 

### Applications affected

All applications using CCPP plus additional UFS applications

### Systems affected

Systems using the LLVM compilers (Atlantis, Bounty)

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
