### PR TITLE
New virtual package dev-utils-env; add py-pydantic

### DIFF
--- a/configs/templates/neptune-dev-llvm/spack.yaml
+++ b/configs/templates/neptune-dev-llvm/spack.yaml
@@ -8,7 +8,7 @@ spack:
   include: []
 
   specs:
-  - dev-utils-env
+  #- dev-utils-env
   - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
   - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b10
   - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b10

--- a/configs/templates/neptune-dev-llvm/spack.yaml
+++ b/configs/templates/neptune-dev-llvm/spack.yaml
@@ -8,6 +8,7 @@ spack:
   include: []
 
   specs:
+  - dev-utils-env
   - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
   - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b10
   - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b10

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -8,6 +8,7 @@ spack:
   include: []
 
   specs:
+  - dev-utils-env
   - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
   - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b10
   - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b10

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -8,8 +8,8 @@ spack:
   include: []
 
   specs:
+  - dev-utils-env
   - ewok-env
-  #- ai-env
   - geos-gcm-env          ^esmf@=8.9.1
   - jedi-fv3-env
   - jedi-geos-env         ^esmf@=8.9.1
@@ -17,7 +17,6 @@ spack:
   - jedi-neptune-env      ^esmf@=8.9.1
   - jedi-tools-env
   - jedi-ufs-env          ^esmf@=8.8.0
-  #- jedi-um-env
   - neptune-env           ^esmf@=8.9.1
   - neptune-python-env    ^esmf@=8.9.1
   - soca-env

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -8,8 +8,8 @@ spack:
   include: []
 
   specs:
+  - dev-utils-env
   - ewok-env
-  #- ai-env
   - geos-gcm-env          ^esmf@=8.9.1
   - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.3
   # Is GMAO ready to move to crtm@3.1.3?
@@ -19,9 +19,7 @@ spack:
   - jedi-geos-env         ^esmf@=8.9.1
   - jedi-mpas-env
   - jedi-neptune-env      ^esmf@=8.9.1
-  #- jedi-tools-env
   - jedi-ufs-env          ^esmf@=8.8.0
-  #- jedi-um-env
   - neptune-env           ^esmf@=8.9.1
   - neptune-python-env    ^esmf@=8.9.1
   - soca-env

--- a/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
@@ -41,6 +41,7 @@ class BaseEnv(BundlePackage):
     depends_on("py-wheel", type="run")
     depends_on("py-setuptools", type="run")
     depends_on("py-setuptools-scm", type="run")
+    depends_on("py-pytest", type="run")
 
     # Miscellaneous
 

--- a/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
@@ -26,7 +26,6 @@ class BaseEnv(BundlePackage):
     depends_on("git", type="run")
     depends_on("wget", type="run")
     depends_on("curl", type="run")
-    depends_on("cloc", type="run")
 
     # I/O
     depends_on("zlib-api", type="run")
@@ -42,9 +41,7 @@ class BaseEnv(BundlePackage):
     depends_on("py-wheel", type="run")
     depends_on("py-setuptools", type="run")
     depends_on("py-setuptools-scm", type="run")
-    depends_on("py-pytest", type="run")
 
     # Miscellaneous
-    depends_on("rank-run", type="run")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/dev_utils_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/dev_utils_env/package.py
@@ -26,7 +26,6 @@ class DevUtilsEnv(BundlePackage):
     # Python
     depends_on("py-pydantic +dotenv", type="run")
     depends_on("py-pydantic-settings", type="run")
-    depends_on("py-pytest", type="run")
 
     # Miscellaneous
     depends_on("cloc", type="run")

--- a/repos/spack_stack/spack_repo/spack_stack/packages/dev_utils_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/dev_utils_env/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack_repo.builtin.build_systems.bundle import BundlePackage
+from spack.package import *
+
+
+class DevUtilsEnv(BundlePackage):
+    """Commonly used development utilities"""
+
+    homepage = "https://github.com/jcsda/spack-stack"
+    git = "https://github.com/jcsda/spack-stack.git"
+
+    maintainers("climbfuji", "AlexanderRichert-NOAA")
+
+    version("1.0.0")
+
+    depends_on("base-env", type="run")
+
+    # I/O
+
+    # Python
+    depends_on("py-pydantic +dotenv", type="run")
+    depends_on("py-pydantic-settings", type="run")
+    depends_on("py-pytest", type="run")
+
+    # Miscellaneous
+    depends_on("cloc", type="run")
+    depends_on("rank-run", type="run")
+
+    # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

This PR introduces a new virtual package `dev-utils-env`, moves `cloc` and `rank-run` from `base-env` to `dev-utils-env`, and adds `py-pydantic` to it.

I did a minor cleanup of the templates while adding `dev-utils-env` to them.

### Dependencies

None

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1960

### Applications affected

None (no actual changes, we are still installing the same packages as before)

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
