### PR TITLE
ursa: add arborx for UFS WM env, add oneAPI compiler modules for MPI and MKL

### DIFF
--- a/configs/common/packages.yaml
+++ b/configs/common/packages.yaml
@@ -13,6 +13,12 @@ packages:
       require:
       - zlib
     # Individual package settings
+    arborx:
+      require:
+      - '@2.1'
+      - +mpi
+      - +openmp
+      - +serial
     awscli-v2:
       require:
       - ~examples

--- a/configs/sites/tier1/ursa/packages.yaml
+++ b/configs/sites/tier1/ursa/packages.yaml
@@ -9,17 +9,23 @@ packages:
     - '@1.2.13'
 
 # Modifications of common packages
-  # GPUs on ursa are H100
   ufs-weather-model-env:
     require::
     - +kokkos
+    - +arborx
 
+  # GPUs on ursa are H100
+  # add: '+cuda cuda_arch=90' to kokkos / kokkos-kernels / arborx if building with CUDA support
+  # add: '+wrapper' to kokkos
   kokkos:
     require:
-    - '+cuda cuda_arch=90'
+    - '%cxx=gcc'
   kokkos-kernels:
     require:
-    - '+cuda cuda_arch=90'
+    - '%cxx=gcc'
+  arborx:
+    require:
+    - '%cxx=gcc'
 
 # All other packages listed alphabetically
   autoconf:

--- a/configs/sites/tier1/ursa/packages_oneapi-2025.3.1-hpcx.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi-2025.3.1-hpcx.yaml
@@ -15,6 +15,7 @@ packages:
     - spec: hpcx-mpi@2.18.1
       prefix: /apps/hpcx-v2.18.1-gcc-mlnx_ofed-redhat9-cuda12-x86_64/ompi-mt-oneapi2025
       modules:
+      - intel-oneapi-compilers/2025.3.1
       - hpc-x/2.18.1-mt-oneapi2025
   intel-oneapi-compilers:
     buildable: False
@@ -37,6 +38,7 @@ packages:
     - spec: intel-oneapi-mkl@2025.3
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2025.3.1/intel-oneapi-mkl-2025.3.0-z5owhveid7qlq4erbay2seqzs65y3etu
       modules:
+      - intel-oneapi-compilers/2025.3.1
       - intel-oneapi-mkl/2025.3.0
   gcc:
     buildable: False

--- a/configs/sites/tier1/ursa/packages_oneapi-2025.3.1.yaml
+++ b/configs/sites/tier1/ursa/packages_oneapi-2025.3.1.yaml
@@ -30,6 +30,7 @@ packages:
     - spec: intel-oneapi-mpi@2021.17
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2025.3.1/intel-oneapi-mpi-2021.17.1-emmz2zv6lx5ypzmlc3csouqffu7mwnwr
       modules:
+      - intel-oneapi-compilers/2025.3.1
       - intel-oneapi-mpi/2021.17.1
   intel-oneapi-mkl:
     buildable: False
@@ -37,6 +38,7 @@ packages:
     - spec: intel-oneapi-mkl@2025.3
       prefix: /apps/spack-2024-12/linux-rocky9-x86_64/oneapi-2025.3.1/intel-oneapi-mkl-2025.3.0-z5owhveid7qlq4erbay2seqzs65y3etu
       modules:
+      - intel-oneapi-compilers/2025.3.1
       - intel-oneapi-mkl/2025.3.0
   intel-oneapi-tbb:
     buildable: False

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -66,7 +66,6 @@ class UfsWeatherModelEnv(BundlePackage):
 
     with when("+arborx"):
         depends_on("arborx", type="run")
-        requires("+kokkos", when="+arborx",
-                 msg="Arborx requires +kokkos")
+        requires("+kokkos", msg="Arborx requires +kokkos")
 
     # There is no need for install() since there is no code.

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ufs_weather_model_env/package.py
@@ -24,7 +24,8 @@ class UfsWeatherModelEnv(BundlePackage):
     )
     variant("python", default=True, description="Include extra Python packages")
     variant("ncutils", default=True, description="Include extra NetCDF utilities (cprnc and nccmp)")
-    variant("kokkos", default=False, description="Include kokkos and kokkos-kernels")
+    variant("kokkos", default=False, description="Enable kokkos and kokkos-kernels")
+    variant("arborx", default=False, description="Enable arborx")
 
     depends_on("cmake", type="run")
     depends_on("python", type="run")
@@ -62,5 +63,10 @@ class UfsWeatherModelEnv(BundlePackage):
     with when("+kokkos"):
         depends_on("kokkos", type="run")
         depends_on("kokkos-kernels", type="run")
+
+    with when("+arborx"):
+        depends_on("arborx", type="run")
+        requires("+kokkos", when="+arborx",
+                 msg="Arborx requires +kokkos")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
This PR adds:

- `arborx` to the UFS WM env package recipe `ufs_weather_model_env/package.py`
- an entry for the oneAPI compiler module to the oneAPI MPI and MKL package specs modules section

## Description

Package `arborx` is now added as a variant for `ufs_weather_model_env`, following on with the addition of `kokkos` and `kokkos-kernels` in [PR #2088](https://github.com/JCSDA/spack-stack/pull/2088). 

Per discussion with Ben Koziol re: `CICE`/`CECE`/`CATChem` components, envs were built for oneAPI and GCC with `arborx`, and with and without `CUDA` support. Testing leads to a preference for adding `arborx` but excluding `CUDA` support at this time.

Like `kokkos` / `kokkos-kernels`,`arborx` is added as a variant to `ufs_weather_model_env/package.py` (`default=False`) and  is enabled only for `ufs_weather_model_env`.

`arborx` / `kokkos` / `kokkos-kernels` are spec'd to build with `%cxx=gcc` because for H100 GPUs, `kokkos` relies on `nvcc_wrapper` for CMake `CUDA` support, and GCC is the primary target host compiler suggested by NVIDIA, as it is known to provide broad stability. The test envs bear this out.

As well, for the backends chosen to be built for `arborx` and `kokkos`, GCC is preferred.

Comments are provided in `configs/sites/tier1/ursa/packages.yaml` to turn on `CUDA` support if desired in the future.

Lastly, for oneAPI package yaml files, an entry for the compiler is added to both the MPI and MKL specs `modules` section, so as to have MPI and MKL module successfully located and loaded at build time.

### Dependencies

None

### Issues addressed

Related to #2066 and likely closes it. See also #2110 and [PR #2119](url)

### Applications affected

UFS WM

### Systems affected

ursa only

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] envs created for / tested by Ben Koziol

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [x] All dependency PRs/issues have been resolved and this PR can be merged.
- [x] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
