### PR TITLE
Narwhal: oneapi-2024.2.0 --> oneapi-2026.1.0

### DIFF
--- a/configs/sites/tier1/narwhal/packages_oneapi-2026.1.0.yaml
+++ b/configs/sites/tier1/narwhal/packages_oneapi-2026.1.0.yaml
@@ -1,7 +1,7 @@
 packages:
   all:
     require:
-    - any_of: ['%intel-oneapi-compilers@=2024.2.0']
+    - any_of: ['%intel-oneapi-compilers@=2026.1.0']
       when: '%intel-oneapi-compilers'
     - any_of: ['%gcc@=13.3.0']
       when: '%gcc'
@@ -12,21 +12,19 @@ packages:
   intel-oneapi-compilers:
     buildable: false
     externals:
-    - spec: intel-oneapi-compilers@2024.2.0 +fix_rt_linkage
-      prefix: /opt/intel/oneapi_2024.2.0.634
+    - spec: intel-oneapi-compilers@2026.1.0 +fix_rt_linkage
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2026.1.0
       modules:
       - PrgEnv-intel/8.5.0
-      - intel-oneapi/2024.2
+      - intel-oneapi/2026.1.0
       extra_attributes:
         compilers:
-          c: /opt/intel/oneapi_2024.2.0.634/compiler/2024.2/bin/icx
-          cxx: /opt/intel/oneapi_2024.2.0.634/compiler/2024.2/bin/icpx
-          fortran: /opt/intel/oneapi_2024.2.0.634/compiler/2024.2/bin/ifort
+          c: /p/app/projects/NEPTUNE/spack-stack/oneapi-2026.1.0/compiler/2026.1/bin/icx
+          cxx: /p/app/projects/NEPTUNE/spack-stack/oneapi-2026.1.0/compiler/2026.1/bin/icpx
+          fortran: /p/app/projects/NEPTUNE/spack-stack/oneapi-2026.1.0/compiler/2026.1/bin/ifx
         environment:
           set:
             CONFIG_SITE: ''
-            # Force ifort not ifx
-            INTEL_COMPILER_TYPE: 'RECOMMENDED'
   gcc:
     buildable: false
     externals:
@@ -59,5 +57,5 @@ packages:
   intel-oneapi-mkl:
     buildable: false
     externals:
-    - spec: intel-oneapi-mkl@2024.2
-      prefix: /opt/intel/oneapi_2024.2.0.634
+    - spec: intel-oneapi-mkl@2026.1
+      prefix: /p/app/projects/NEPTUNE/spack-stack/oneapi-2026.1.0

--- a/util/compilers/intel_oneapi-2026.1.0_install.sh
+++ b/util/compilers/intel_oneapi-2026.1.0_install.sh
@@ -10,7 +10,9 @@
 set -eu
 
 umask 0022
+set +e
 module purge
+set -e
 
 if [ "$#" -lt 1 ]; then
   echo "Error: Not enough arguments. Provide Intel oneAPI installation prefix."


### PR DESCRIPTION
## Description

1. Update of Intel oneAPI compiler on Narwhal from oneapi-2024.2.0 to oneapi-2026.1.0.
2. Wrap `module purge` in Intel oneAPI installer script in `set +e ... set -e` because this command exits with an error on Blueback and Narwhal (`cannot unalias mpirun`) that can be ignored.

### Dependencies

None

### Issues addressed

Closes https://github.com/JCSDA/spack-stack/issues/2104

### Applications affected

None

### Systems affected

Narwhal

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built unified-env and neptune-env on Narwhal with Intel oneAPI 2026.1.0

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
