### PR TITLE
ufs-weather-model-env: remove base-env dependency/explicitly list deps; make nccmp, cprnc optional

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -22,25 +22,34 @@ class UfsWeatherModelEnv(BundlePackage):
         default=False,
         description="Build a debug version of certain dependencies (ESMF, MAPL)",
     )
-    variant("python", default=True, description="Build Python dependencies")
+    variant("python", default=True, description="Include extra Python packages")
+    variant("ncutils", default=True, description="Include extra NetCDF utilities (cprnc and nccmp)")
 
-    depends_on("base-env", type="run")
-    depends_on("ufs-pyenv", type="run", when="+python")
+    depends_on("cmake", type="run")
+    depends_on("python", type="run")
 
-    depends_on("fms +gfs_phys constants=GFS", type="run")
     depends_on("bacio", type="run")
     depends_on("crtm", type="run")
+    depends_on("fms +gfs_phys constants=GFS", type="run")
     depends_on("g2", type="run")
     depends_on("g2tmpl", type="run")
+    depends_on("hdf5", type="run")
     depends_on("ip", type="run")
+    depends_on("netcdf-c", type="run")
+    depends_on("netcdf-fortran", type="run")
+    depends_on("parallelio", type="run")
+    depends_on("scotch", type="run")
     depends_on("sp", type="run", when="^ip@:4")
     depends_on("w3emc", type="run")
-    depends_on("scotch", type="run")
-    depends_on("cprnc", type="run")
+    depends_on("zlib-api", type="run")
 
     depends_on("esmf~debug", type="run", when="~debug")
     depends_on("esmf+debug", type="run", when="+debug")
     depends_on("mapl~debug", type="run", when="~debug")
     depends_on("mapl+debug", type="run", when="+debug")
+
+    depends_on("ufs-pyenv", type="run", when="+python")
+    depends_on("cprnc", type="run", when="+ncutils")
+    depends_on("nccmp", type="run", when="+ncutils")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class UfsWeatherModelEnv(BundlePackage):
-    """Development environment for ufs-weathermodel-bundle"""
+    """Development environment for ufs-weather-model"""
 
     homepage = "https://github.com/ufs-community/ufs-weather-model"
     git = "https://github.com/ufs-community/ufs-weather-model.git"
@@ -30,11 +30,18 @@ class UfsWeatherModelEnv(BundlePackage):
 
     depends_on("bacio", type="run")
     depends_on("crtm", type="run")
+    depends_on("esmf~debug", type="run", when="~debug")
+    depends_on("esmf+debug", type="run", when="+debug")
     depends_on("fms +gfs_phys constants=GFS", type="run")
     depends_on("g2", type="run")
     depends_on("g2tmpl", type="run")
+    depends_on("gftl-shared", type="run")
     depends_on("hdf5", type="run")
     depends_on("ip", type="run")
+    depends_on("jasper", type="run")
+    depends_on("libpng", type="run")
+    depends_on("mapl~debug", type="run", when="~debug")
+    depends_on("mapl+debug", type="run", when="+debug")
     depends_on("netcdf-c", type="run")
     depends_on("netcdf-fortran", type="run")
     depends_on("parallelio", type="run")
@@ -42,11 +49,6 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("sp", type="run", when="^ip@:4")
     depends_on("w3emc", type="run")
     depends_on("zlib-api", type="run")
-
-    depends_on("esmf~debug", type="run", when="~debug")
-    depends_on("esmf+debug", type="run", when="+debug")
-    depends_on("mapl~debug", type="run", when="~debug")
-    depends_on("mapl+debug", type="run", when="+debug")
 
     depends_on("ufs-pyenv", type="run", when="+python")
     depends_on("cprnc", type="run", when="+ncutils")


### PR DESCRIPTION
## Description

This PR updates ufs-weather-model-env, including a proposal to remove the dependency on base-env and list dependencies explicitly. Specifically, it reflects the list in https://github.com/ufs-community/ufs-weather-model/blob/develop/modulefiles/ufs_common.lua. It adds variants for including/excluding netcdf utilities (nccmp, cprnc) and build dependencies (cmake, python, git) so that developers can use this metapackage to install strictly the packages needed to build UFSWM with no frills.

### Dependencies

none

### Issues addressed

none

### Applications affected

UFS Weather Model

### Systems affected

all

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
- Additional testing: _Add information on any additional tests conducted_
    - [x] test concretization of unified-dev and UFSWM only envs on Acorn

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
