### PR TITLE
Make libbacktrace a dependency for all platforms (instead of only darwin)

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
@@ -20,8 +20,7 @@ class BaseEnv(BundlePackage):
     version("1.0.0")
 
     # Basic utilities
-    if sys.platform == "darwin":
-        depends_on("libbacktrace", type="run")
+    depends_on("libbacktrace", type="run")
     depends_on("cmake", type="run")
     depends_on("git", type="run")
     depends_on("wget", type="run")

--- a/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/base_env/package.py
@@ -20,7 +20,6 @@ class BaseEnv(BundlePackage):
     version("1.0.0")
 
     # Basic utilities
-    depends_on("libbacktrace", type="run")
     depends_on("cmake", type="run")
     depends_on("git", type="run")
     depends_on("wget", type="run")

--- a/repos/spack_stack/spack_repo/spack_stack/packages/jedi_base_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/jedi_base_env/package.py
@@ -23,6 +23,7 @@ class JediBaseEnv(BundlePackage):
     variant("hdf4", default=True, description="Build hdf4 library and python hdf module")
     variant("bufrquery", default=True, description="Build bufr-query library")
 
+    depends_on("libbacktrace", type="run")
     depends_on("base-env", type="run")
     depends_on("bison", type="run")
     depends_on("blas", type="run")


### PR DESCRIPTION
## Description

This PR removes the "if darwin" qualifier on defining libbacktrace as a dependency, effectively making it a dependency for all platforms.

### Dependencies

None

### Issues addressed

Resolves #1965 

### Applications affected

This goes into the base_env package so it impacts any application using that package (which I guess is most). The driver was fixing this issue: jcsda-internal/ioda/issues/1699, and I realized that having libbacktrace might be helpful across more than JEDI applications. If not, and the consensus is to limit this to JEDI applications, I'm okay with that.

### Systems affected

See above

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
