### PR TITLE
Move GEOS envs in UE to ESMF 9.0.0b11

### DIFF
--- a/configs/sites/tier2/macos.gmao/README.md
+++ b/configs/sites/tier2/macos.gmao/README.md
@@ -56,8 +56,22 @@ brew install rust
 
 Use the appropriate branch or tag:
 
+### Fixed Tag - JCSDA
+
 ```bash
-git clone --recurse-submodules https://github.com/GMAO-SI-Team/spack-stack.git -b geos-testing spack-stack-dev
+git clone --recurse-submodules https://github.com/JCSDA/spack-stack.git -b x.y.z spack-stack-x.y.z
+```
+
+### Development - JCSDA
+
+```bash
+git clone --recurse-submodules https://github.com/JCSDA/spack-stack.git -b develop spack-stack-dev
+```
+
+### Development - SI Team
+
+```bash
+git clone --recurse-submodules https://github.com/GMAO-SI-Team/spack-stack.git -b develop spack-stack-siteam
 ```
 
 ---

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -10,13 +10,13 @@ spack:
   specs:
   - dev-utils-env
   - ewok-env
-  - geos-gcm-env          ^esmf@=8.9.1
+  - geos-gcm-env          ^esmf@=9.0.0b11
   - global-workflow-env   ^esmf@=8.6.1 ^crtm@=3.1.3
   # Is GMAO ready to move to crtm@3.1.3?
   - gmao-swell-env                     ^crtm@=v2.4.1-jedi.2
   - gsi-env                            ^crtm@=3.1.3
   - jedi-fv3-env
-  - jedi-geos-env         ^esmf@=8.9.1
+  - jedi-geos-env         ^esmf@=9.0.0b11
   - jedi-mpas-env
   - jedi-neptune-env      ^esmf@=9.0.0b11
   - jedi-ufs-env          ^esmf@=8.8.0
@@ -37,7 +37,6 @@ spack:
   # Various esmf tags (list all to avoid duplicate packages)
   - esmf@=8.6.1
   - esmf@=8.8.0
-  - esmf@=8.9.1
   - esmf@=9.0.0b11
 
   # Various fms builds


### PR DESCRIPTION
## Description

GEOS and MAPL are fine with ESMF 9.0.0b11 so we might as well move `geos-gcm-env` and `jedi-geos-env` to use it in `unified-env`. Plus this removes one ESMF from the matrix which should help build times. (Would be nice to remove the other old ones as well...)

Also, a tiny update to the macos.gmao readme.

### Dependencies

None

### Issues addressed

None

### Applications affected

GEOS, maybe JEDI?

Before the `jedi-geos-env` was using ESMF 8.9.0. Since it has "geos" in the name, I figure it's roughly GEOS shaped and so would do fine with ESMF 9.0.0b11 (since I imagine MAPL is the reason for ESMF).

### Systems affected

All

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
