### PR TITLE
Add adp-preprocessors@1.1.4; bug fixes for ctests in oops and ioda

### DIFF
--- a/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/adp_preprocessors/package.py
@@ -21,6 +21,7 @@ class AdpPreprocessors(MakefilePackage):
     license("custom", checked_by="climbfuji")
 
     # These are not official versions; 1.1.1 lives in @climbfuji's fork.
+    version("1.1.4", commit="4a5b60139e0a135ee189bca18a54ead18a9854bb")
     version("1.1.3", commit="3f0477aa0ecbbf423d1b872d7518eb2d74a02fab")
     version("1.1.2", commit="729b0e7572a497b1103d0b8b1e6ff3972efd0d29")
     version(

--- a/repos/spack_stack/spack_repo/spack_stack/packages/ioda/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/ioda/package.py
@@ -104,7 +104,11 @@ class Ioda(CMakePackage):
                 "ioda_bufr_python_encoder",
                 "ioda_bufr_python_parallel",
             ]
-
+            # This test segfaults randomly with oneapi@2026
+            if self.spec.satisfies("%oneapi"):
+                skipped_tests += [
+                    "ioda_time_io_script",
+                ]
         ctest = Executable(self.spec["cmake"].prefix.bin.ctest)
         with working_dir(self.build_directory):
             if skipped_tests:

--- a/repos/spack_stack/spack_repo/spack_stack/packages/oops/package.py
+++ b/repos/spack_stack/spack_repo/spack_stack/packages/oops/package.py
@@ -77,6 +77,17 @@ class Oops(CMakePackage):
         ]
         return res
 
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        """Wrapper until spack has a real implementation of setup_test_environment()"""
+        if self.run_tests:
+            self.setup_test_environment(env)
+
+    def setup_test_environment(self, env: EnvironmentModifications):
+        """For OpenMPI, allow oversubscribing of MPI tasks"""
+        if self.spec.satisfies("^[virtuals=mpi] openmpi"):
+            env.set("OMPI_MCA_rmaps_base_oversubscribe", "1")
+            env.set("PRTE_MCA_rmaps_default_mapping_policy", ":oversubscribe")
+
     def check(self):
         skipped_tests = None
         with when("@1.10.0.20250827"):


### PR DESCRIPTION
## Description

1. Add adp-preprocessors@1.1.4, which fixes `make` dependencies.
2. Minor bug fixes for running `ctest` for oops and ioda: oops requires up to 9 MPI tasks for certain tests, allow oversubscribing for OpenMPI. One ioda test failed randomly on my machine with oneapi@2026.0.0. Since these are older tags (March-May 2026), it's not worth investigating those here.

### Dependencies

None

### Issues addressed

1. Repeated adp-preprocessor build failures due to missing dependencies.
2. oops/ioda ctest failures on my new devbox.

### Applications affected

None

### Systems affected

None

## Testing

- CI: _Note whether the automatic tests (GitHub actions tests that run automatically for every commit) pass or not_
    - [x] GitHub actions CI tests pass
    - [ ] GitHub actions CI tests do not pass (_provide explanation_)
    - [ ] GitHub actions CI tests skipped (_provide explanation if necessary_)
- New tests added: _List and describe any new tests added to GitHub actions_
    - [ ] ...
- Additional testing: _Add information on any additional tests conducted_
    - [x] Built neptune and unified environments on my devbox with gcc@14.2.1 and oneapi@2026.0.0, ran tests for all JEDI components in neptune-env

## Checklist

- [x] This PR addresses one issue/problem/enhancement or has a very good reason for not doing so.
- [x] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
- [ ] All necessary updates to the documentation ([spack-stack wiki](https://github.com/jcsda/spack-stack/wiki)) will be made when this PR is merged
