### PR TITLE
Enable variant +shared for libbacktrace in configs/common/packages.yaml

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -257,6 +257,10 @@ packages:
       prefer:
       - build_system=cmake
       - generator=make
+    # https://github.com/JCSDA/spack-stack/issues/2058
+    libbacktrace:
+      require:
+      - +shared
     libpng:
       require:
       - '@1.6.55'


### PR DESCRIPTION
## Description

All in the title. Fixes https://github.com/JCSDA/spack-stack/issues/2058.

### Dependencies

None.

### Issues addressed

Fixes https://github.com/JCSDA/spack-stack/issues/2058.

### Applications affected

Any JEDI bundle build

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] blueback / neptune-bundle

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
