### PR TITLE
adding ecflow requirement for ewok-env

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -87,6 +87,9 @@ packages:
     codee:
       require:
       - '@2025.4.7'
+    ewok-env:
+      require:
+      - +ecflow
     # Attention - when updating also check the various jcsda-emc-bundles env packages
     crtm:
       require:

--- a/configs/sites/tier1/atlantis/packages.yaml
+++ b/configs/sites/tier1/atlantis/packages.yaml
@@ -1,7 +1,7 @@
 packages:
   # Modification of common packages
   ewok-env:
-    require:
+    require::
     - '~ecflow'
   zlib-api:
     buildable: False


### PR DESCRIPTION
## Description

I found when building and using spack-stack 2.1 on discover, the ecflow module got loaded with the gcc build but not with the oneapi build. This PR adds the ecflow requirement to ewok-env. 

```
jedipara@discover33:/gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-2.1.0/envs/ue-oneapi-2024.2.0> grep ewok-env log.concretize 
 -   k7u3wmq  ewok-env@1.0.0~cylc~ecflow~ewok~mysql~r2d2~solo build_system=bundle platform=linux os=sles15 target=zen3
jedipara@discover33:/gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-2.1.0/envs/ue-oneapi-2024.2.0> grep ewok-env ../ue-gcc-13.4.0/log.concretize 
 -   gb5e4ur  ewok-env@1.0.0~cylc+ecflow~ewok~mysql~r2d2~solo build_system=bundle platform=linux os=sles15 target=zen3
 ```

### Dependencies

None

### Issues addressed

None ... 

### Applications affected

List all known applications (UFS WM, JEDI, SRW, etc.) intentionally or unintentionally affected by this PR.

### Systems affected

List all systems intentionally or unintentionally affected by this PR.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [ ] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
