### PR TITLE
Add support for gcc@14

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
   url = https://github.com/jcsda/spack-packages
-  branch = bugfix/py_protobuf_gcc14
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
   url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  branch = bugfix/py_protobuf_gcc14

--- a/configs/sites/tier2/bounty/README_gcc-14.2.1.yaml
+++ b/configs/sites/tier2/bounty/README_gcc-14.2.1.yaml
@@ -1,0 +1,21 @@
+WSL 2 Alma Linux 9 installation notes for GCC 14 compiler
+
+yum install \
+gdb \
+gcc-toolset-14-runtime \
+gcc-toolset-14-dwz \
+gcc-toolset-14 \
+gcc-toolset-14-gcc \
+gcc-toolset-14-libquadmath-devel \
+gcc-toolset-14-libstdc++-devel \
+gcc-toolset-14-annobin-docs \
+gcc-toolset-14-annobin-plugin-gcc \
+gcc-toolset-14-gcc-c++ \
+gcc-toolset-14-gcc-gfortran \
+gcc-toolset-14-libtsan-devel \
+gcc-toolset-14-libasan-devel \
+gcc-toolset-14-libubsan-devel \
+gcc-toolset-14-liblsan-devel \
+gcc-toolset-14-binutils-gold \
+gcc-toolset-14-binutils \
+gcc-toolset-14-gcc-plugin-devel

--- a/configs/sites/tier2/bounty/packages_gcc-14.2.1.yaml
+++ b/configs/sites/tier2/bounty/packages_gcc-14.2.1.yaml
@@ -1,0 +1,18 @@
+packages:
+  all:
+    require:
+    - any_of: ['%gcc@=14.2.1']
+      when: '%gcc'
+  mpi:
+    require:
+    - "openmpi@=5.0.8"
+  gcc:
+    buildable: False
+    externals:
+    - spec: gcc@14.2.1 languages:='c,c++,fortran'
+      prefix: /opt/rh/gcc-toolset-14/root/usr
+      extra_attributes:
+        compilers:
+          c: /opt/rh/gcc-toolset-14/root/usr/bin/gcc
+          cxx: /opt/rh/gcc-toolset-14/root/usr/bin/g++
+          fortran: /opt/rh/gcc-toolset-14/root/usr/bin/gfortran

--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -176,7 +176,7 @@ case ${SPACK_STACK_BATCH_HOST} in
     SPACK_STACK_CARGO_MIRROR="/home/dom/prod/spack-cargo-mirror"
     ;;
   bounty)
-    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2025.3.0" "gcc@=13.3.1" "clang@=22.1.0")
+    SPACK_STACK_BATCH_COMPILERS=("oneapi@=2025.3.0" "gcc@=14.2.1" "gcc@=13.3.1" "clang@=22.1.0")
     SPACK_STACK_BATCH_TEMPLATES=("neptune-dev" "neptune-dev-llvm" "unified-dev" "cylc-dev")
     SPACK_STACK_MODULE_CHOICE="tcl"
     SPACK_STACK_BOOTSTRAP_MIRROR="/home/dom/prod/spack-bootstrap-mirror"


### PR DESCRIPTION
## Description

This PR adds support for gcc@14 for the three environment templates `unified-dev`, `neptune-dev`, `cylc-dev`.

This requires an update for spack-packages, see https://github.com/JCSDA/spack-packages/pull/52.

Tested on my laptop with gcc@14 running Almalinux 9 under WSL2.

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/52

### Issues addressed

Support for gcc@14 was identified as one of the main goals for spack-stack-2.2.0.

### Applications affected

None

### Systems affected

My laptop only (no tier-1 system is using gcc@14 yet to my knowledge)

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged **will be made (compiler compatibility matrix)**
