### PR TITLE
Update setuptools to v75

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -441,7 +441,7 @@ packages:
     # Pin the py-setuptools version to avoid duplicate Python packages
     py-setuptools:
       require:
-      - '@69'
+      - '@75'
     py-torch:
       require:
       - +custom-protobuf


### PR DESCRIPTION
This change updates our pinned setuptools version to v75.  This change is necessary due to the update to py-awscrt here https://github.com/spack/spack-packages/pull/3553 which now requires setuptools >= v71.


### Issues addressed

This change is part of the resolution to https://github.com/JCSDA/spack-stack/issues/1932

### Applications affected

`ewok-env`

### Systems affected

ec2, jedi-ci

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- __N/A__ All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
