### PR TITLE
New NRL-only package py-lis-ncoda-utils

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -70,10 +70,11 @@ jobs:
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler gcc
             spack env activate ${ENVDIR}
 
-            # Turn off variants "adp" and "jedi" for neptune-dev (NRL internal only)
+            # Turn off certain variants for neptune-dev (NRL internal only)
             if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
               sed -i 's/+adp/~adp/g' ${ENVDIR}/spack.yaml
               sed -i 's/+jedi/~jedi/g' ${ENVDIR}/spack.yaml
+              sed -i 's/+lis-ncoda-utils/~lis-ncoda-utils/g' ${ENVDIR}/spack.yaml
             fi
 
             unset SPACK_DISABLE_LOCAL_CONFIG

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -70,10 +70,11 @@ jobs:
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler oneapi
             spack env activate ${ENVDIR}
 
-            # Turn off variants "adp" and "jedi" for neptune-dev (NRL internal only)
+            # Turn off certain variants for neptune-dev (NRL internal only)
             if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
               sed -i 's/+adp/~adp/g' ${ENVDIR}/spack.yaml
               sed -i 's/+jedi/~jedi/g' ${ENVDIR}/spack.yaml
+              sed -i 's/+lis-ncoda-utils/~lis-ncoda-utils/g' ${ENVDIR}/spack.yaml
             fi
 
             unset SPACK_DISABLE_LOCAL_CONFIG

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -70,10 +70,11 @@ jobs:
             spack stack create env --site linux.default --template ${TEMPLATE} --name ${ENVNAME} --compiler oneapi
             spack env activate ${ENVDIR}
 
-            # Turn off variants "adp" and "jedi" for neptune-dev (NRL internal only)
+            # Turn off certain variants for neptune-dev (NRL internal only)
             if [[ "${TEMPLATE}" == *"neptune-dev"* ]]; then
               sed -i 's/+adp/~adp/g' ${ENVDIR}/spack.yaml
               sed -i 's/+jedi/~jedi/g' ${ENVDIR}/spack.yaml
+              sed -i 's/+lis-ncoda-utils/~lis-ncoda-utils/g' ${ENVDIR}/spack.yaml
             fi
 
             unset SPACK_DISABLE_LOCAL_CONFIG

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -427,6 +427,10 @@ packages:
     py-numpy:
       require:
       - '@1'
+    # Restrict py-pandas to older versions compatible with py-numpy and py-xarray
+    py-pandas:
+      require:
+      - '@:2'
     # To avoid duplicate packages
     py-poetry-core:
       require:

--- a/configs/templates/neptune-dev/spack.yaml
+++ b/configs/templates/neptune-dev/spack.yaml
@@ -26,8 +26,8 @@ spack:
   - neptune-env +debug +openmp +espc +ncview ^esmf@=9.0.0b11
   - neptune-env ~debug ~openmp +espc +ncview ^esmf@=9.0.0b11
   - neptune-env +debug ~openmp +espc +ncview ^esmf@=9.0.0b11
-  - neptune-python-env +gittools ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
-  - jedi-neptune-env +adp +jedi  ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - neptune-python-env +gittools +lis-ncoda-utils ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
+  - jedi-neptune-env +adp +jedi                   ^neptune-env ~debug +openmp +espc +ncview ^esmf@=9.0.0b11
   - crtm@3.1.3
 
   packages:

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
@@ -21,6 +21,7 @@ class NeptunePythonEnv(BundlePackage):
     version("1.5.0")
 
     variant("gittools", default=False, description="Build additional tools for Git/GitHub")
+    variant("lis-ncoda-utils", default=False, description="Build LIS/NCODA utilities")
 
     depends_on("neptune-env", type="run")
     # Enable the Python variant for ESMF
@@ -49,5 +50,8 @@ class NeptunePythonEnv(BundlePackage):
     with when("+gittools"):
         depends_on("gh", type="run")
         depends_on("py-pygithub", type="run")
+
+    with when("+lis-ncoda-utils"):
+        depends_on("py-lis-ncoda-utils", type="run")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
@@ -19,11 +19,12 @@ class PyLisNcodaUtils(PythonPackage):
     license("custom")
 
     version("develop", branch="develop")
-    #version("2024.05.23", sha256="73611e72f4a192c9b93039381fdd085c7f1fe09fbdff4bdeb285f744ad2fb05d")
+    version("2.0.0", commit="85cb17c70705e88d15c5ff191b177090a5136052")
 
     depends_on("python@3.11:", type=("build", "run"))
     depends_on("fortran", type="build")
-    
+
+    depends_on("cmake@3.15:", type="build")    
     depends_on("py-scikit-build-core", type="build")
     depends_on("py-numpy", type=("build", "run"))
     

--- a/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyLisNcodaUtils(PythonPackage):
+    """Utility to convert LIS and NCODA files for NEPTUNE."""
+
+    homepage = "https://github.nrlmry.navy.mil/neptune/lis-ncoda-utils"
+    url = "https://github.nrlmry.navy.mil/neptune/lis-ncoda-utils/archive/refs/tags/2.0.0.tar.gz"
+    git = "https://github.nrlmry.navy.mil/neptune/lis-ncoda-utils.git"
+
+    maintainers("climbfuji")
+
+    license("custom")
+
+    version("develop", branch="develop")
+    #version("2024.05.23", sha256="73611e72f4a192c9b93039381fdd085c7f1fe09fbdff4bdeb285f744ad2fb05d")
+
+    depends_on("python@3.11:", type=("build", "run"))
+    depends_on("fortran", type="build")
+    
+    depends_on("py-scikit-build-core", type="build")
+    depends_on("py-numpy", type=("build", "run"))
+    
+    depends_on("py-cfgrib", type="run")
+    depends_on("py-h5py", type="run")
+    depends_on("py-netcdf4", type="run")
+    depends_on("py-xarray", type="run")


### PR DESCRIPTION
## Description

This PR adds a new package `py-lis-ncoda-utils`, which is available at NRL internally only. A new variant is added to the `neptune-python-env` virtual package and the `neptune-dev` template. Like for other NRL-internal packages, these variants are turned off in GitHub actions testing in this repo.

### Dependencies

- [x] NRL-internal PR, after which tag 2.0.0 will be created for the new package `py-lis-ncoda-utils`

### Issues addressed

NRL-internal issue, not visible here.

### Applications affected

NEPTUNE

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built `py-lis-ncoda-utils` with spack-stack and tested the utilities on real data.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
