### PR TITLE
Bug fix in Nautilus site config: set correct variants for external OpenMPI

### DIFF
--- a/configs/sites/tier1/nautilus/packages_gcc-13.3.1.yaml
+++ b/configs/sites/tier1/nautilus/packages_gcc-13.3.1.yaml
@@ -22,7 +22,7 @@ packages:
   openmpi:
     buildable: False
     externals:
-    - spec: openmpi@5.0.8
+    - spec: openmpi@5.0.8 ~internal-hwloc +two_level_namespace
       prefix: /p/app/penguin/openmpi/5.0.8/gcc-13.3.1
       modules:
       - penguin/openmpi/5.0.8/gcc-13.3.1

--- a/configs/sites/tier2/blackpearl/packages.yaml
+++ b/configs/sites/tier2/blackpearl/packages.yaml
@@ -65,7 +65,6 @@ packages:
     - spec: groff@1.22.4
       prefix: /usr
   m4:
-    # DH* NEEDED? buildable: false
     externals:
     - spec: m4@1.4.19
       prefix: /usr

--- a/configs/sites/tier2/bounty/packages.yaml
+++ b/configs/sites/tier2/bounty/packages.yaml
@@ -69,7 +69,6 @@ packages:
     - spec: groff@1.22.4
       prefix: /usr
   m4:
-    # DH* NEEDED? buildable: false
     externals:
     - spec: m4@1.4.19
       prefix: /usr


### PR DESCRIPTION
## Description

All in the title.

This code is already in the NRL fork/branch, but didn't find its way back into spack-stack develop.

Same for the two comments in the Blackpearl and Bounty site configs.

No CI testing needed.

### Dependencies

None

### Issues addressed

None

### Applications affected

None

### Systems affected

Nautilus

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
