### PR TITLE
weekly builder: Add option to exclude packages from spack.yaml

### DIFF
--- a/util/weekly_build/03_SetupEnv.sh
+++ b/util/weekly_build/03_SetupEnv.sh
@@ -21,10 +21,12 @@ for compiler in $COMPILERS; do
     cd $envdir
     spack env activate .
     spack config add "config:install_tree:padded_length:${PADDED_LENGTH:-200}"
+    # Optionally remove packages from spack.yaml. NOTE: fails if package is not spec'd.
+    if [ ! -z "$PACKAGES_TO_EXCLUDE" ]; then
+        spack remove $PACKAGES_TO_EXCLUDE
+    fi
     # Check for duplicates and fail before doing the "real" concretization:
     spack_wrapper log.concretize concretize --fresh
     ${SPACK_STACK_DIR:?}/util/show_duplicate_packages.py -i crtm-fix -i crtm -i esmf -i mapl -i neptune-env
-#   The following is not working at the moment, for seemingly a couple reasons. Therefore packages with test-only deps cannot be tested.
-#    spack concretize --force --fresh --test all | tee log.concretize_test
   done
 done


### PR DESCRIPTION
## Description

This PR adds an option to provide `$PACKAGES_TO_EXCLUDE` in the weekly build scripts (03_SetupEnv.sh). If set, `spack remove $PACKAGES_TO_EXCLUDE` will be run. The motivation for this is to be able to run the weekly builds for a subset of the unified env while still using the unified-dev template.

### Dependencies

none

### Issues addressed

none

### Applications affected

n/a

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- Additional testing: _Add information on any additional tests conducted_
    - [x] tested on Acorn

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
