### PR TITLE
Acorn: Remove $env template dir

### DIFF
--- a/configs/sites/tier1/acorn/config.yaml
+++ b/configs/sites/tier1/acorn/config.yaml
@@ -2,5 +2,4 @@ config:
   build_jobs: 6
   build_stage: $tempdir/$user/spack-stage
   template_dirs:
-  - $env/site/templates
   - $spack/share/spack/templates


### PR DESCRIPTION
## Description

This PR removes the custom template dir under $env from the Acorn configuration; I only want to use this for WCOSS2-related deployments, otherwise regular module file usage becomes a mess for R&D models due to the prereq's. I retroactively fixed the module files for the 2.1.0 release on Acorn so the documentation is accurate.

### Dependencies

none

### Issues addressed

none

### Applications affected

n/a

### Systems affected

Acorn

## Testing

Tested on Acorn (verified correct behavior after removing config entry)

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
