### PR TITLE
NRL updates: New template neptune-dev-llvm, update met/metplus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/w3emc_2130

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/w3emc_2130
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -434,14 +434,10 @@ packages:
     uwtools:
       require:
       - '@2.7.2'
-    # Need extradeps for grib-utils, enable by default to avoid duplicate packages
-    # w3emc@2.11.0 doesn't build with LLVM 21
     w3emc:
       require:
-      - one_of: ['@=2.11.0', '@=2.10.0']
-      - one_of: ['@=2.10.0']
-        when: '%clang'
-      - precision=4,d,8 +extradeps
+      - '@2.13.0'
+      - precision=4,d,8 +build_deprecated
     w3nco:
       require:
       - '@2.4.1'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -221,11 +221,11 @@ packages:
       - ~shared ~f2py +pflogger
     met:
       require:
-      - '@12.0.1'
+      - '@12.1.1'
       - +python +grib2
     metplus:
       require:
-      - '@6.0.0'
+      - '@6.1.0'
     metis:
       require:
       - +int64 +real64

--- a/configs/templates/neptune-dev-llvm/spack.yaml
+++ b/configs/templates/neptune-dev-llvm/spack.yaml
@@ -1,0 +1,35 @@
+# Template for NEPTUNE development
+#
+spack:
+  concretizer:
+    unify: when_possible
+
+  view: false
+  include: []
+
+  specs:
+  - neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-env +debug +openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-env ~debug ~openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-env +debug ~openmp +espc +ncview ^esmf@=8.9.1
+  # Until we can build the entire set of dependencies for
+  # neptune-python-env and jedi-neptune-env, we need to
+  # add the required packages for the NEPTUNE standalone
+  # model manually
+  #- neptune-python-env    ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  #- jedi-neptune-env +adp ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  - py-numpy
+  # Let's assume/hope that by the time FALCON starts
+  # testing with LLVM, we have moved from crtm v2 to v3
+  - crtm@3.1.2
+  #- crtm@v2.4.1-jedi.2
+
+  packages:
+    # Turn on python variant for esmf
+    esmf:
+      require:
+      - +python
+    # Avoid duplicate builds of parallelio +pnetcdf and ~pnetcdf
+    parallelio:
+      require:
+      - ~pnetcdf

--- a/repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py
@@ -22,6 +22,7 @@ class JediNeptuneEnv(BundlePackage):
 
     depends_on("jedi-base-env", type="run")
     depends_on("neptune-env", type="run")
+    depends_on("neptune-python-env", type="run")
 
     with when("+adp"):
         depends_on("adp-preprocessors", type="run")

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
@@ -25,8 +25,10 @@ class NeptunePythonEnv(BundlePackage):
     depends_on("esmf +python", type="run")
 
     depends_on("py-arch", type="run")
+    depends_on("py-cartopy", type="run")
     depends_on("py-cfgrib", type="run")
     depends_on("py-h5py", type="run")
+    depends_on("py-matplotlib", type="run")
     depends_on("py-netcdf4", type="run")
     depends_on("py-pandas", type="run")
     depends_on("py-pycodestyle", type="run")

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -111,7 +111,7 @@ fi
 case ${SPACK_STACK_BATCH_HOST} in
   atlantis)
     SPACK_STACK_BATCH_COMPILERS=("oneapi@=2024.2.1" "oneapi@=2025.3.0" "gcc@=13.4.0" "clang@=21.1.0")
-    SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "neptune-ops" "unified-dev" "cylc-dev")
+    SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "neptune-dev-llvm" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="lmod"
     SPACK_STACK_BOOTSTRAP_MIRROR="/neptune_diagnostics/spack-stack/bootstrap-mirror"
     SPACK_STACK_CARGO_MIRROR="/neptune_diagnostics/spack-stack/cargo-mirror"
@@ -167,7 +167,7 @@ case ${SPACK_STACK_BATCH_HOST} in
     ;;
   bounty)
     SPACK_STACK_BATCH_COMPILERS=("oneapi@=2025.3.0" "gcc@=13.3.1" "clang@=21.1.1")
-    SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "neptune-ops" "unified-dev" "cylc-dev")
+    SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "neptune-dev-llvm" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/home/dom/prod/spack-bootstrap-mirror"
     SPACK_STACK_CARGO_MIRROR="/home/dom/prod/spack-cargo-mirror"
@@ -353,12 +353,12 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     if [[ "${template}" == "cylc-dev" && ! "${compiler_name}" == "gcc" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
-    # With clang, only neptune-ops 
-    elif [[ "${compiler_name}" == "clang" && ! "${template}" == "neptune-ops" ]]; then
+    # With clang, only neptune-dev-llvm 
+    elif [[ "${compiler_name}" == "clang" && ! "${template}" == "neptune-dev-llvm" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
-    # With other compilers, skip neptune-ops
-    elif [[ ! "${compiler_name}" == "clang" && "${template}" == "neptune-ops" ]]; then
+    # With other compilers, skip neptune-dev-llvm
+    elif [[ ! "${compiler_name}" == "clang" && "${template}" == "neptune-dev-llvm" ]]; then
       echo "Skipping template ${template} with compiler ${compiler}"
       continue
     # FMS compiler ICE: https://github.com/NOAA-GFDL/FMS/issues/1680
@@ -377,7 +377,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
       neptune-dev)
         env_name_prefix="ne"
         ;;
-      neptune-ops)
+      neptune-dev-llvm)
         env_name_prefix="ne"
         ;;
       cylc-dev)


### PR DESCRIPTION
## Description

This PR bundles a few updates for NRL:
1. New template `neptune-dev-llvm` for - as the name suggests - the LLVM compilers. We use this instead of the stripped-down `neptune-ops` template so that basic Python packages like `py-numpy` are available. The goal is to gradually fix builds with LLVM until we can switch over to the full `neptune-dev` template and delete the `neptune-dev-llvm` template.
2. Update met to 12.1.1 and metplus to 6.1.0
3. Make Python dependencies `py-cartopy` and `py-matplotlib` explicit in `neptune-python-env`, and by extension also in `jedi-neptune-env`. These packages are already built because of the `py-xarray` dependency, but it's good to list them explicitly in case we remove the `py-xarray` dependency at some point.

### Dependencies

None.

### Issues addressed

Closes #1847 
Closes an issue in the NRL Enterprise GitHub related to updating met and metplus


### Applications affected

Applications using met/metplus.

### Systems affected

NRL systems using LLVM (Atlantis, Bounty).

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Manual testing on Bounty with NEPTUNE
    - [x] Testing on Atlantis with NEPTUNE

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged - **this step is needed and will be completed**
