### PR TITLE
Ubuntu CI runners: build-cache-new-spack-v1 -> build-cache

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-gnu.yaml
@@ -20,8 +20,7 @@ defaults:
     shell: bash
 
 env:
-  # DH* REVERT ME AFTER MERGE
-  BUILD_CACHE_PATH: /home/ubuntu/spack-stack/build-cache-new-spack-v1
+  BUILD_CACHE_PATH: /home/ubuntu/spack-stack/build-cache
   SOURCE_CACHE_PATH: /home/ubuntu/spack-stack/source-cache
 
 jobs:

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi-ifx.yaml
@@ -20,8 +20,7 @@ defaults:
     shell: bash
 
 env:
-  # DH* REVERT ME AFTER MERGE
-  BUILD_CACHE_PATH: /home/ubuntu/spack-stack/build-cache-new-spack-v1
+  BUILD_CACHE_PATH: /home/ubuntu/spack-stack/build-cache
   SOURCE_CACHE_PATH: /home/ubuntu/spack-stack/source-cache
 
 jobs:

--- a/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64-oneapi.yaml
@@ -20,8 +20,7 @@ defaults:
     shell: bash
 
 env:
-  # DH* REVERT ME AFTER MERGE
-  BUILD_CACHE_PATH: /home/ubuntu/spack-stack/build-cache-new-spack-v1
+  BUILD_CACHE_PATH: /home/ubuntu/spack-stack/build-cache
   SOURCE_CACHE_PATH: /home/ubuntu/spack-stack/source-cache
 
 jobs:


### PR DESCRIPTION
## Description

`.github/workflows/ubuntu-ci-x86_64-*yaml`: revert `/home/ubuntu/spack-stack/build-cache-new-spack-v1` to `/home/ubuntu/spack-stack/build-cache`. See https://github.com/JCSDA/spack-stack/pull/2114#issuecomment-5534854702

### Dependencies

None

### Issues addressed

Housekeeping.

### Applications affected

None

### Systems affected

Ubuntu CI runners

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [ ] ...

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] ~~All dependency PRs/issues have been resolved and this PR can be merged.~~
- [ ] ~~All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged~~
