### PR TITLE
Fixing a typo inside the module yaml files for most hosts across tiers (`enable::` ---> `enable:`)

### DIFF
--- a/configs/sites/tier1/acorn/modules.yaml
+++ b/configs/sites/tier1/acorn/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       all:

--- a/configs/sites/tier1/atlantis/modules.yaml
+++ b/configs/sites/tier1/atlantis/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       exclude:

--- a/configs/sites/tier1/aws-pcluster/modules.yaml
+++ b/configs/sites/tier1/aws-pcluster/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/blueback/modules.yaml
+++ b/configs/sites/tier1/blueback/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier1/container/modules.yaml
+++ b/configs/sites/tier1/container/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl
     tcl:
       include:

--- a/configs/sites/tier1/derecho/modules.yaml
+++ b/configs/sites/tier1/derecho/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/discover-scu17/modules.yaml
+++ b/configs/sites/tier1/discover-scu17/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/gaea-c6/modules.yaml
+++ b/configs/sites/tier1/gaea-c6/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/hera/modules.yaml
+++ b/configs/sites/tier1/hera/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/hercules/modules.yaml
+++ b/configs/sites/tier1/hercules/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/narwhal/modules.yaml
+++ b/configs/sites/tier1/narwhal/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier1/nas/modules.yaml
+++ b/configs/sites/tier1/nas/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier1/nautilus/modules.yaml
+++ b/configs/sites/tier1/nautilus/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier1/navy-aws/modules.yaml
+++ b/configs/sites/tier1/navy-aws/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier1/noaa-aws/modules.yaml
+++ b/configs/sites/tier1/noaa-aws/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/noaa-azure/modules.yaml
+++ b/configs/sites/tier1/noaa-azure/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/noaa-gcloud/modules.yaml
+++ b/configs/sites/tier1/noaa-gcloud/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier1/orion/modules.yaml
+++ b/configs/sites/tier1/orion/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       - openssl

--- a/configs/sites/tier1/ursa/modules.yaml
+++ b/configs/sites/tier1/ursa/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       exclude:

--- a/configs/sites/tier1/wcoss2/modules.yaml
+++ b/configs/sites/tier1/wcoss2/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       hierarchy:

--- a/configs/sites/tier2/aws-ubuntu2404/modules.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier2/blackpearl/modules.yaml
+++ b/configs/sites/tier2/blackpearl/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl
     tcl:
       include:

--- a/configs/sites/tier2/bounty/modules.yaml
+++ b/configs/sites/tier2/bounty/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl
     tcl:
       include:

--- a/configs/sites/tier2/casper/modules.yaml
+++ b/configs/sites/tier2/casper/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       exclude:

--- a/configs/sites/tier2/cole/modules.yaml
+++ b/configs/sites/tier2/cole/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier2/emc-rhel/modules.yaml
+++ b/configs/sites/tier2/emc-rhel/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       include:

--- a/configs/sites/tier2/endeavor/modules.yaml
+++ b/configs/sites/tier2/endeavor/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier2/frontera/modules.yaml
+++ b/configs/sites/tier2/frontera/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       exclude:

--- a/configs/sites/tier2/gaea-c5/modules.yaml
+++ b/configs/sites/tier2/gaea-c5/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier2/jean/modules.yaml
+++ b/configs/sites/tier2/jean/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier2/jet/modules.yaml
+++ b/configs/sites/tier2/jet/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod

--- a/configs/sites/tier2/linux.default/modules.yaml
+++ b/configs/sites/tier2/linux.default/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl
     tcl:
       include:

--- a/configs/sites/tier2/macos.default/modules.yaml
+++ b/configs/sites/tier2/macos.default/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       include:

--- a/configs/sites/tier2/s4/modules.yaml
+++ b/configs/sites/tier2/s4/modules.yaml
@@ -1,6 +1,6 @@
 modules:
   default:
-    enable::
+    enable:
     - lmod
     lmod:
       include:

--- a/configs/sites/tier2/tusk/modules.yaml
+++ b/configs/sites/tier2/tusk/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier2/ubuntu2404-nvhpc/modules.yaml
+++ b/configs/sites/tier2/ubuntu2404-nvhpc/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl

--- a/configs/sites/tier2/wheat/modules.yaml
+++ b/configs/sites/tier2/wheat/modules.yaml
@@ -1,4 +1,4 @@
 modules:
   default:
-    enable::
+    enable:
     - tcl


### PR DESCRIPTION
## Description

This PR fixes a typo inside the module yaml files for most hosts across tiers (`enable::` ---> `enable:`).

### Dependencies

None.

### Issues addressed

Not created yet... needs confirmation if it's really an issue.

### Applications affected

None.

### Systems affected

None.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [ ] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
