### PR TITLE
Pin py-setuptools to 73.0.1 to fix broken py-numpy@1.26.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = bugfix/numpy_1p26p5_setuptools_73p0p1
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = bugfix/numpy_1p26p5_setuptools_73p0p1

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -439,10 +439,11 @@ packages:
     py-ruamel-yaml:
       require:
       - '@0.17.16'
-    # Pin the py-setuptools version to avoid duplicate Python packages
+    # https://github.com/JCSDA/spack-stack/issues/1942
+    # https://github.com/spack/spack-packages/issues/3695
     py-setuptools:
       require:
-      - '@75'
+      - '@73.0.1'
     py-torch:
       require:
       - +custom-protobuf


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for `repos/builtin` (https://github.com/JCSDA/spack-packages/pull/45; add `py-setuptools@73.0.1` etc.) and pins `py-setuptools` to that version to fix #1942 (`py-numpy@1.26.4` broken by recent update to `py-setuptools@75`).

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/45

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1942

### Applications affected

All (fixes broken `py-numpy`)

### Systems affected

None directly

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
