### PR TITLE
[skip ci] add oneapi@2025.3.1 compilers and oneapi@2021.17 MPI

### DIFF
--- a/configs/sites/tier1/ursa/packages_gcc-12.4.0.yaml
+++ b/configs/sites/tier1/ursa/packages_gcc-12.4.0.yaml
@@ -1,4 +1,8 @@
 packages:
+  all:
+    require:
+    - any_of: ['%gcc@=12.4.0']
+      when: '%gcc'
   mpi:
     buildable: False
     require:
@@ -18,7 +22,7 @@ packages:
   openmpi:
     buildable: False
     externals:
-    - spec: openmpi@4.1.6
+    - spec: openmpi@4.1.6 ~internal-hwloc +two_level_namespace
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/openmpi-4.1.6-2dkf6t23iyw4xodxruh72yvmrhhvyoms
       modules:
       - openmpi/4.1.6

--- a/configs/sites/tier1/ursa/packages_oneapi-2025.3.1-hpcx.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi-2025.3.1-hpcx.yaml
@@ -1,0 +1,52 @@
+packages:
+  all:
+    require:
+    - any_of: ['%intel-oneapi-compilers@=2025.3.1']
+      when: '%intel-oneapi-compilers'
+    - any_of: ['%gcc@=12.4.0']
+      when: '%gcc'
+  mpi:
+    buildable: False
+    require:
+    - hpcx-mpi@2.18.1
+  hpcx-mpi:
+    buildable: False
+    externals:
+    - spec: hpcx-mpi@2.18.1
+      prefix: /apps/hpcx-v2.18.1-gcc-mlnx_ofed-redhat9-cuda12-x86_64/ompi-mt-oneapi2025
+      modules:
+      - hpc-x/2.18.1-mt-oneapi2025
+  intel-oneapi-compilers:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-compilers@2025.3.1
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk
+      modules:
+      - intel-oneapi-compilers/2025.3.1
+      extra_attributes:
+        compilers:
+          c: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk/compiler/2025.3/bin/icx
+          cxx: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk/compiler/2025.3/bin/icpx
+          fortran: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk/compiler/2025.3/bin/ifx
+        environment:
+          prepend_path:
+            LD_LIBRARY_PATH: '/usr/lib:/usr/lib64'
+  intel-oneapi-mkl:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mkl@2025.3
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2025.3.1/intel-oneapi-mkl-2025.3.0-z5owhveid7qlq4erbay2seqzs65y3etu
+      modules:
+      - intel-oneapi-mkl/2025.3.0
+  gcc:
+    buildable: False
+    externals:
+    - spec: gcc@12.4.0 languages:='c,c++'
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj
+      modules:
+      - gcc/12.4.0
+      extra_attributes:
+        compilers:
+          c: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gcc
+          cxx: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/g++
+          fortran: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gfortran

--- a/configs/sites/tier1/ursa/packages_oneapi-2025.3.1.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi-2025.3.1.yaml
@@ -1,0 +1,57 @@
+packages:
+  all:
+    require:
+    - any_of: ['%intel-oneapi-compilers@=2025.3.1']
+      when: '%intel-oneapi-compilers'
+    - any_of: ['%gcc@=12.4.0']
+      when: '%gcc'
+  mpi:
+    buildable: False
+    require:
+    - intel-oneapi-mpi@2021.17
+  intel-oneapi-compilers:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-compilers@2025.3.1
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk
+      modules:
+      - intel-oneapi-compilers/2025.3.1
+      extra_attributes:
+        compilers:
+          c: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk/compiler/2025.3/bin/icx
+          cxx: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk/compiler/2025.3/bin/icpx
+          fortran: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-oneapi-compilers-2025.3.1-yqgrg5v3jonwexcjwd3xu3rzvwcp4ejk/compiler/2025.3/bin/ifx
+        environment:
+          prepend_path:
+            LD_LIBRARY_PATH: '/usr/lib:/usr/lib64'
+  intel-oneapi-mpi:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mpi@2021.17
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2025.3.1/intel-oneapi-mpi-2021.17.1-emmz2zv6lx5ypzmlc3csouqffu7mwnwr
+      modules:
+      - intel-oneapi-mpi/2021.17.1
+  intel-oneapi-mkl:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-mkl@2025.3
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2025.3.1/intel-oneapi-mkl-2025.3.0-z5owhveid7qlq4erbay2seqzs65y3etu
+      modules:
+      - intel-oneapi-mkl/2025.3.0
+  intel-oneapi-tbb:
+    buildable: False
+    externals:
+    - spec: intel-oneapi-tbb@2021.12
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/intel-tbb-2021.12.0-grcsmccjpm3trn6rgtyq76kdxks6ygzm
+  gcc:
+    buildable: False
+    externals:
+    - spec: gcc@12.4.0 languages:='c,c++'
+      prefix: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj
+      modules:
+      - gcc/12.4.0
+      extra_attributes:
+        compilers:
+          c: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gcc
+          cxx: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/g++
+          fortran: /apps/spack-2024-12/linux-rocky9-x86_64/gcc-11.4.1/gcc-12.4.0-dsgnou52lpn2tus6mohdmcw5mjqmqrhj/bin/gfortran


### PR DESCRIPTION
## Description

Add configuration files for oneapi@2025.3.1 compilers and oneapi@2021.17 MPI. HPC-X MPI remains at v2.18.1

### Dependencies

### Issues addressed

None

### Applications affected

All applications (UFS WM, SRW, etc.) that build agains spack-stack@v2.1

### Systems affected

ursa

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)

CI skipped for configuration file changes.

Test environments build successfully.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
