### PR TITLE
More 2.1 site-config fixes for aws-ubuntu2404

### DIFF
--- a/configs/sites/tier2/aws-ubuntu2404/modules.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/modules.yaml
@@ -2,3 +2,17 @@ modules:
   default:
     enable::
     - lmod
+    lmod:
+      include:
+      # Compiler modules
+      - apple-clang
+      - gcc
+      - intel-oneapi-compilers
+      - llvm
+      # MPI modules
+      - cray-mpich
+      - intel-mpi
+      - intel-oneapi-mpi
+      - mpich
+      - mpt
+      - openmpi

--- a/configs/sites/tier2/aws-ubuntu2404/packages.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages.yaml
@@ -6,6 +6,8 @@ packages:
   ewok-env:
     require:
     - +ecflow
+  met:
+    require: [+python, +grib2, +graphics, +lidar2nc, +modis]
   py-awscrt:
     require:
     - "@0.19.19"
@@ -60,11 +62,6 @@ packages:
     externals:
     - spec: git-lfs@3.4.1
       prefix: /usr
-  gmake:
-    buildable: false
-    externals:
-    - spec: gmake@4.3
-      prefix: /usr
   grep:
     externals:
     - spec: grep@3.11
@@ -72,10 +69,6 @@ packages:
   groff:
     externals:
     - spec: groff@1.23.0
-      prefix: /usr
-  libtool:
-    externals:
-    - spec: libtool@2.4.7
       prefix: /usr
   m4:
     externals:

--- a/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
@@ -14,7 +14,7 @@ packages:
     - '%fortran=gcc %c,cxx=oneapi'
     - '%fortran=gcc %c=oneapi'
     providers:
-      mpi: [intel-oneapi-mpi@2021.17]
+      mpi:: [intel-oneapi-mpi@2021.17]
 
   intel-oneapi-compilers:
     buildable: false
@@ -35,6 +35,10 @@ packages:
     buildable: false
   mpich:
     buildable: false
+  mpi:
+    buildable: false
+    require:
+    - intel-oneapi-mpi@2021.17
   gcc:
     externals:
     - spec: gcc@13.3.0 languages:='c,c++,fortran'

--- a/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
@@ -1,4 +1,21 @@
 packages:
+
+  # Compilers.
+  all:
+    prefer:
+    - '%oneapi'
+    conflict:
+    - '%c=oneapi %fortran=gcc'
+    - '%c,cxx=oneapi %fortran=gcc'
+    - '%c=gcc %fortran=oneapi'
+    - '%c,cxx=gcc %fortran=oneapi'
+    - '%fortran=oneapi %c=gcc'
+    - '%fortran=oneapi %c,cxx=gcc'
+    - '%fortran=gcc %c,cxx=oneapi'
+    - '%fortran=gcc %c=oneapi'
+    providers:
+      mpi: [intel-oneapi-mpi@2021.17]
+
   intel-oneapi-compilers:
     buildable: false
     externals:
@@ -49,3 +66,23 @@ packages:
       prefix: /opt/intel/oneapi
       modules:
       - tbb/2022.3
+
+  # Package constraints.
+  jedi-base-env:
+    require: [+fftw, +hdf4, +bufrquery]
+  eccodes:
+    require:
+    - "jp2k=jasper"
+  jasper:
+    require:
+    - +jpeg
+  elfutils:
+    require:
+    - '@0.191'
+  libelf:
+    buildable: false
+  curl:
+    require: ['+nghttp2']
+  py-pyyaml:
+    require:
+    - +libyaml


### PR DESCRIPTION
I did a clean site config build from a fresh clone and found the following issues with aws-ubuntu2404. With these changes the stack builds cleanly in both gcc and oneapi.

Issues:

https://github.com/JCSDA/spack-stack/issues/1957 - Addressed at the site-config level. TBD if we need this in our common config.

https://github.com/JCSDA/spack-stack/issues/1884 - This is built and tested from a clean clone. No further changes for aws-ubuntu2404