### PR TITLE
[release/2.1] Update netcdf-c from spack develop to fix missing plugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-2.1.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-2.1.0
-  url = https://github.com/climbfuji/spack-packages
-  branch = feature/update_netcdf_c_from_upstream_rel21
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-2.1.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-2.1.0
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-2.1.0
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-2.1.0
+  url = https://github.com/climbfuji/spack-packages
+  branch = feature/update_netcdf_c_from_upstream_rel21


### PR DESCRIPTION
## Description

Update submodule pointer for `repos/builtin` for the changes in https://github.com/JCSDA/spack-packages/pull/58.

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/58

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/1997

### Applications affected

UFS

### Systems affected

None directly

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
