### PR TITLE
require ecflow for ewok-env

### DIFF
--- a/configs/sites/tier1/derecho/packages.yaml
+++ b/configs/sites/tier1/derecho/packages.yaml
@@ -7,6 +7,9 @@ packages:
   esmf:
     require:
     - 'esmf_os=Linux esmf_comm=mpich'
+  ewok-env:
+    require:
+    - '+ecflow'
 
 ### All other external packages listed alphabetically
   autoconf:

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -1,4 +1,8 @@
 packages:
+### Modification of common packages
+  ewok-env:
+    require:
+    - '+ecflow'
   # For addressing https://github.com/JCSDA/spack-stack/issues/1355
   # Use system zlib instead of spack-built zlib-ng
   all:

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -1,5 +1,5 @@
 packages:
-### Modification of common packages
+# Modification of common packages
   ewok-env:
     require:
     - '+ecflow'

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -1,5 +1,5 @@
 packages:
-### Modification of common packages
+# Modification of common packages
   ewok-env:
     require:
     - '+ecflow'

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -1,4 +1,8 @@
 packages:
+### Modification of common packages
+  ewok-env:
+    require:
+    - '+ecflow'
   # For addressing https://github.com/JCSDA/spack-stack/issues/1355
   #   Use system zlib instead of spack-built zlib-ng
   all:


### PR DESCRIPTION
## Description

Add the ecflow requirement for ewok-env to JCSDA used HPCs.

### Dependencies

None

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1980

### Applications affected

EWOK/Skylab

### Systems affected

Orion, Hercules, Derecho

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications. <- tested on discover and aws-ubuntu
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
