### PR TITLE
update bacio, crtm module vars in common/modules_*.yaml

### DIFF
--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -162,10 +162,8 @@ modules:
       bacio:
         environment:
           set:
-            'BACIO_INC4': '{prefix}/include_4'
-            'BACIO_INC8': '{prefix}/include_8'
-            'BACIO_LIB4': '{prefix}/lib/libbacio_4.a'
-            'BACIO_LIB8': '{prefix}/lib/libbacio_8.a'
+            'BACIO_INC': '{prefix}/include'
+            'BACIO_LIB': '{prefix}/lib/libbacio.a'
       bufr:
         environment:
           set:

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -163,7 +163,7 @@ modules:
         environment:
           set:
             'BACIO_INC': '{prefix}/include'
-            'BACIO_LIB': '{prefix}/lib/libbacio.a'
+            'BACIO_LIB': '{prefix}/lib64/libbacio.a'
       bufr:
         environment:
           set:

--- a/configs/common/modules_lmod.yaml
+++ b/configs/common/modules_lmod.yaml
@@ -172,7 +172,7 @@ modules:
         environment:
           set:
             'CRTM_INC': '{prefix}/include'
-            'CRTM_LIB': '{prefix}/lib/libcrtm.a'
+            'CRTM_LIB': '{prefix}/lib/libcrtm.so'
       g2tmpl:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -181,10 +181,8 @@ modules:
       bacio:
         environment:
           set:
-            'BACIO_INC4': '{prefix}/include_4'
-            'BACIO_INC8': '{prefix}/include_8'
-            'BACIO_LIB4': '{prefix}/lib/libbacio_4.a'
-            'BACIO_LIB8': '{prefix}/lib/libbacio_8.a'
+            'BACIO_INC': '{prefix}/include'
+            'BACIO_LIB': '{prefix}/lib/libbacio.a'
       bufr:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -182,7 +182,7 @@ modules:
         environment:
           set:
             'BACIO_INC': '{prefix}/include'
-            'BACIO_LIB': '{prefix}/lib/libbacio.a'
+            'BACIO_LIB': '{prefix}/lib64/libbacio.a'
       bufr:
         environment:
           set:

--- a/configs/common/modules_tcl.yaml
+++ b/configs/common/modules_tcl.yaml
@@ -191,7 +191,7 @@ modules:
         environment:
           set:
             'CRTM_INC': '{prefix}/include'
-            'CRTM_LIB': '{prefix}/lib/libcrtm.a'
+            'CRTM_LIB': '{prefix}/lib/libcrtm.so'
       g2tmpl:
         environment:
           set:


### PR DESCRIPTION
## Description

This PR updates the bacio vars to use `$BACIO_LIB` and `$BACIO_INC` instead of being suffixed with 4/8, reflecting the removal of the type-differentiated library versions following bacio 2.6.0. It also changes `$CRTM_LIB` to point to the shared library.

### Dependencies

none

### Issues addressed

Fixes #1894

### Applications affected

most applications are affected

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- Additional testing: _Add information on any additional tests conducted_
    - [x] test on Acorn: install crtm 3.1.3 and bacio 2.6.0 with module files and verify that BACIO_LIB/BACIO_INC/CRTM_LIB point to existing paths.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
