### PR TITLE
Add py-imageio to neptune-python-env

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -150,6 +150,10 @@ packages:
       require:
       - '@0.14.3'
       - +eckit
+    ffmpeg:
+      require:
+      - ~gpl
+      - ~nonfree
     fftw:
       require:
       - '@3.3.10'
@@ -465,6 +469,10 @@ packages:
     py-pygithub:
       require:
       - '@2.7:'
+    # See py-pycparser
+    py-imageio:
+      require:
+      - '@2.37.0'
     # This version builds with Intel oneAPI compilers, newer versions don't
     py-pyogrio:
       require:

--- a/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/neptune_python_env/package.py
@@ -31,6 +31,7 @@ class NeptunePythonEnv(BundlePackage):
     depends_on("py-cartopy", type="run")
     depends_on("py-cfgrib", type="run")
     depends_on("py-h5py", type="run")
+    depends_on("py-imageio", type="run")
     depends_on("py-matplotlib", type="run")
     depends_on("py-netcdf4", type="run")
     depends_on("py-pandas", type="run")


### PR DESCRIPTION
## Description

All in the title. @mathomp4 @eap please take note of the additional requirements for `py-imageio` in `configs/common/packages.yaml`. This can be relaxed/removed when updating the Python stack to 3.13 and to a newer `py-setuptools` version.

### Dependencies

None

### Issues addressed

NRL-internal issue

### Applications affected

NEPTUNE

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
