### PR TITLE
Install ioda on Ubuntu

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 
 from spack.package import *
@@ -104,8 +106,10 @@ class Ioda(CMakePackage):
     @run_after("install")
     def fix_ioda_yaml_root_path(self):
         with when("@2.9.0.20250826"):
+            # use either lib64 or lib depending on OS
+            libdir = "lib64" if os.path.isdir(join_path(self.prefix, "lib64")) else "lib"
             filter_file(
                 join_path(self.build_directory, "share/test/testinput/"),
                 join_path(self.prefix, "share/ioda/yaml"),
-                join_path(self.prefix, "lib64/cmake/ioda/ioda-import.cmake"),
+                join_path(self.prefix, libdir, "cmake/ioda/ioda-import.cmake"),
             )


### PR DESCRIPTION
## Description

Currently, the package `ioda` won't install on Ubuntu due to a missing path in the `@run_after(install)` block. `fix_ioda_yaml_root_path()` attempts to use a hardcoded path `lib64\cmake\`... which breaks on Ubuntu, where `lib` rather than `lib64` is used. This PR adds a statement to handle both cases, allowing for `ioda` to be installed either way.

### Dependencies

None.

### Issues addressed

None.

### Applications affected

Any application that attempts to build `ioda` on Ubuntu (or other Debian-based OS's). `lib64` is the default and is always used if it exists, so no change of behavior is expected anywhere `ioda` already installs.

### Systems affected

No supported systems should be affected.

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_

- Additional testing: _Add information on any additional tests conducted_
    - [x] Built `ioda` successfully on Ubuntu WSL
    - [ ] Built `ioda` successfully on Ursa (to verify `lib64` is used when appropriate)

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
