### PR TITLE
gsi-ncdiag & bufr updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "repos/builtin"]
   path = repos/builtin
   url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-2.1.0
+  branch = release/2.1

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -201,7 +201,7 @@ packages:
       - '@1.4.2'
     gsi-ncdiag:
       require:
-      - '@1.1.2'
+      - '@1.1.3'
     harfbuzz:
       # cmake-based harfbuzz fails during build
       require:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -52,7 +52,7 @@ packages:
       - visibility=hidden
     bufr:
       require:
-      - '@12.1.0'
+      - '@12.3.0'
       - +python
     bufr-query:
       require:


### PR DESCRIPTION
## Description

Update to gsi-ncdiag@1.1.3 and bufr@12.3.0.

### Dependencies

none (spack-packages PR/s already merged)

### Issues addressed

#1931

### Applications affected

GSI

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
