### PR TITLE
Common config oneapi - fix elfutils / libelf version issue

### DIFF
--- a/configs/common/packages_oneapi.yaml
+++ b/configs/common/packages_oneapi.yaml
@@ -33,6 +33,11 @@ packages:
       require:
       - +mkl
       - ~fftw
+    elfutils:
+      require:
+      - '@0.191:'
+    libelf:
+      buildable: false
     gmake:
       require:
       - '%c=gcc'

--- a/configs/sites/tier1/acorn/packages_oneapi-2024.2.1.yaml
+++ b/configs/sites/tier1/acorn/packages_oneapi-2024.2.1.yaml
@@ -71,8 +71,6 @@ packages:
     require: ['%gcc']
   ectrans:
     require:: ['@1.2.0', '+fftw']
-  elfutils:
-    require: ['@0.191']
   glib:
     require: ['%gcc']
   gsibec:

--- a/configs/sites/tier1/wcoss2/packages_oneapi-2024.2.1.yaml
+++ b/configs/sites/tier1/wcoss2/packages_oneapi-2024.2.1.yaml
@@ -81,8 +81,6 @@ packages:
     require:: ['@:']
   ectrans:
     require:: ['@1.2.0', '+fftw']
-  elfutils:
-    require: ['@0.191']
   fckit:
     require:: ['@:', '+eckit']
   gdal:

--- a/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
+++ b/configs/sites/tier2/aws-ubuntu2404/packages_oneapi.yaml
@@ -80,11 +80,6 @@ packages:
   jasper:
     require:
     - +jpeg
-  elfutils:
-    require:
-    - '@0.191'
-  libelf:
-    buildable: false
   curl:
     require: ['+nghttp2']
   py-pyyaml:


### PR DESCRIPTION
elfutils@0.181 fails to build with OneAPI. Bumping to elfutils@0.191 fixes the build, but in some cases Spack will silently swap in the deprecated libelf unless you also set `libelf: buildable: false`.

Fixes: https://github.com/JCSDA/spack-stack/issues/1957

Testing:
- This has been tested on the ec2 site config. The CI should also verify that this fix is non-breaking.