### PR TITLE
[release/2.1] Update Derecho site config

### DIFF
--- a/configs/sites/tier1/derecho/packages_gcc-13.3.1.yaml
+++ b/configs/sites/tier1/derecho/packages_gcc-13.3.1.yaml
@@ -32,6 +32,9 @@ packages:
     - spec: cray-mpich@8.1.32 +wrappers
       prefix: /opt/cray/pe/mpich/8.1.32/ofi/gnu/12.3
       modules:
+      - crayenv/25.03
+      - PrgEnv-gnu/8.6.0
+      - gcc-native/13.2
       - craype-network-ofi
       - cray-mpich/8.1.32
       - libfabric/1.22.0

--- a/configs/sites/tier1/derecho/packages_oneapi-2025.3.1.yaml
+++ b/configs/sites/tier1/derecho/packages_oneapi-2025.3.1.yaml
@@ -15,9 +15,9 @@ packages:
     - spec: intel-oneapi-compilers@2025.3.1
       prefix: /glade/work/epicufsrt/contrib/spack-stack/derecho/installs/oneapi-2025.3.1
       modules:
-        - crayenv/25.03
-        - PrgEnv-intel/8.6.0
-        - intel/2025.3.1
+      - crayenv/25.03
+      - PrgEnv-intel/8.6.0
+      - intel/2025.3.1
       extra_attributes:
         compilers:
           c: /glade/work/epicufsrt/contrib/spack-stack/derecho/installs/oneapi-2025.3.1/compiler/2025.3/bin/icx
@@ -54,6 +54,9 @@ packages:
     - spec: cray-mpich@8.1.32 +wrappers
       prefix: /opt/cray/pe/mpich/8.1.32/ofi/intel/2022.1
       modules:
+      - crayenv/25.03
+      - PrgEnv-intel/8.6.0
+      - intel/2025.3.1
       - craype-network-ofi
       - cray-mpich/8.1.32
       - libfabric/1.22.0


### PR DESCRIPTION
## Description

Update Derecho site config for the `release/2.1` branch. We will merge this back to develop later.

Apparently, the sysadmins made yet another round of changes to the modules, which requires a few updates to the site config.

### Dependencies

None

### Issues addressed

Working toward #1884

### Applications affected

None

### Systems affected

Derecho

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Deployed spack-stack-2.1.0 environments on Derecho in `/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.1.0`. Built `jedi-bundle` as far as I could with both compilers until I hit errors in `saber` (https://github.com/JCSDA-internal/saber/issues/1201) and `fv3-jedi-`linearmodel` (https://github.com/JCSDA-internal/fv3-jedi-linearmodel/issues/18#issuecomment-3985604145) that need to be fixed in the JEDI code, i.e. that are not an issue in spack-stack-2.1.0. Updated Wiki page for release 2.1.0 accordingly (https://github.com/JCSDA/spack-stack/wiki/Release-2.1.0)

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
