### PR TITLE
Don't autload JEDI components in jedi-neptune-env

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py
@@ -31,9 +31,12 @@ class JediNeptuneEnv(BundlePackage):
         depends_on("adp-preprocessors", type="run")
 
     with when("+jedi"):
-        depends_on("oops@1.10.0.20250827", type="run")
-        depends_on("crtm@3.1.3", type="run")
-        depends_on("ioda@2.9.0.20250826", type="run")
-        depends_on("ioda-converters@0.0.1.20250830", type="run")
-        depends_on("ropp-ufo@11.0.20251022", type="run")
-        depends_on("ufo@1.10.0.20250821 +ropp", type="run")
+        # https://github.com/JCSDA/spack-stack/issues/2015
+        # Changed type from "run" to "build" so that
+        # the modules don't get loaded automatically
+        depends_on("oops@1.10.0.20250827", type="build")
+        depends_on("crtm@3.1.3", type="build")
+        depends_on("ioda@2.9.0.20250826", type="build")
+        depends_on("ioda-converters@0.0.1.20250830", type="build")
+        depends_on("ropp-ufo@11.0.20251022", type="build")
+        depends_on("ufo@1.10.0.20250821 +ropp", type="build")


### PR DESCRIPTION
## Description

Don't autoload JEDI components in `repos/spack_stack/spack_repo/spack_stack/packages/jedi_neptune_env/package.py`.

### Dependencies

None

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/2015

### Applications affected

JEDI-NEPTUNE

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested to work as expected on my local machine

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
