### PR TITLE
Updating util/nrl/batch_install.sh: CARGO env vars etc

### DIFF
--- a/util/nrl/batch_install.sh
+++ b/util/nrl/batch_install.sh
@@ -287,11 +287,7 @@ function run_interactive_job() {
   script=$2
   reuse_build_cache=$3
   tpn=$(tasks_per_node ${host})
-  if [[ "${reuse_build_cache}" == "true" ]]; then
-    walltime="120"
-  else
-    walltime="720"
-  fi
+  walltime="720"
   if [[ ! -n "${ACCOUNT}" ]]; then
     echo "ERROR, environment variable ACCOUNT not set"
     exit 1
@@ -655,6 +651,11 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     if [[ "${update_cargo_mirror}" == "true"* ]]; then
       set +e
       echo "Updating local cargo mirror ..."
+      export CARGO_HTTP_MULTIPLEXING=false
+      export CARGO_HTTP_TIMEOUT=600
+      export CARGO_HTTP_LOW_SPEED_LIMIT=1
+      export CARGO_HTTP_LOW_SPEED_TIMEOUT=600
+      export CARGO_NET_RETRY=10
       ./util/fetch_cargo_deps.py
       set -e
     fi
@@ -676,7 +677,7 @@ for compiler in "${SPACK_STACK_BATCH_COMPILERS[@]}"; do
     case ${submit_to_scheduler} in
       "true")
         jobs=$(tasks_per_node ${host})
-        parallel_install_flags="--concurrent-packages=4 --jobs=${jobs}"
+        parallel_install_flags="--concurrent-packages=2 --jobs=${jobs}"
         ;;
       "false")
         parallel_install_flags=""


### PR DESCRIPTION
## Description

This PR updates util/nrl/batch_install.sh:
- Add CARGO environment variables before `fetch_cargo_deps.py`; with this change, fetching the rust/cargo dependencies works on some of the NavyDSRC login nodes, but not on all.
- Reduce number of concurrent packages being built
- Use walltime 720 minutes unconditionally when submitting build to queue

### Dependencies

None

### Issues addressed

None

### Applications affected

None

### Systems affected

NRL systems

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
