### PR TITLE
Add gittools as varant to neptune-python-env/neptune-dev, add rank-run to base-env

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -101,6 +101,7 @@ jobs:
             spack external find --scope system wget
             spack external find --scope system texlive
             spack external find --scope system mysql
+            spack external find --scope system bash
 
             # Find compilers
             spack compiler find --scope system

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -101,6 +101,7 @@ jobs:
             spack external find --scope system wget
             spack external find --scope system texlive
             spack external find --scope system mysql
+            spack external find --scope system bash
 
             # Find compilers
             spack compiler find --scope system

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -101,6 +101,7 @@ jobs:
             spack external find --scope system wget
             spack external find --scope system texlive
             spack external find --scope system mysql
+            spack external find --scope system bash
 
             # Find compilers
             spack compiler find --scope system

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "spack"]
   path = spack
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack
-  branch = feature/update_spack-stack-dev_from_develop
+  url = https://github.com/jcsda/spack
+  branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
   #url = https://github.com/jcsda/spack-packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/pygithub_rank_run
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,7 @@
   branch = feature/update_spack-stack-dev_from_develop
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/pygithub_rank_run

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -374,6 +374,10 @@ packages:
     py-poetry-core:
       require:
       - '@1.7'
+    # Need at least py-pygithub@2.7 for self-hosted runner management
+    py-pygithub:
+      require:
+      - '@2.7:'
     # This version builds with Intel oneAPI compilers, newer versions don't
     py-pyogrio:
       require:
@@ -394,7 +398,6 @@ packages:
     py-setuptools:
       require:
       - '@69'
-    ## When making changes here, also check the packages.yaml for atlantis, nautilus, blackpearl
     py-torch:
       require:
       - +custom-protobuf ~mkldnn

--- a/configs/common/packages_oneapi.yaml
+++ b/configs/common/packages_oneapi.yaml
@@ -32,6 +32,9 @@ packages:
     gmake:
       require:
       - '%gcc'
+    go:
+      require:
+      - '%c,cxx=gcc'
     libbsd:
       require:
       - '%gcc'

--- a/configs/sites/tier1/atlantis/packages.yaml
+++ b/configs/sites/tier1/atlantis/packages.yaml
@@ -15,6 +15,10 @@ packages:
     externals:
     - spec: automake@1.16.1
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.20
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.30.117

--- a/configs/sites/tier1/blueback/packages.yaml
+++ b/configs/sites/tier1/blueback/packages.yaml
@@ -12,6 +12,10 @@ packages:
     externals:
     - spec: automake@1.15.1
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.23
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.43.1~gold+headers

--- a/configs/sites/tier1/narwhal/packages.yaml
+++ b/configs/sites/tier1/narwhal/packages.yaml
@@ -12,6 +12,10 @@ packages:
     externals:
     - spec: automake@1.15.1
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.23
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.37.20211103

--- a/configs/sites/tier1/nautilus/packages.yaml
+++ b/configs/sites/tier1/nautilus/packages.yaml
@@ -12,6 +12,10 @@ packages:
     externals:
     - spec: automake@1.16.1
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.20
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.30.117

--- a/configs/sites/tier2/blackpearl/packages.yaml
+++ b/configs/sites/tier2/blackpearl/packages.yaml
@@ -10,6 +10,10 @@ packages:
     externals:
     - spec: automake@1.16.2
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@5.1.8
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.35.2

--- a/configs/sites/tier2/bounty/packages.yaml
+++ b/configs/sites/tier2/bounty/packages.yaml
@@ -10,6 +10,10 @@ packages:
     externals:
     - spec: automake@1.16.2
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@5.1.8
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.35.2~gold+headers

--- a/configs/sites/tier2/jean/packages.yaml
+++ b/configs/sites/tier2/jean/packages.yaml
@@ -21,6 +21,10 @@ packages:
     externals:
     - spec: automake@1.16.1
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.20
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.30.125~gold~headers

--- a/configs/sites/tier2/wheat/packages.yaml
+++ b/configs/sites/tier2/wheat/packages.yaml
@@ -21,6 +21,10 @@ packages:
     externals:
     - spec: automake@1.16.1
       prefix: /usr
+  bash:
+    externals:
+    - spec: bash@4.4.20
+      prefix: /usr
   binutils:
     externals:
     - spec: binutils@2.30.117

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -12,8 +12,8 @@ spack:
   - neptune-env +debug +openmp +espc +ncview ^esmf@=8.9.1
   - neptune-env ~debug ~openmp +espc +ncview ^esmf@=8.9.1
   - neptune-env +debug ~openmp +espc +ncview ^esmf@=8.9.1
-  - neptune-python-env    ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
-  - jedi-neptune-env +adp ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  - neptune-python-env +gittools ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
+  - jedi-neptune-env +adp        ^neptune-env ~debug +openmp +espc +ncview ^esmf@=8.9.1
   - crtm@3.1.2
   - crtm@v2.4.1-jedi.2
 

--- a/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
@@ -44,4 +44,7 @@ class BaseEnv(BundlePackage):
     depends_on("py-setuptools-scm", type="run")
     depends_on("py-pytest", type="run")
 
+    # Miscellaneous
+    depends_on("rank-run", type="run")
+
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
@@ -20,6 +20,8 @@ class NeptunePythonEnv(BundlePackage):
 
     version("1.5.0")
 
+    variant("gittools", default=False, description="Build additional tools for Git/GitHub")
+
     depends_on("neptune-env", type="run")
     # Enable the Python variant for ESMF
     depends_on("esmf +python", type="run")
@@ -43,5 +45,9 @@ class NeptunePythonEnv(BundlePackage):
 
     depends_on("met", type="run")
     depends_on("metplus", type="run")
+
+    with when("+gittools"):
+        depends_on("gh", type="run")
+        depends_on("py-pygithub", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

1. Add `gittools` variant (`gh`, `py-pygithub`) to `neptune-python-env` and enable in `neptune-dev` template. I couldn't enable it in the `unified-dev` template for `oneapi`, because the concretizer ended up in an infinite loop, heating my room overnight but not concretizing the environment.
2. Add `rank-run` to `base-env`.
3. Add external `bash` to all DOD HPCMP systems (required by `gh` --> `go`, don't want to build `bash`!), also find in GitHub workflows (I checked that it is being found and used).
4. Fix bug in `.gitmodules`: unintentional leftover from previous PR that didn't revert the `spack` submodule pointer information.

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/36

### Issues addressed

Closes #1805 
Closes #1727

### Applications affected

NEPTUNE

### Systems affected

NRL systems

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
