### PR TITLE
Some Macos build patches

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda/ioda_yaml_root.patch
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda/ioda_yaml_root.patch
@@ -7,7 +7,7 @@ index 907fce15..0d7ae528 100644
  		# tools (like Spack) will complain about this path and may indicate that ioda
  		# is a non-relocatable package, even though it is completely relocatable.
 -		set( IODA_YAML_ROOT "@IODA_YAML_ROOT@" )
-+		set( IODA_YAML_ROOT "${CMAKE_CURRENT_LIST_FILE}/share/test/testinput/" )
++		set( IODA_YAML_ROOT "${CMAKE_CURRENT_LIST_DIR}/share/test/testinput/" )
  	endif()
  endif()
  

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda/ioda_yaml_root.patch
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda/ioda_yaml_root.patch
@@ -1,13 +1,65 @@
 diff --git a/cmake/ioda-import.cmake.in b/cmake/ioda-import.cmake.in
-index 907fce15..0d7ae528 100644
+index 907fce15..c049b2c6 100644
 --- a/cmake/ioda-import.cmake.in
 +++ b/cmake/ioda-import.cmake.in
-@@ -96,7 +96,7 @@ else()
- 		# in the ioda-post-import.cmake file, even if it is never again used. Some
- 		# tools (like Spack) will complain about this path and may indicate that ioda
- 		# is a non-relocatable package, even though it is completely relocatable.
--		set( IODA_YAML_ROOT "@IODA_YAML_ROOT@" )
-+		set( IODA_YAML_ROOT "${CMAKE_CURRENT_LIST_DIR}/share/test/testinput/" )
- 	endif()
+@@ -6,7 +6,6 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
+-
+ # These instructions parallel ioda's top-level CMakeLists.txt dependencies
+ 
+ # Required packages
+@@ -80,24 +79,3 @@ if(NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID STREQUAL CMAKE_Fortran_COMPILE
+             "but this build for ${PROJECT_NAME} uses incompatible compiler ${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}")
  endif()
  
+-# Export ioda YAML validation files directory
+-if( IS_ABSOLUTE "@CMAKE_INSTALL_DATADIR@")
+-	set( IODA_YAML_ROOT "@CMAKE_INSTALL_DATADIR@/ioda/yaml" )
+-else()
+-	if ( DEFINED _IMPORT_PREFIX )
+-		# We are in a CMake install tree
+-		set( IODA_YAML_ROOT "${_IMPORT_PREFIX}/@CMAKE_INSTALL_DATADIR@/ioda/yaml" )
+-	else()
+-		# We are in a CMake build tree. Ergo, we can use the variable set in
+-		# IODA's top-level CMakeLists.txt that points to the YAML root path
+-		# in the source tree.
+-		#
+-		# Note: a small downside of this approach is that a source tree path is hardcoded
+-		# in the ioda-post-import.cmake file, even if it is never again used. Some
+-		# tools (like Spack) will complain about this path and may indicate that ioda
+-		# is a non-relocatable package, even though it is completely relocatable.
+-		set( IODA_YAML_ROOT "@IODA_YAML_ROOT@" )
+-	endif()
+-endif()
+-
+-
+diff --git a/cmake/ioda-post-import.cmake.in b/cmake/ioda-post-import.cmake.in
+index d5fe93a8..9de02495 100644
+--- a/cmake/ioda-post-import.cmake.in
++++ b/cmake/ioda-post-import.cmake.in
+@@ -13,3 +13,23 @@ endif()
+ if( (TARGET _ioda_python) AND NOT (TARGET ioda::Python) )
+   add_library( ioda::Python ALIAS _ioda_python )
+ endif()
++
++# Export ioda YAML validation files directory
++
++# ioda_BINARY_DIR is only set if we are in a build tree somewhere
++# (either in a bundle or a standalone build).
++if( DEFINED ioda_BINARY_DIR )
++        # We are in the build tree.
++        # CMAKE_CURRENT_LIST_DIR is the old var
++        set( IODA_YAML_ROOT "${ioda_BINARY_DIR}/share/test/testinput" )
++else()
++	# We are outside of ioda's build tree.
++	if( IS_ABSOLUTE "@CMAKE_INSTALL_DATADIR@")
++		set( IODA_YAML_ROOT "@CMAKE_INSTALL_DATADIR@/ioda/yaml" )
++	else()
++		# ioda_BASE_DIR is defined by the ecbuild-generated ioda-config.cmake.
++		# See https://github.com/ecmwf/ecbuild/blob/develop/cmake/project-config.cmake.in
++		set( IODA_YAML_ROOT "${ioda_BASE_DIR}/@CMAKE_INSTALL_DATADIR@/ioda/yaml" )
++	endif()
++endif()
++

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda/ioda_yaml_root.patch
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda/ioda_yaml_root.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/ioda-import.cmake.in b/cmake/ioda-import.cmake.in
+index 907fce15..0d7ae528 100644
+--- a/cmake/ioda-import.cmake.in
++++ b/cmake/ioda-import.cmake.in
+@@ -96,7 +96,7 @@ else()
+ 		# in the ioda-post-import.cmake file, even if it is never again used. Some
+ 		# tools (like Spack) will complain about this path and may indicate that ioda
+ 		# is a non-relocatable package, even though it is completely relocatable.
+-		set( IODA_YAML_ROOT "@IODA_YAML_ROOT@" )
++		set( IODA_YAML_ROOT "${CMAKE_CURRENT_LIST_FILE}/share/test/testinput/" )
+ 	endif()
+ endif()
+ 

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda/package.py
@@ -20,6 +20,7 @@ class Ioda(CMakePackage):
     version("2.9.0.20250826", commit="6e76616001067384f7d0ca4341ad78e81527af8b")
 
     patch("ioda_cmake_import.patch", when="@2.9.0.20250826")
+    patch("ioda_yaml_root.patch", when="@2.9.0.20250826")
 
     variant("doc", default=False, description="Build IODA documentation")
     # Let's always assume IODA_BUILD_LANGUAGE_FORTRAN=on.
@@ -101,11 +102,11 @@ class Ioda(CMakePackage):
             else:
                 ctest("--timeout", "120")
 
-    @run_after("install")
-    def fix_ioda_yaml_root_path(self):
-        with when("@2.9.0.20250826"):
-            filter_file(
-                join_path(self.build_directory, "share/test/testinput/"),
-                join_path(self.prefix, "share/ioda/yaml"),
-                join_path(self.prefix, "lib64/cmake/ioda/ioda-import.cmake"),
-            )
+    #@run_after("install")
+    #def fix_ioda_yaml_root_path(self):
+    #    with when("@2.9.0.20250826"):
+    #        filter_file(
+    #            join_path(self.build_directory, "share/test/testinput/"),
+    #            join_path(self.prefix, "share/ioda/yaml"),
+    #            join_path(self.prefix, "lib64/cmake/ioda/ioda-import.cmake"),
+    #        )

--- a/repos/spack_stack/spack_repo/spack_stack/packages/oops/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/oops/package.py
@@ -22,6 +22,7 @@ class Oops(CMakePackage):
     version("1.10.0.20250827", commit="91889ad09d3789f14a1184701dd80a4913d3ce3e")
 
     patch("include_algorithm.patch", when="@1.10.0.20250827")
+    patch("patch-1.10.0.atlas.mac.patch", when="@1.10.0.20250827")
 
     variant("l95", default=True, description="Build LORENZ95 toy model")
     variant("mkl", default=False, description="Use MKL for LAPACK implementation (if available)")

--- a/repos/spack_stack/spack_repo/spack_stack/packages/oops/patch-1.10.0.atlas.mac.patch
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/oops/patch-1.10.0.atlas.mac.patch
@@ -1,0 +1,34 @@
+diff --git a/src/oops/util/ParallelFieldSetIO.cc b/src/oops/util/ParallelFieldSetIO.cc
+index 04e4c55c..0a07a9ba 100644
+--- a/src/oops/util/ParallelFieldSetIO.cc
++++ b/src/oops/util/ParallelFieldSetIO.cc
+@@ -80,9 +80,6 @@ atlas::FieldSet ParallelFieldSetIO::ioFieldSet(const atlas::FieldSet& nativeFiel
+             case atlas::array::DataType::KIND_INT32:
+                 ioFieldSet.add(functionSpace_.createField<int>(fieldSetConfig));
+                 break;
+-            case atlas::array::DataType::KIND_INT64:
+-                ioFieldSet.add(functionSpace_.createField<int64_t>(fieldSetConfig));
+-                break;
+             case atlas::array::DataType::KIND_REAL32:
+                 ioFieldSet.add(functionSpace_.createField<float>(fieldSetConfig));
+                 break;
+@@ -105,9 +102,6 @@ void ParallelFieldSetIO::writeFieldByTypeAndRank(const atlas::Field& field,
+         case atlas::array::DataType::KIND_INT32:
+             dispatchWriteField<int>(field, netcdfGeneralIDs, netcdfVarID);
+             break;
+-        case atlas::array::DataType::KIND_INT64:
+-            dispatchWriteField<int64_t>(field, netcdfGeneralIDs, netcdfVarID);
+-            break;
+         case atlas::array::DataType::KIND_REAL32:
+             dispatchWriteField<float>(field, netcdfGeneralIDs, netcdfVarID);
+             break;
+@@ -129,9 +123,6 @@ void ParallelFieldSetIO::readFieldByTypeAndRank(atlas::Field& field,
+         case atlas::array::DataType::KIND_INT32:
+             dispatchReadField<int>(field, netcdfGeneralIDs, netcdfVarID);
+             break;
+-        case atlas::array::DataType::KIND_INT64:
+-            dispatchReadField<int64_t>(field, netcdfGeneralIDs, netcdfVarID);
+-            break;
+         case atlas::array::DataType::KIND_REAL32:
+             dispatchReadField<float>(field, netcdfGeneralIDs, netcdfVarID);
+             break;


### PR DESCRIPTION
## Description

Hi guys. I recently tried to build ioda-converters using spack-stack 2.1 on an arm64 mac laptop. I'm not trying to build one of the heavier environments / this was a test of a more limited package subset. I encountered some errors when building & linking oops and ioda, and here are two potential patches.

### The oops change

The oops patch is an easy one. It is backported from https://github.com/JCSDA/oops/commit/f378c46bcc4dfd04da3773d45f9057f1046801b5, and this change was made in response to https://github.com/ecmwf/atlas/issues/307.

The underlying bug was never incorporated into a stable JCSDA tag of oops. It only affects the code around spack-stack's 2025-08-27 oops commit.

Users might wonder why using `int64_t` in oops triggers this compiler-time bug. This is because int64_t is a typedef to a _fundamental_ C++ type, and depending on the platform it may point to either `long` or `long long`. It doesn't matter that `long` and `long long` are frequently the same size nowadays. They are distinct types.

### The ioda change

The initial `filter_file` command can't find the target file. ioda-import.cmake isn't always installed into `lib64/cmake/ioda/`, and there is likely a `lib` vs `lib64` platform-specific issue.

The patch file is a bit terse, so here's an explanation of the problematic code in [cmake/ioda-import.cmake.in](https://github.com/JCSDA/ioda/blob/develop/cmake/ioda-import.cmake.in#L93):
```
# Export ioda YAML validation files directory
if( IS_ABSOLUTE "@CMAKE_INSTALL_DATADIR@")
	set( IODA_YAML_ROOT "@CMAKE_INSTALL_DATADIR@/ioda/yaml" )
else()
	if ( DEFINED _IMPORT_PREFIX )
		# We are in a CMake install tree
		set( IODA_YAML_ROOT "${_IMPORT_PREFIX}/@CMAKE_INSTALL_DATADIR@/ioda/yaml" )
	else()
		# We are in a CMake build tree. Ergo, we can use the variable set in
		# IODA's top-level CMakeLists.txt that points to the YAML root path
		# in the source tree.
		#
		# Note: a small downside of this approach is that a source tree path is hardcoded
		# in the ioda-post-import.cmake file, even if it is never again used. Some
		# tools (like Spack) will complain about this path and may indicate that ioda
		# is a non-relocatable package, even though it is completely relocatable.
		set( IODA_YAML_ROOT "@IODA_YAML_ROOT@" )
	endif()
endif()
```

IODA_YAML_ROOT is set in ioda's `share/CMakeLists.txt` file to `${CMAKE_CURRENT_BINARY_DIR}/test/testinput/`. If you're in a build mode (i.e. not install mode), `ioda-import.cmake` should be placed in at the top of the project's build tree, so IODA_YAML_ROOT can always point to `${CMAKE_CURRENT_LIST_DIR}/share/test/testinput/`. 

I'm redoing my stack, so I haven't tested this in a bundle build and can't recall whether ecbuild is forcing the `*-import.cmake` files to be placed in CMAKE_BINARY_DIR or PROJECT_BINARY_DIR. That might change the patch _slightly_, but you should get the gist.

### One other issue with scipy (not addressed here)

spack-stack doesn't seem to pin a specific py-scipy version. Someone should review that recipe, as not all patches apply to py-scipy@1.16.0. Some of the files to be patched have moved or no longer exist.

### Dependencies

None

### Issues addressed

None

### Applications affected

None operational. This is mostly for macs.

### Systems affected

Macos systems

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
