### PR TITLE
Add dependency on 'c' for py_lis_ncoda_utils

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
@@ -22,6 +22,7 @@ class PyLisNcodaUtils(PythonPackage):
     version("2.0.0", commit="85cb17c70705e88d15c5ff191b177090a5136052")
 
     depends_on("python@3.11:", type=("build", "run"))
+    depends_on("c", type="build")
     depends_on("fortran", type="build")
 
     depends_on("cmake@3.15:", type="build")    


### PR DESCRIPTION
## Description

Testing on Narwhal revealed that we need to add dependency on 'c' for `py_lis_ncoda_utils`.

### Dependencies

None

### Issues addressed

See above

### Applications affected

NEPTUNE environments

### Systems affected

Narwhal and probably Blueback

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass (`py-lis-ncoda-utils` aren't installed in the CI tests here)
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Tested on Narwhal

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
