### PR TITLE
Containers and ec2 changes for 2.1 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# .dockerignore
+
+# Log files. 
+log.*
+*.log
+
+# spack-stack environments and builds.
+envs/
+.env/
+build/
+cache/
+
+# Misc.
+.vscode
+.Trashes
+.github/
+venv/
+.venv/
+

--- a/configs/sites/tier1/container/Dockerfile.gcc
+++ b/configs/sites/tier1/container/Dockerfile.gcc
@@ -72,10 +72,15 @@ FROM ubuntu_base AS builder
 ENV SPACK_STACK_DIR=/opt/spack-stack \
     SPACK_ROOT=/opt/spack-stack/spack
 
-
 # Copy spack-stack from build context. Note the build context must be the
 # root of the spack-stack repository (see the README.md for details).
-COPY . ${SPACK_STACK_DIR}
+# Do not copy the dockerfiles into the container.
+COPY --exclude=configs/sites/tier1/container/Dockerfile.oneapi \
+    --exclude=configs/sites/tier1/container/Dockerfile.gcc \
+    --exclude=configs/sites/tier1/container/packages_oneapi.yaml \
+    --exclude=envs/** \
+    --exclude=cache/** \
+    . ${SPACK_STACK_DIR}
 
 # Create spack-stack environment
 WORKDIR /opt/spack-stack
@@ -89,12 +94,19 @@ RUN mkdir -p /tmp/spack-stack && \
         --compiler $COMPILER && \
     cd ${SPACK_STACK_DIR}/envs/container && \
     spack env activate . && \
-    spack concretize 2>&1 | tee log.concretize && \
-    spack install --fail-fast -j ${BUILD_JOBS} 2>&1 | tee log.install && \
+    spack concretize 2>&1 | tee log.concretize
+
+# Build the spack environment.
+RUN  source setup.sh &&  cd ${SPACK_STACK_DIR}/envs/container && spack env activate . && \
+        spack install --fail-fast -j ${BUILD_JOBS} 2>&1 | tee log.install
+
+# Setup modules and meta-modules.
+RUN source setup.sh &&  cd ${SPACK_STACK_DIR}/envs/container && spack env activate . && \
     spack module tcl refresh -y && \
     spack stack setup-meta-modules && \
     # Save output of spack find.
     spack find 2>&1 | tee /opt/spack-software/spack_find.out && \
+    cp ./log.concretize /opt/spack-software/log.concretize && \
     spack clean --all
 
 ## ---------- Create runtime container ----------
@@ -118,7 +130,20 @@ RUN echo "ulimit -s unlimited" > /etc/spack_container_rc.sh \
     && echo "export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe" >> /etc/spack_container_rc.sh \
     && echo "# TCL module path for the spack-stack environment." >> /etc/spack_container_rc.sh \
     && echo "source /etc/profile.d/modules.sh" >> /etc/spack_container_rc.sh \
-    && echo "module use /opt/spack-software/modules/Core" >> /etc/spack_container_rc.sh \
+    && echo "module use /opt/spack-software/modulefiles" >> /etc/spack_container_rc.sh \
+    && echo "module use /opt/spack-software/modulefiles/Core" >> /etc/spack_container_rc.sh \
+    && echo "# Bash function to load modules necessary to build the JEDI bundle." >> /etc/spack_container_rc.sh \
+    && echo "load_jedi_bundle_env() {" >> /etc/spack_container_rc.sh \
+    && echo "    module purge" >> /etc/spack_container_rc.sh \
+    && echo "    module load stack-gcc" >> /etc/spack_container_rc.sh \
+    && echo "    module load stack-openmpi" >> /etc/spack_container_rc.sh \
+    && echo "    module load base-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load jedi-mpas-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load py-fortranformat" >> /etc/spack_container_rc.sh \
+    && echo "    module load jedi-fv3-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load ewok-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load ip" >> /etc/spack_container_rc.sh \
+    && echo "}" >> /etc/spack_container_rc.sh \ \
     && echo "source /etc/spack_container_rc.sh" >> /etc/bash.bashrc \
     && printf "[credential]\n    helper = cache --timeout=7200\n" >> /root/.gitconfig \
     && mkdir /root/.pmix \

--- a/configs/sites/tier1/container/Dockerfile.gcc
+++ b/configs/sites/tier1/container/Dockerfile.gcc
@@ -34,10 +34,6 @@ RUN set -euo pipefail; \
         # External dependencies.
         libcurl4-openssl-dev \
         libmysqlclient-dev \
-        libqt5svg5-dev \
-        qt5-qmake \
-        qt5dxcb-plugin \
-        qtbase5-dev \
         zstd \
         # Shell tools, source retrieval and networking.
         sed \

--- a/configs/sites/tier1/container/Dockerfile.oneapi
+++ b/configs/sites/tier1/container/Dockerfile.oneapi
@@ -91,7 +91,13 @@ ENV SPACK_STACK_DIR=/opt/spack-stack \
 
 # Copy spack-stack from build context. Note the build context must be the
 # root of the spack-stack repository (see the README.md for details).
-COPY . ${SPACK_STACK_DIR}
+# Do not copy the dockerfiles into the container.
+COPY --exclude=configs/sites/tier1/container/Dockerfile.oneapi \
+    --exclude=configs/sites/tier1/container/Dockerfile.gcc \
+    --exclude=configs/sites/tier1/container/packages_gcc.yaml \
+    --exclude=envs/** \
+    --exclude=cache/** \
+    . ${SPACK_STACK_DIR}
 
 # Create spack-stack environment
 WORKDIR /opt/spack-stack
@@ -105,12 +111,19 @@ RUN mkdir -p /tmp/spack-stack && \
         --compiler oneapi && \
     cd ${SPACK_STACK_DIR}/envs/container && \
     spack env activate . && \
-    spack concretize 2>&1 | tee log.concretize && \
-    spack install --fail-fast -j ${BUILD_JOBS} 2>&1 | tee log.install && \
+    spack concretize 2>&1 | tee log.concretize
+
+# Build the spack environment.
+RUN  source setup.sh &&  cd ${SPACK_STACK_DIR}/envs/container && spack env activate . && \
+        spack install --fail-fast -j ${BUILD_JOBS} 2>&1 | tee log.install
+
+# Setup modules and meta-modules.
+RUN source setup.sh &&  cd ${SPACK_STACK_DIR}/envs/container && spack env activate . && \
     spack module tcl refresh -y && \
     spack stack setup-meta-modules && \
     # Save output of spack find.
     spack find 2>&1 | tee /opt/spack-software/spack_find.out && \
+    cp ./log.concretize /opt/spack-software/log.concretize && \
     spack clean --all
 
 ## ---------- Create runtime container ----------
@@ -129,10 +142,22 @@ RUN echo "ulimit -s unlimited" > /etc/spack_container_rc.sh \
     && echo "export CXX=icpx" >> /etc/spack_container_rc.sh \
     && echo "export FC=ifx" >> /etc/spack_container_rc.sh \
     && echo "# TCL module path for the spack-stack environment." >> /etc/spack_container_rc.sh \
-    && echo "export MODULEPATH=/opt/spack-software/modules/Core" >> /etc/spack_container_rc.sh \
     && echo "source /etc/profile.d/modules.sh" >> /etc/spack_container_rc.sh \
     && echo "module use /opt/intel/oneapi/modulefiles" >> /etc/spack_container_rc.sh \
-    && echo "module use /opt/spack-software/modules/Core" >> /etc/spack_container_rc.sh \
+    && echo "module use /opt/spack-software/modulefiles" >> /etc/spack_container_rc.sh \
+    && echo "module use /opt/spack-software/modulefiles/Core" >> /etc/spack_container_rc.sh \
+    && echo "# Bash function to load modules necessary to build the JEDI bundle." >> /etc/spack_container_rc.sh \
+    && echo "load_jedi_bundle_env() {" >> /etc/spack_container_rc.sh \
+    && echo "    module purge" >> /etc/spack_container_rc.sh \
+    && echo "    module load stack-intel-oneapi-compilers" >> /etc/spack_container_rc.sh \
+    && echo "    module load stack-intel-oneapi-mpi" >> /etc/spack_container_rc.sh \
+    && echo "    module load base-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load jedi-mpas-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load py-fortranformat" >> /etc/spack_container_rc.sh \
+    && echo "    module load jedi-fv3-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load ewok-env" >> /etc/spack_container_rc.sh \
+    && echo "    module load ip" >> /etc/spack_container_rc.sh \
+    && echo "}" >> /etc/spack_container_rc.sh \ \
     && echo "source /etc/spack_container_rc.sh" >> /etc/bash.bashrc \
     && printf "[credential]\n    helper = cache --timeout=7200\n" >> /root/.gitconfig \
     && mkdir /root/.pmix

--- a/configs/sites/tier1/container/Dockerfile.oneapi
+++ b/configs/sites/tier1/container/Dockerfile.oneapi
@@ -34,10 +34,6 @@ RUN set -euo pipefail; \
         # External dependencies.
         libcurl4-openssl-dev \
         libmysqlclient-dev \
-        libqt5svg5-dev \
-        qt5-qmake \
-        qt5dxcb-plugin \
-        qtbase5-dev \
         zstd \
         # Shell tools, source retrieval and networking.
         sed \

--- a/configs/sites/tier1/container/packages.yaml
+++ b/configs/sites/tier1/container/packages.yaml
@@ -32,26 +32,22 @@ packages:
     - "@1.7.2"
 
   # System packages installed during the container build.
-  grep:
+  autoconf:
     externals:
-    - spec: grep@3.11
-      prefix: /usr
-  findutils:
-    externals:
-    - spec: findutils@4.9.0
+    - spec: autoconf@2.71
       prefix: /usr
   coreutils:
     externals:
     - spec: coreutils@9.4
       prefix: /usr
-  autoconf:
-    externals:
-    - spec: autoconf@2.71
-      prefix: /usr
   diffutils:
     buildable: false
     externals:
     - spec: diffutils@3.10
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.9.0
       prefix: /usr
   git:
     buildable: false
@@ -63,17 +59,15 @@ packages:
     externals:
     - spec: git-lfs@3.4.1
       prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.11
+      prefix: /usr
   llvm:
     buildable: false
     externals:
     - spec: llvm@14.0.6
       prefix: /usr
-  qt:
-    buildable: false
-    externals:
-    - spec: qt@5.15.3
-      prefix: /usr
-    version: [5.15.3]
   perl:
     buildable: false
     externals:

--- a/configs/sites/tier1/container/packages.yaml
+++ b/configs/sites/tier1/container/packages.yaml
@@ -1,8 +1,36 @@
 packages:
   all:
-    target: [core2]
+    target: [x86_64_v3]
+  awscli-v2:
+    require:
+    - "@2.22.4"
+  cairo:
+    variants: +pic
+  ewok-env:
+    require:
+    - +ecflow
+  fontconfig:
+    variants: +pic
   met:
     variants: +python +grib2 +graphics +lidar2nc +modis
+  parallelio:
+    require:
+    - +pnetcdf
+  pixman:
+    variants: +pic
+  py-awscrt:
+    require:
+    - "@0.19.19"
+  py-botocore:
+    require:
+    - "@1.34.162"
+  py-boto3:
+    require:
+    - "@1.34.162"
+  py-netcdf4:
+    require:
+    - "@1.7.2"
+
   # System packages installed during the container build.
   grep:
     externals:
@@ -46,11 +74,6 @@ packages:
     - spec: qt@5.15.3
       prefix: /usr
     version: [5.15.3]
-  wget:
-    buildable: false
-    externals:
-    - spec: wget@1.21.4
-      prefix: /usr
   perl:
     buildable: false
     externals:

--- a/configs/sites/tier1/container/packages_oneapi.yaml
+++ b/configs/sites/tier1/container/packages_oneapi.yaml
@@ -15,8 +15,8 @@ packages:
       modules:
       - umf/1.0.2
       - tbb/2022.3
-      - compiler-rt/2025.3.0
-      - compiler/2025.3.0
+      - compiler-rt/2025.3.2
+      - compiler/2025.3.2
       extra_attributes:
         compilers:
           c: /opt/intel/oneapi/compiler/2025.3/bin/icx

--- a/configs/sites/tier2/aws-ubuntu2404/packages.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages.yaml
@@ -28,6 +28,10 @@ packages:
     externals:
     - spec: automake@1.16.5
       prefix: /usr
+  binutils:
+    externals:
+    - spec: binutils@2.42+gold~headers
+      prefix: /usr
   coreutils:
     externals:
     - spec: coreutils@9.4
@@ -52,6 +56,10 @@ packages:
     externals:
     - spec: git@2.43.0~tcltk
       prefix: /usr
+  git-lfs:
+    externals:
+    - spec: git-lfs@3.4.1
+      prefix: /usr
   gmake:
     buildable: false
     externals:
@@ -69,6 +77,10 @@ packages:
     externals:
     - spec: libtool@2.4.7
       prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.19
+      prefix: /usr
   perl:
     externals:
     - spec: perl@5.38.2~cpanm+opcode+open+shared+threads
@@ -81,7 +93,6 @@ packages:
     externals:
     - spec: sed@4.9
       prefix: /usr
-  wget:
+  tar:
     externals:
-    - spec: wget@1.21.4
-      prefix: /usr
+    - spec: tar@1.35

--- a/configs/sites/tier2/aws-ubuntu2404/packages.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages.yaml
@@ -1,37 +1,25 @@
 packages:
-  gmake:
-    buildable: false
-    externals:
-    - spec: gmake@4.3
-      prefix: /usr
-  grep:
-    externals:
-    - spec: grep@3.11
-      prefix: /usr
-  wget:
-    externals:
-    - spec: wget@1.21.4
-      prefix: /usr
-  perl:
-    externals:
-    - spec: perl@5.38.2~cpanm+opcode+open+shared+threads
-      prefix: /usr
-  findutils:
-    externals:
-    - spec: findutils@4.9.0
-      prefix: /usr
-  coreutils:
-    externals:
-    - spec: coreutils@9.4
-      prefix: /usr
-  pkgconf:
-    externals:
-    - spec: pkgconf@1.8.1
-      prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.7
-      prefix: /usr
+  # Package constraints.
+  awscli-v2:
+    require:
+    - "@2.22.4"
+  ewok-env:
+    require:
+    - +ecflow
+  py-awscrt:
+    require:
+    - "@0.19.19"
+  py-botocore:
+    require:
+    - "@1.34.162"
+  py-boto3:
+    require:
+    - "@1.34.162"
+  py-netcdf4:
+    require:
+    - "@1.7.2"
+
+  # System packages.
   autoconf:
     externals:
     - spec: autoconf@2.71
@@ -39,6 +27,22 @@ packages:
   automake:
     externals:
     - spec: automake@1.16.5
+      prefix: /usr
+  coreutils:
+    externals:
+    - spec: coreutils@9.4
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.10
+      prefix: /usr
+  findutils:
+    externals:
+    - spec: findutils@4.9.0
+      prefix: /usr
+  flex:
+    externals:
+    - spec: flex@2.6.4+lex
       prefix: /usr
   gawk:
     externals:
@@ -48,19 +52,36 @@ packages:
     externals:
     - spec: git@2.43.0~tcltk
       prefix: /usr
-  flex:
+  gmake:
+    buildable: false
     externals:
-    - spec: flex@2.6.4+lex
+    - spec: gmake@4.3
+      prefix: /usr
+  grep:
+    externals:
+    - spec: grep@3.11
+      prefix: /usr
+  groff:
+    externals:
+    - spec: groff@1.23.0
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.7
+      prefix: /usr
+  perl:
+    externals:
+    - spec: perl@5.38.2~cpanm+opcode+open+shared+threads
+      prefix: /usr
+  pkgconf:
+    externals:
+    - spec: pkgconf@1.8.1
       prefix: /usr
   sed:
     externals:
     - spec: sed@4.9
       prefix: /usr
-  diffutils:
+  wget:
     externals:
-    - spec: diffutils@3.10
-      prefix: /usr
-  groff:
-    externals:
-    - spec: groff@1.23.0
+    - spec: wget@1.21.4
       prefix: /usr


### PR DESCRIPTION
This is a batch of changes to the container environment in 2.1. Additionally this includes an update to the aws-ec2 environment which allows both numpy and aws tools to coexist with the older python setuptools.

### Systems affected

CI, containers, ec2.

## Testing

Local builds and testing.


## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged [__pending__]
