### PR TITLE
Explicitly state the qt package is not buildable when externals are provided

### DIFF
--- a/configs/sites/tier1/hera/packages.yaml
+++ b/configs/sites/tier1/hera/packages.yaml
@@ -128,6 +128,7 @@ packages:
     - spec: pkg-config@0.27.1
       prefix: /usr
   qt:
+    buildable: False
     externals:
     - spec: qt@5.12.6
       prefix: /contrib/spack-stack/installs/qt-5.12.6/qtbase

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -84,6 +84,7 @@ packages:
     - spec: pkgconf@1.7.3
       prefix: /usr
   qt:
+    buildable: False
     externals:
     - spec: qt@5.15.14
       prefix: /apps/contrib/spack-stack-1.1/gcc-11.3.1/qt-5.15.14-mfeuvcidmyqoi2m5i2tfrk6yd7xtk6pt

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -94,6 +94,7 @@ packages:
     - spec: pkgconf@1.7.3
       prefix: /usr
   qt:
+    buildable: False
     externals:
     - spec: qt@5.15.14
       prefix: /apps/spack-managed-x86_64_v3-v1.0/gcc-11.3.1/qt-5.15.14-xsxk4vxuyi4apu36ix6heamra673izdu


### PR DESCRIPTION
For all tier1 sites which define where qt can be found externally, add the `buildable:false` attribute.
Note this is already specified in most site1 specific package files.

There are two remaining site1 specific packages specs which contain specs for qt:
acorn
`configs/sites/tier1/acorn/packages_intel-19.1.3.304.yaml` and
wcoss2
`configs/sites/tier1/wcoss2/packages_intel-19.1.3.304.yaml`
These are for the intel compiler so should not be impacted.
Neither the packages.yaml or the packages_oneapi *.yaml files in acorn and wcoss2 have any specs for qt.

## Description
There had been a conflict between the spec for the qt package in `configs/common/packages_oneapi.yaml` and some site specific config files, e.g. `configs/sites/tier1/derecho/packages.yaml`

This issue was exposed when ecflow was added as required for the derecho, hercules and orion sites in PR https://github.com/JCSDA/spack-stack/pull/1989

This issue was partially resolved when PR https://github.com/JCSDA/spack-stack/pull/2011 removed the qt specification from `configs/common/packages_oneapi.yaml`

### Dependencies
None.
### Issues addressed
None
### Applications affected
???
### Systems affected
Potentially hera, hercules, orion

## Testing
I do not have access to any of the potentially impacted systems, so my testing has been limited to creating environments for hera, hercules, and orion, and subsequently concretizing those environments All that was done on the derecho system.
The concretize step succeeded for the hercules and orion environments.
The concretize step failed for the hera environment, but apparently for reason(s) unrelated to this PR:
```
==> Error: the spec 'intel-oneapi-mpi@2021.13%oneapi@2024.2.1' depends on 'intel-oneapi-compilers@2024.2.1', but there is no such external spec in packages.yaml [/glade/derecho/scratch/jwittig/repos-s/spack-stack-dev/spack-stack/envs/unified-dev.hera.oneapi/site/packages.yaml:18]
``` 

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
