### PR TITLE
Merge release/2.1 into develop 2026/07/15

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,5 @@
 [submodule "repos/builtin"]
   path = repos/builtin
   url = https://github.com/jcsda/spack-packages
-  branch = spack-stack-dev
+  #branch = spack-stack-dev
+  branch = feature/spstdev_merge_rel21_2060715

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,4 @@
 [submodule "repos/builtin"]
   path = repos/builtin
   url = https://github.com/jcsda/spack-packages
-  #branch = spack-stack-dev
-  branch = feature/spstdev_merge_rel21_2060715
+  branch = spack-stack-dev

--- a/configs/sites/tier1/hercules/packages.yaml
+++ b/configs/sites/tier1/hercules/packages.yaml
@@ -17,6 +17,13 @@ packages:
       prefix: /apps/spack-managed/gcc-11.3.1/zlib-1.2.13-ltp4c3zzde3zi3gf7x4b7c7nj5ww4i4g
       modules:
       - zlib/1.2.13
+ 
+  # https://github.com/JCSDA/spack-stack/issues/1892
+  openssl:
+    require:
+    - +shared
+    - '@3.0.16'
+
   autoconf:
     externals:
     - spec: autoconf@2.69

--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -17,6 +17,13 @@ packages:
       prefix: /apps/spack-managed/gcc-11.3.1/zlib-1.2.13-ltp4c3zzde3zi3gf7x4b7c7nj5ww4i4g
       modules:
       - zlib/1.2.13
+
+  # https://github.com/JCSDA/spack-stack/issues/1892
+  openssl:
+    require:
+    - +shared
+    - '@3.0.16'
+
   autoconf:
     externals:
     - spec: autoconf@2.69


### PR DESCRIPTION
## Description

Update spack-stack develop / spack-packages spack-stack-dev from `release/2.1`.

- Hercules pin openssl
- Intel oneAPI flags for FMS

### Dependencies

- [x] Waiting on https://github.com/JCSDA/spack-packages/pull/71

### Issues addressed

Closes #2007 

### Applications affected

UFS (FMS)

### Systems affected

Hercules

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested as part of `release/2.1`

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
