### PR TITLE
Bump NEPTUNE environments to esmf@9.0.0b11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/esmf900b11
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/esmf900b11

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -140,9 +140,8 @@ packages:
       - any_of:
         - '@=8.6.1 snapshot=none'
         - '@=8.8.0 snapshot=none'
-        - '@=8.9.0 snapshot=none'
         - '@=8.9.1 snapshot=none'
-        - '@=9.0.0b10 snapshot=b10'
+        - '@=9.0.0b11 snapshot=b11'
       - any_of:
         - 'fflags="-fp-model precise" cxxflags="-fp-model precise"'
         when: '%intel'

--- a/configs/templates/neptune-dev-llvm/spack.yaml
+++ b/configs/templates/neptune-dev-llvm/spack.yaml
@@ -9,16 +9,16 @@ spack:
 
   specs:
   #- dev-utils-env
-  - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-env +debug ~openmp +espc +ncview ^esmf@=9.0.0b10
+  - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-env +debug ~openmp +espc +ncview ^esmf@=9.0.0b11
   # Until we can build the entire set of dependencies for
   # neptune-python-env and jedi-neptune-env, we need to
   # add the required packages for the NEPTUNE standalone
   # model manually
-  #- neptune-python-env    ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
-  #- jedi-neptune-env +adp ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
+  #- neptune-python-env    ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  #- jedi-neptune-env +adp ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
   - py-numpy
   - crtm@3.1.3
 

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -22,12 +22,12 @@ spack:
 
   specs:
   - dev-utils-env
-  - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-env +debug ~openmp +espc +ncview ^esmf@=9.0.0b10
-  - neptune-python-env +gittools ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
-  - jedi-neptune-env +adp +jedi  ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b10
+  - neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-env +debug ~openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-python-env +gittools ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - jedi-neptune-env +adp +jedi  ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
   - crtm@3.1.3
 
   packages:

--- a/configs/templates/neptune-ops/spack.yaml
+++ b/configs/templates/neptune-ops/spack.yaml
@@ -8,7 +8,7 @@ spack:
   include: []
 
   specs:
-  - neptune-env ~debug +openmp +espc ~ncview ^esmf@=9.0.0b10
+  - neptune-env ~debug +openmp +espc ~ncview ^esmf@=9.0.0b11
 
   packages:
     # Turn off python variant for esmf

--- a/configs/templates/skylab-dev/spack.yaml
+++ b/configs/templates/skylab-dev/spack.yaml
@@ -14,11 +14,11 @@ spack:
   - jedi-fv3-env
   - jedi-geos-env         ^esmf@=8.9.1
   - jedi-mpas-env
-  - jedi-neptune-env      ^esmf@=8.9.1
+  - jedi-neptune-env      ^esmf@=9.0.0b11
   - jedi-tools-env
   - jedi-ufs-env          ^esmf@=8.8.0
-  - neptune-env           ^esmf@=8.9.1
-  - neptune-python-env    ^esmf@=8.9.1
+  - neptune-env           ^esmf@=9.0.0b11
+  - neptune-python-env    ^esmf@=9.0.0b11
   - soca-env
 
   # Various crtm tags (list all to avoid duplicate packages)
@@ -30,9 +30,9 @@ spack:
   - mapl@2.53.4 ^esmf@8.8.0
 
   # Various esmf tags (list all to avoid duplicate packages)
-  - esmf@=8.6.1
   - esmf@=8.8.0
   - esmf@=8.9.1
+  - esmf@=9.0.0b11
 
   packages:
     # Turn on python variant for esmf

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -18,10 +18,10 @@ spack:
   - jedi-fv3-env
   - jedi-geos-env         ^esmf@=8.9.1
   - jedi-mpas-env
-  - jedi-neptune-env      ^esmf@=8.9.1
+  - jedi-neptune-env      ^esmf@=9.0.0b11
   - jedi-ufs-env          ^esmf@=8.8.0
-  - neptune-env           ^esmf@=8.9.1
-  - neptune-python-env    ^esmf@=8.9.1
+  - neptune-env           ^esmf@=9.0.0b11
+  - neptune-python-env    ^esmf@=9.0.0b11
   - soca-env
   - ufs-srw-app-env       ^esmf@=8.8.0 ^crtm@=3.1.3
   - ufs-weather-model-env ^esmf@=8.8.0 ^crtm@=3.1.3
@@ -38,6 +38,7 @@ spack:
   - esmf@=8.6.1
   - esmf@=8.8.0
   - esmf@=8.9.1
+  - esmf@=9.0.0b11
 
   # Various fms builds
   - fms +gfs_phys constants=GFS


### PR DESCRIPTION
## Description

All in the title

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/54

### Issues addressed

Closes #1991 

### Applications affected

NEPTUNE

### Systems affected

None directly

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
