### PR TITLE
Add bats & bug fixes for ioda-converters and jedi-cmake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #url = https://github.com/jcsda/spack-packages
+  #branch = spack-stack-dev
+  url = https://github.com/climbfuji/spack-packages
+  branch = bugfix/jedicmake

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
   branch = spack-stack-dev
 [submodule "repos/builtin"]
   path = repos/builtin
-  #url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  url = https://github.com/climbfuji/spack-packages
-  branch = bugfix/jedicmake
+  url = https://github.com/jcsda/spack-packages
+  branch = spack-stack-dev

--- a/configs/templates/cylc-dev/spack.yaml
+++ b/configs/templates/cylc-dev/spack.yaml
@@ -15,7 +15,7 @@ spack:
   view:
     cylc:
       root: view
-      select: [^python]
+      select: [^python, bats]
       link: run
       link_type: symlink
   include: []
@@ -24,4 +24,4 @@ spack:
   - py-cylc-flow@8.4.2
   - py-cylc-rose@1.5.1
   - py-cylc-uiserver@1.6.1
-
+  - bats

--- a/repos/spack_stack/spack_repo/spack_stack/packages/dev_utils_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/dev_utils_env/package.py
@@ -34,6 +34,7 @@ class DevUtilsEnv(BundlePackage):
     depends_on("cube +gui", when="+scalasca", type="run")
   
     # Miscellaneous
+    depends_on("bats", type="run")
     depends_on("cloc", type="run")
     depends_on("rank-run", type="run")
 

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda_converters/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda_converters/package.py
@@ -41,6 +41,9 @@ class IodaConverters(CMakePackage):
     depends_on("eccodes")
     depends_on("eckit")
     depends_on("eigen@3")
+    # error: could not find git for clone of yaml-cpp-populate
+    # fixed in repo Sep 25, 2025 - need only for 0.0.1.20250830
+    depends_on("git", type=("build"), when="@0.0.1.20250830")
     depends_on("gsl-lite")
     depends_on("ioda")
     depends_on("jedi-cmake", type=("build"))


### PR DESCRIPTION
## Description

1. Add `bats` to `dev-utils-env` and the `cylc-dev` template. Bats is a lightweight testing framework for `bash`. It has zero dependencies and installs in a second or two.
2. Bug fix in ioda-converters. The version currently configured in the spack recipe clones `yaml-cpp` during the `cmake` step. This has been fixed in later versions of the code, hence `git` is only required for this version.
3. Submodule pointer update for https://github.com/JCSDA/spack-packages/pull/65

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/65

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/2032
Closes https://github.com/JCSDA/spack-stack/issues/2031

### Applications affected

All and none, since the changes are trivial.

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
