### PR TITLE
[skip ci] Add ifx at TOSS5

### DIFF
--- a/configs/sites/tier1/nas-toss5/packages_oneapi-2025.3.0.yaml
+++ b/configs/sites/tier1/nas-toss5/packages_oneapi-2025.3.0.yaml
@@ -1,0 +1,68 @@
+packages:
+  all:
+    require:
+    - any_of: ['%intel-oneapi-compilers@=2025.3.0']
+      when: '%intel-oneapi-compilers'
+    - any_of: ['%gcc@=12.5.0']
+      when: '%gcc'
+  mpi:
+    buildable: false
+    require:
+    - "cray-mpich@8.1.33"
+  intel-oneapi-compilers:
+    externals:
+    - spec: intel-oneapi-compilers@2025.3.0
+      prefix: /nobackup/gmao_SIteam/intel/oneapi
+      modules:
+      - cray-libpals/1.7.1
+      - cray-pals/1.7.1
+      - craype-x86-turin
+      - libfabric/12.0
+      - craype-network-ofi
+      - cray-dsmml/0.3.1
+      - PrgEnv-intel/8.6.0
+      - comp-intel/2025.3.0
+      extra_attributes:
+        compilers:
+          c: /nobackup/gmao_SIteam/intel/oneapi/compiler/2025.3/bin/icx
+          cxx: /nobackup/gmao_SIteam/intel/oneapi/compiler/2025.3/bin/icpx
+          fortran: /nobackup/gmao_SIteam/intel/oneapi/compiler/2025.3/bin/ifx
+        environment:
+          prepend_path:
+            PATH: /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/bin
+            CPATH: /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/include
+            LD_LIBRARY_PATH: '/nobackup/gmao_SIteam/intel/oneapi/compiler/2025.3/lib/:/nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/lib64'
+        extra_rpaths:
+        - /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/lib64
+        - /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/lib
+  gcc:
+    buildable: false
+    externals:
+    - spec: gcc@12.5.0 languages:='c,c++'
+      prefix: /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5
+      modules:
+      - comp-gcc/12.5.0-TOSS5
+      extra_attributes:
+        compilers:
+          c: /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/bin/gcc
+          cxx: /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/bin/g++
+          fortran: /nobackup/gmao_SIteam/gcc/gcc-12.5.0-TOSS5/bin/gfortran
+  cray-mpich:
+    buildable: false
+    externals:
+    - spec: cray-mpich@8.1.33
+      prefix: /opt/cray/pe/mpich/8.1.33/ofi/intel/2022.1
+      modules:
+      - cray-libpals/1.7.1
+      - cray-pals/1.7.1
+      - craype-x86-turin
+      - libfabric/12.0
+      - craype-network-ofi
+      - cray-dsmml/0.3.1
+      - cray-mpich/8.1.33
+
+  intel-oneapi-mkl:
+    buildable: false
+    externals:
+    - spec: intel-oneapi-mkl@2025.3
+      prefix: /nobackup/gmao_SIteam/intel/oneapi


### PR DESCRIPTION
## Description

Adds a oneapi-ifx stack at NAS on TOSS5

### Dependencies

None

### Issues addressed

None

### Applications affected

None

### Systems affected

NAS TOSS5

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged

skip-checks: true