### PR TITLE
Add py-lis-ncoda-utils@2.1.0

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/py_lis_ncoda_utils/package.py
@@ -19,6 +19,7 @@ class PyLisNcodaUtils(PythonPackage):
     license("custom")
 
     version("develop", branch="develop")
+    version("2.1.0", commit="608d265b8351cdd9a32a75912f6caef1e17d5014")
     version("2.0.0", commit="85cb17c70705e88d15c5ff191b177090a5136052")
 
     depends_on("python@3.11:", type=("build", "run"))


### PR DESCRIPTION
## Description

This PR adds py-lis-ncoda-utils@2.1.0, which fixes a bug in the LIS decoder.

### Dependencies

None

### Issues addressed

NRL-internal issue

### Applications affected

LIS decoder

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [ ] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built lis-ncoda-utils and tested the decoder on a set of LIS files, including some that failed with py-lis-ncoda-utils@2.0.0. They all converted.

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
