### PR TITLE
Add codee@2025.4.7 to neptune-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/cherry_pick_codee_e07895d7186370847b19b53b22cbe0698d972818

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/cherry_pick_codee_e07895d7186370847b19b53b22cbe0698d972818
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -84,6 +84,9 @@ packages:
       require:
       - '@3.29:'
       - +ownlibs
+    codee:
+      require:
+      - '@2025.4.7'
     # Attention - when updating also check the various jcsda-emc-bundles env packages
     crtm:
       require:

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_env/package.py
@@ -32,6 +32,7 @@ class NeptuneEnv(BundlePackage):
     if not sys.platform == "darwin":
         depends_on("numactl", type="run")
 
+    depends_on("codee", type="run")
     depends_on("libyaml", type="run")
     depends_on("p4est", type="run")
     depends_on("w3emc", type="run")


### PR DESCRIPTION
## Description

All in the title.

### Dependencies

- [x]  Waiting on https://github.com/JCSDA/spack-packages/pull/41

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1920

### Applications affected

None

### Systems affected

Systems using `neptune-dev` template (CI, NRL)

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
