### PR TITLE
Add support for kokkos / kokkos-kernels and cuda to unified-dev env

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -252,13 +252,11 @@ packages:
     kokkos:
       require:
       - '@5.1.1'
-      - ~cuda
       - +openmp
       - +serial
     kokkos-kernels:
       require:
       - '@5.1.1'
-      - ~cuda
       - +openmp
       - +serial
     landsfcutil:

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -249,6 +249,18 @@ packages:
     jedi-cmake:
       require:
       - '@1.4.0'
+    kokkos:
+      require:
+      - '@5.1.1'
+      - ~cuda
+      - +openmp
+      - +serial
+    kokkos-kernel:
+      require:
+      - '@5.1.1'
+      - ~cuda
+      - +openmp
+      - +serial
     landsfcutil:
       require:
       - '@2.4.2'

--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -255,7 +255,7 @@ packages:
       - ~cuda
       - +openmp
       - +serial
-    kokkos-kernel:
+    kokkos-kernels:
       require:
       - '@5.1.1'
       - ~cuda

--- a/configs/sites/tier1/gaea-c6/packages.yaml
+++ b/configs/sites/tier1/gaea-c6/packages.yaml
@@ -10,6 +10,19 @@ packages:
     - spec: zlib@1.2.13
       prefix: /usr
 
+# Modifications of common packages
+  # GPUs on ursa are H100
+  ufs-weather-model-env:
+    require::
+    - +kokkos
+
+  kokkos:
+    require:
+    - '~cuda'
+  kokkos-kernels:
+    require:
+    - '~cuda'
+
   autoconf:
     externals:
     - spec: autoconf@2.69

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -9,10 +9,17 @@ packages:
     - '@1.2.13'
 
 # Modifications of common packages
+  # GPUs on ursa are H100
   ufs-weather-model-env:
     require::
-    - ~cuda
     - +kokkos
+
+  kokkos:
+    require:
+    - '+cuda cuda_arch=90'
+  kokkos-kernels:
+    require:
+    - '+cuda'
 
 # All other packages listed alphabetically
   autoconf:

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -8,6 +8,12 @@ packages:
     require::
     - '@1.2.13'
 
+# Modifications of common packages
+  ufs-weather-model-env:
+    require::
+    - ~cuda
+    - +kokkos
+
 # All other packages listed alphabetically
   autoconf:
     externals:

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -19,7 +19,7 @@ packages:
     - '+cuda cuda_arch=90'
   kokkos-kernels:
     require:
-    - '+cuda'
+    - '+cuda cuda_arch=90'
 
 # All other packages listed alphabetically
   autoconf:

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -25,7 +25,6 @@ class UfsWeatherModelEnv(BundlePackage):
     variant("python", default=True, description="Include extra Python packages")
     variant("ncutils", default=True, description="Include extra NetCDF utilities (cprnc and nccmp)")
     variant("kokkos", default=False, description="Include kokkos and kokkos-kernels")
-    #variant("cuda", default=False, description="Enable cuda support for kokkos")
 
     depends_on("cmake", type="run")
     depends_on("python", type="run")
@@ -58,13 +57,31 @@ class UfsWeatherModelEnv(BundlePackage):
 
     # https://github.com/JCSDA/spack-stack/issues/2081
     # kokkos for UFS-WM atmospheric composition modeling components (CATChem & CECE)
-    # default to +openmp for both packages
+    # default to +openmp and +serial for both packages
     with when("+kokkos"):
-        variant("cuda", default=False, description="Enable cuda support for kokkos")
-        depends_on("kokkos +cuda +openmp", type="run", when="+cuda")
-        depends_on("kokkos-kernel +openmp", type="run", when="+kokkos")
+        variant("cuda", default=False, description="Enable cuda support")
+        variant("openmp", default=False, description="Build the OpenMP backend")
+        variant("serial", default=False, description="Build the serial backend")
 
-        #depends_on("kokkos +openmp", type="run", when="+kokkos")
-        #depends_on("kokkos-kernel +openmp", type="run", when="+kokkos")
+        depends_on("kokkos", type="run")
+        depends_on("kokkos-kernel", type="run")
+
+        # cuda
+        depends_on("kokkos +cuda", type=("build", "run"), when="+cuda")
+        depends_on("kokkos ~cuda", type=("build", "run"), when="~cuda")
+        depends_on("kokkos-kernel +cuda", type=("build", "run"), when="+cuda")
+        depends_on("kokkos-kernel ~cuda", type=("build", "run"), when="~cuda")
+
+        # openmp backend
+        depends_on("kokkos +openmp", type=("build", "run"), when="+openmp")
+        depends_on("kokkos ~openmp", type=("build", "run"). when="~openmp")
+        depends_on("kokkos-kernel +openmp", type=("build", "run"), when="+openmp")
+        depends_on("kokkos-kernel ~openmp", type=("build", "run"). when="~openmp")
+
+        # serial backend
+        depends_on("kokkos +serial", type=("build", "run"), when="+serial")
+        depends_on("kokkos ~serial", type=("build", "run"), when="~serial")
+        depends_on("kokkos-kernel +serial", type=("build", "run"), when="+serial")
+        depends_on("kokkos-kernel ~serial", type=("build", "run"), when="~serial")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -64,24 +64,24 @@ class UfsWeatherModelEnv(BundlePackage):
         variant("serial", default=False, description="Build the serial backend")
 
         depends_on("kokkos", type="run")
-        depends_on("kokkos-kernel", type="run")
+        depends_on("kokkos-kernels", type="run")
 
         # cuda
-        depends_on("kokkos +cuda", type=("build", "run"), when="+cuda")
-        depends_on("kokkos ~cuda", type=("build", "run"), when="~cuda")
-        depends_on("kokkos-kernel +cuda", type=("build", "run"), when="+cuda")
-        depends_on("kokkos-kernel ~cuda", type=("build", "run"), when="~cuda")
+        depends_on("kokkos +cuda", type="run", when="+cuda")
+        depends_on("kokkos ~cuda", type="run", when="~cuda")
+        depends_on("kokkos-kernels +cuda", type="run", when="+cuda")
+        depends_on("kokkos-kernels ~cuda", type="run", when="~cuda")
 
         # openmp backend
-        depends_on("kokkos +openmp", type=("build", "run"), when="+openmp")
-        depends_on("kokkos ~openmp", type=("build", "run"). when="~openmp")
-        depends_on("kokkos-kernel +openmp", type=("build", "run"), when="+openmp")
-        depends_on("kokkos-kernel ~openmp", type=("build", "run"). when="~openmp")
+        depends_on("kokkos +openmp", type="run", when="+openmp")
+        depends_on("kokkos ~openmp", type="run", when="~openmp")
+        depends_on("kokkos-kernels +openmp", type="run", when="+openmp")
+        depends_on("kokkos-kernels ~openmp", type="run", when="~openmp")
 
         # serial backend
-        depends_on("kokkos +serial", type=("build", "run"), when="+serial")
-        depends_on("kokkos ~serial", type=("build", "run"), when="~serial")
-        depends_on("kokkos-kernel +serial", type=("build", "run"), when="+serial")
-        depends_on("kokkos-kernel ~serial", type=("build", "run"), when="~serial")
+        depends_on("kokkos +serial", type="run", when="+serial")
+        depends_on("kokkos ~serial", type="run", when="~serial")
+        depends_on("kokkos-kernels +serial", type="run", when="+serial")
+        depends_on("kokkos-kernels ~serial", type="run", when="~serial")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -58,30 +58,9 @@ class UfsWeatherModelEnv(BundlePackage):
     # https://github.com/JCSDA/spack-stack/issues/2081
     # kokkos for UFS-WM atmospheric composition modeling components (CATChem & CECE)
     # default to +openmp and +serial for both packages
+    # kokkos and kokkos-kernels are spec'd in common/packages.yaml and <site>/packages.yaml
     with when("+kokkos"):
-        variant("cuda", default=False, description="Enable cuda support")
-        variant("openmp", default=False, description="Build the OpenMP backend")
-        variant("serial", default=False, description="Build the serial backend")
-
         depends_on("kokkos", type="run")
         depends_on("kokkos-kernels", type="run")
-
-        # cuda
-        depends_on("kokkos +cuda", type="run", when="+cuda")
-        depends_on("kokkos ~cuda", type="run", when="~cuda")
-        depends_on("kokkos-kernels +cuda", type="run", when="+cuda")
-        depends_on("kokkos-kernels ~cuda", type="run", when="~cuda")
-
-        # openmp backend
-        depends_on("kokkos +openmp", type="run", when="+openmp")
-        depends_on("kokkos ~openmp", type="run", when="~openmp")
-        depends_on("kokkos-kernels +openmp", type="run", when="+openmp")
-        depends_on("kokkos-kernels ~openmp", type="run", when="~openmp")
-
-        # serial backend
-        depends_on("kokkos +serial", type="run", when="+serial")
-        depends_on("kokkos ~serial", type="run", when="~serial")
-        depends_on("kokkos-kernels +serial", type="run", when="+serial")
-        depends_on("kokkos-kernels ~serial", type="run", when="~serial")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -24,6 +24,8 @@ class UfsWeatherModelEnv(BundlePackage):
     )
     variant("python", default=True, description="Include extra Python packages")
     variant("ncutils", default=True, description="Include extra NetCDF utilities (cprnc and nccmp)")
+    variant("kokkos", default=False, description="Include kokkos and kokkos-kernels")
+    #variant("cuda", default=False, description="Enable cuda support for kokkos")
 
     depends_on("cmake", type="run")
     depends_on("python", type="run")
@@ -53,5 +55,16 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("ufs-pyenv", type="run", when="+python")
     depends_on("cprnc", type="run", when="+ncutils")
     depends_on("nccmp", type="run", when="+ncutils")
+
+    # https://github.com/JCSDA/spack-stack/issues/2081
+    # kokkos for UFS-WM atmospheric composition modeling components (CATChem & CECE)
+    # default to +openmp for both packages
+    with when("+kokkos"):
+        variant("cuda", default=False, description="Enable cuda support for kokkos")
+        depends_on("kokkos +cuda +openmp", type="run", when="+cuda")
+        depends_on("kokkos-kernel +openmp", type="run", when="+kokkos")
+
+        #depends_on("kokkos +openmp", type="run", when="+kokkos")
+        #depends_on("kokkos-kernel +openmp", type="run", when="+kokkos")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

Add support for `kokkos / kokkos-kernels` and `cuda` (where appropriate) to the `unified-dev` env.

`kokkos / kokkos-kernels` each specify, per variants, two backends to be built: `openmp` and `serial`. Further, for host ursa, GPUs (`H100`) are available, thus `+cuda cuda_arch=90` (`-DKokkos_ARCH_HOPPER90=ON`) is specified.

Version `5.1.1` for each was spec'd per what users have been testing with; see issue #2081. This can likely change and still result in concretization / build success.

#### Build Notes

`kokkos / kokkos-kernels` build with both `GCC` and `Intel oneAPI` compilers when `cuda` support is not requested. When `cuda` support is requested, they must be built with `GCC`, per this error message:

```
    /path/to/envs/<env>/install/none/none/cuda-13.3.0-aqm2afo/bin/../targets/x86_64-linux/include/crt/host_config.h:118:2:
    118 | #error -- unsupported Intel ICX compiler! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.
```

That message comes from NVIDIA `nvcc,` not from Kokkos. `cuda` does not support `icx/icpx` as a host compiler, and configuration per `host_config.h.`

Note also that #2066 is in play here; successful builds of test environments required not using `module:` stanzas for host-specific `compiler+MPI` and other packages (e.g. `MKL`) in `yaml` config files, in favor of pathing only.

### Dependencies

Depends on https://github.com/JCSDA/spack-packages/pull/80

### Issues addressed

Resolves #2081 

### Applications affected

UFS WM

### Systems affected

`gaea-c6`: no cuda support (no GPUs available)
`ursa`: with cuda support for H100s

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] built test envs with and without cuda support on gaea-c6 and ursa; users requesting this change reported satisfactory resulrs

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
