### PR TITLE
unified-dev template: Remove unused mapl and esmf versions

### DIFF
--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -31,12 +31,10 @@ spack:
   - crtm@v2.4.1-jedi.2
   - crtm@3.1.3
 
-  # Mapl with various esmf tags
-  - mapl@2.53.0 ^esmf@8.6.1
+  # Mapl with specific esmf tags (list all to avoid duplicate packages)
   - mapl@2.53.4 ^esmf@8.8.0
 
   # Various esmf tags (list all to avoid duplicate packages)
-  - esmf@=8.6.1
   - esmf@=8.8.0
   - esmf@=9.0.0b11
 


### PR DESCRIPTION
## Description

With PR #2068, esmf@8.6.1 and the associated mapl version are no longer needed. Might as well not build them!

### Dependencies

None

### Issues addressed

None

### Applications affected

None

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
