### PR TITLE
Add `bin/compiler` to `PATH` for `intel-oneapi-compilers`

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -241,4 +241,6 @@ jobs:
           module list
 
           # https://github.com/JCSDA/spack-stack/issues/1903
+          module show stack-intel-oneapi-compilers/2024.2.0
+          which llvm-ar
           llvm-ar --version

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -239,3 +239,6 @@ jobs:
           module load ewok-env
           module load soca-env
           module list
+
+          # https://github.com/JCSDA/spack-stack/issues/1903
+          llvm-ar --version

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -241,4 +241,6 @@ jobs:
           module list
 
           # https://github.com/JCSDA/spack-stack/issues/1903
+          module show stack-intel-oneapi-compilers/2024.2.0
+          which llvm-ar
           llvm-ar --version

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -239,3 +239,6 @@ jobs:
           module load ewok-env
           module load soca-env
           module list
+
+          # https://github.com/JCSDA/spack-stack/issues/1903
+          llvm-ar --version

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -401,7 +401,6 @@ def setup_meta_modules():
         logging.debug("  ... ... F77 : {}".format(substitutes["F77"]))
         logging.debug("  ... ... FC  : {}".format(substitutes["FC"]))
 
-
         # Compiler flags; names are lowercase in spack
         if "flags" in compiler.extra_attributes.keys():
             for flag_name in compiler.extra_attributes["flags"].keys():

--- a/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -399,7 +399,8 @@ def setup_meta_modules():
         logging.debug("  ... ... CC  : {}".format(substitutes["CC"]))
         logging.debug("  ... ... CXX : {}".format(substitutes["CXX"]))
         logging.debug("  ... ... F77 : {}".format(substitutes["F77"]))
-        logging.debug("  ... ... FC' : {}".format(substitutes["FC"]))
+        logging.debug("  ... ... FC  : {}".format(substitutes["FC"]))
+
 
         # Compiler flags; names are lowercase in spack
         if "flags" in compiler.extra_attributes.keys():
@@ -422,6 +423,17 @@ def setup_meta_modules():
                         env_name,
                         env_values
                     )
+        # https://github.com/JCSDA/spack-stack/issues/1903
+        # Attempt to locate directory "compiler" in the same directory where
+        # "icx" resides. If found, add it to PATH in the compiler module
+        if compiler.name=="intel-oneapi-compilers":
+            path_to_icx = os.path.dirname(substitutes["CC"])
+            if os.path.isdir(os.path.join(path_to_icx, "compiler")):
+                substitutes["ENVVARS"] +=  prepend_path_command(
+                    module_choice,
+                    "PATH",
+                    os.path.join(path_to_icx, "compiler"),
+                )
         substitutes["ENVVARS"] = substitutes["ENVVARS"].rstrip("\n")
         logging.debug("  ... ... ENVVARS  : {}".format(substitutes["ENVVARS"]))
 


### PR DESCRIPTION
## Description

In `spack-ext/lib/jcsda-emc/spack-stack/stack/meta_modules.py`: for `intel-oneapi-compilers`, attempt to add subdirectory `compiler` of `bin` to `PATH`, and test in CI.

This will have no effect on Cray systems using the Cray compiler wrappers, but that's fine. Cray systems have their own, Cray-generated compiler modules anyway.

### Dependencies

None

### Issues addressed

Closes #1903

### Applications affected

None

### Systems affected

Systems using Intel oneAPI compilers

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested on Nautilus where this issue was identified first

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
