### PR TITLE
Additional NRL site config updates after pulling in spack/spack-packages develop

### DIFF
--- a/configs/sites/tier1/blueback/packages.yaml
+++ b/configs/sites/tier1/blueback/packages.yaml
@@ -1,5 +1,8 @@
 packages:
   # Modification of common packages
+  cairo:
+    # /usr/lib64/libgdk-x11-2.0.so: undefined reference to `cairo_xlib_surface_set_size'
+    require: +X
   zlib-api:
     buildable: False
 

--- a/configs/sites/tier1/narwhal/packages.yaml
+++ b/configs/sites/tier1/narwhal/packages.yaml
@@ -1,5 +1,8 @@
 packages:
   # Modification of common packages
+  cairo:
+    # /usr/lib64/libgdk-x11-2.0.so: undefined reference to `cairo_xlib_surface_set_size'
+    require: +X
   zlib-api:
     buildable: False
 

--- a/configs/sites/tier1/narwhal/packages.yaml
+++ b/configs/sites/tier1/narwhal/packages.yaml
@@ -48,8 +48,6 @@ packages:
     externals:
     - spec: git-lfs@2.10.0
       prefix: /p/app/projects/NEPTUNE/spack-stack/git-lfs-2.10.0
-      modules:
-      - git-lfs/2.10.0
   gmake:
     externals:
     - spec: gmake@4.2.1
@@ -70,13 +68,6 @@ packages:
     externals:
     - spec: m4@1.4.18
       prefix: /usr
-  #mysql:
-  #  buildable: False
-  #  externals:
-  #  - spec: mysql@8.0.31
-  #    prefix: /p/app/projects/NEPTUNE/spack-stack/mysql-8.0.31
-  #    modules:
-  #    - mysql/8.0.31
   perl:
     externals:
     - spec: perl@5.26.1~cpanm+shared+threads


### PR DESCRIPTION
## Description

This PR contains two small bug fixes for the Blueback and Narwhal site configs that are required to build the different environments after the update of spack and spack-packages from develop last month.

### Dependencies

n/a

### Issues addressed

n/a

### Applications affected

n/a

### Systems affected

Blueback, Narwhal

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [x] GitHub actions CI tests skipped **these files aren't used by GitHub Actions**
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built all spack-stack environments with all supported compilers on NRL's Atlantis, Blueback, Narwhal, Nautilus

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
