### PR TITLE
Bug fix in Narwhal site config: revert back from OFI to UCX

### DIFF
--- a/configs/sites/tier1/narwhal/packages_gcc-13.3.0.yaml
+++ b/configs/sites/tier1/narwhal/packages_gcc-13.3.0.yaml
@@ -30,10 +30,10 @@ packages:
     buildable: false
     externals:
     - spec: cray-mpich@8.1.30
-      prefix: /opt/cray/pe/mpich/8.1.30/ofi/gnu/12.3
+      prefix: /opt/cray/pe/mpich/8.1.30/ucx/gnu/12.3
       modules:
-      - craype-network-ofi
-      - cray-mpich/8.1.30
+      - craype-network-ucx
+      - cray-mpich-ucx/8.1.30
       - libfabric/1.22.0
       extra_attributes:
         extra_rpaths:

--- a/configs/sites/tier1/narwhal/packages_oneapi-2024.2.0.yaml
+++ b/configs/sites/tier1/narwhal/packages_oneapi-2024.2.0.yaml
@@ -50,10 +50,10 @@ packages:
     buildable: false
     externals:
     - spec: cray-mpich@8.1.30
-      prefix: /opt/cray/pe/mpich/8.1.30/ofi/intel/2022.1
+      prefix: /opt/cray/pe/mpich/8.1.30/ucx/intel/2022.1
       modules:
-      - craype-network-ofi
-      - cray-mpich/8.1.30
+      - craype-network-ucx
+      - cray-mpich-ucx/8.1.30
       - libfabric/1.22.0
       extra_attributes:
         extra_rpaths:


### PR DESCRIPTION
## Description

All in the title.

While the full tests I ran on Narwhal indicated that OFI was fine, repeated test runs showed a significant slowdown, and random errors reading and writing HDF5 files.

### Dependencies

None

### Issues addressed

None created

### Applications affected

None

### Systems affected

Narwhal

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested on Narwhal, merged into NEPTUNE

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
