### PR TITLE
Update versions of ECMWF libraries / bug fix in spack (GMAO-SI-Team/fix/module-already-loaded)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,4 @@
 [submodule "repos/builtin"]
   path = repos/builtin
   url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  branch = feature/cherrypick_ecmwflibs
+  branch = spack-stack-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,5 @@
 [submodule "repos/builtin"]
   path = repos/builtin
   url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #branch = spack-stack-dev
+  branch = feature/cherrypick_ecmwflibs

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -340,7 +340,7 @@ packages:
     # ninja - when adding information here, also check Discover site config
     odc:
       require:
-      - '@1.6.1'
+      - '@1.6.3'
       - ~fortran
     openmpi:
       require:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -109,19 +109,19 @@ packages:
       - +ui
     eckit:
       require:
-      - '@1.32.3'
+      - '@2.0.7'
       - linalg=eigen,lapack
       - compression=lz4,bzip2
     ecmwf-atlas:
       require:
-      - '@0.44.1'
+      - '@0.46.0'
       - +fckit
       - +trans
       - +tesselation
       - +fftw
     ectrans:
       require:
-      - '@1.7.0'
+      - '@1.8.0'
     eigen:
       require:
       - '@3.4.0'
@@ -148,14 +148,14 @@ packages:
       - ~libbsd
     fckit:
       require:
-      - '@0.14.1'
+      - '@0.14.3'
       - +eckit
     fftw:
       require:
       - '@3.3.10'
     fiat:
       require:
-      - '@1.6.1'
+      - '@2.0.0'
     flex:
       require:
       - '@2.6.4'

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_env/package.py
@@ -56,5 +56,6 @@ class NeptuneEnv(BundlePackage):
     depends_on("py-f90nml", type="run")
     depends_on("py-python-dateutil", type="run")
     depends_on("py-pyyaml", type="run")
+    depends_on("py-ruamel-yaml", type="run")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
@@ -37,7 +37,6 @@ class NeptunePythonEnv(BundlePackage):
     depends_on("py-pycodestyle", type="run")
     depends_on("py-pybind11", type="run")
     depends_on("py-pyhdf", type="run")
-    depends_on("py-pyyaml", type="run")
     depends_on("py-regionmask", type="run")
     depends_on("py-scipy", type="run")
     depends_on("py-xarray", type="run")


### PR DESCRIPTION
## Description

Update ECMWF libraries used by JEDI:
- eckit 2.0.7
- fckit 0.14.3
- fiat 2.0.0
- ectrans 1.8.0
- atlas 0.46.0
- odc 1.6.3

Also included: Update submodule pointer for spack: GMAO-SI-Team/fix/module-already-loaded

### Dependencies

- [x] waiting on https://github.com/spack/spack-packages/pull/5426
- [x] waiting on https://github.com/spack/spack-packages/pull/6115
- [x] waiting on https://github.com/JCSDA/spack-packages/pull/75
- [x] waiting on https://github.com/JCSDA/spack/pull/578

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/2037

### Applications affected

JEDI

### Systems affected

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested jedi-bundle on Ubuntu 24.04 server with these package versions, built with gcc and oneapi, but _outside_ of spack-stack.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
